### PR TITLE
Map Directive Removal

### DIFF
--- a/browser-caching/nginx-includes/all/assets-expiry.conf.j2
+++ b/browser-caching/nginx-includes/all/assets-expiry.conf.j2
@@ -1,24 +1,19 @@
 # Nginx configuration for browser caching of static assets
 
-# Cache settings for different file types
-map $sent_http_content_type $expires {
-    default                                 1d;  # Default caching time
-    text/html                               epoch;  # Don't cache HTML
-    text/css                                7d;  # Cache CSS for 7 days
-    text/javascript                         7d;  # Cache JS for 7 days
-    application/javascript                  7d;
-    ~image/                                 30d;  # Cache images for 30 days
-    ~font/                                  30d;  # Cache fonts for 30 days
-    application/vnd.ms-fontobject           30d;
-    application/x-font-ttf                  30d;
-    application/font-woff                   30d;
-    application/font-woff2                  30d;
-    application/x-font-woff                 30d;
+# Settings for SVG files (moved before general static files to take precedence)
+location ~* \.svg$ {
+    add_header Content-Security-Policy "default-src 'self'";
+    expires 30d;
+    add_header Cache-Control "public, no-transform";
+    add_header Vary Accept;
+    access_log off;
+    etag on;
+    try_files $uri =404;
 }
 
-# Enable cache for all static files
-location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|css|js|svg|eot|ttf|woff|woff2|otf)$ {
-    expires $expires;
+# Enable cache for all static files (removed svg from this block)
+location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|css|js|eot|ttf|woff|woff2|otf)$ {
+    expires 30d;
     add_header Cache-Control "public, no-transform";
     add_header Vary Accept;
     access_log off;
@@ -30,16 +25,9 @@ location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|css|js|svg|eot|ttf|woff|woff2|otf)
     try_files $uri =404;
 }
 
-# Settings for SVG files
-location ~* \.svg$ {
-    add_header Content-Security-Policy "default-src 'self'";
-    expires $expires;
-    add_header Cache-Control "public, no-transform";
-}
-
 # Cache WordPress common files (minified JS/CSS, emoji JS)
 location ~* ^.*\.(min\.(css|js)|wp-emoji-release\.min\.js)$ {
-    expires $expires;
+    expires 7d;
     add_header Cache-Control "public, no-transform";
 }
 


### PR DESCRIPTION
This pull request refactors the Nginx configuration for browser caching, focusing on improving cache control for SVG files and simplifying cache settings for static assets. The changes ensure better security and caching behavior for SVG files while maintaining clarity in configuration.

### SVG-specific changes:
* Introduced a dedicated `location` block for SVG files with a 30-day cache expiration, a `Content-Security-Policy` header, and other caching headers for improved security and caching behavior. SVG files were removed from the general static files block to give this configuration precedence. (`browser-caching/nginx-includes/all/assets-expiry.conf.j2`, [browser-caching/nginx-includes/all/assets-expiry.conf.j2L3-R16](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L3-R16))

### General caching adjustments:
* Simplified the caching configuration for static assets by removing the `$expires` variable and setting a fixed 30-day expiration for all static files except SVG. (`browser-caching/nginx-includes/all/assets-expiry.conf.j2`, [browser-caching/nginx-includes/all/assets-expiry.conf.j2L3-R16](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L3-R16))
* Updated the cache expiration for WordPress-specific files (e.g., minified CSS/JS and emoji JS) to a fixed 7-day period instead of relying on the `$expires` variable. (`browser-caching/nginx-includes/all/assets-expiry.conf.j2`, [browser-caching/nginx-includes/all/assets-expiry.conf.j2L33-R30](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L33-R30))