### PR TITLE
Longer Expiry Dates for Assets

### DIFF
--- a/browser-caching/README.md
+++ b/browser-caching/README.md
@@ -40,13 +40,13 @@ The `nginx-includes/all/assets-expiry.conf.j2` file in this repository contains 
 
 ```bash
 # For production
-trellis provision production --tags nginx-includes
+trellis provision --tags nginx-includes production 
 
 # For staging  
-trellis provision staging --tags nginx-includes
+trellis provision --tags nginx-includes staging
 
 # For development
-trellis provision development --tags nginx-includes
+trellis provision --tags nginx-includes development
 ```
 
 **Note**: Since the file is in the `all/` directory, it will be automatically included for every site configured in Trellis. You don't need to modify your `wordpress_sites.yml` configuration.

--- a/browser-caching/nginx-includes/all/assets-expiry.conf.j2
+++ b/browser-caching/nginx-includes/all/assets-expiry.conf.j2
@@ -3,7 +3,7 @@
 # Settings for SVG files (moved before general static files to take precedence)
 location ~* \.svg$ {
     add_header Content-Security-Policy "default-src 'self'";
-    expires 30d;
+    expires 1y;
     add_header Cache-Control "public, no-transform";
     add_header Vary Accept;
     access_log off;
@@ -12,12 +12,11 @@ location ~* \.svg$ {
 }
 
 # Enable cache for all static files (removed svg from this block)
-# Only match files with specific extensions and ensure they exist as static files
-location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|css|js|eot|ttf|woff|woff2|otf)$ {
-    # Only apply caching if the file actually exists as a static file
+# Images and fonts - cache for 1 year
+location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|eot|ttf|woff|woff2|otf)$ {
     try_files $uri =404;
     
-    expires 30d;
+    expires 1y;
     add_header Cache-Control "public, no-transform";
     add_header Vary Accept;
     access_log off;
@@ -26,9 +25,21 @@ location ~* \.(jpg|jpeg|png|gif|ico|webp|avif|css|js|eot|ttf|woff|woff2|otf)$ {
     etag on;
 }
 
-# Cache WordPress common files (minified JS/CSS, emoji JS) - be more specific
+# CSS and JS files - cache for 1 year (with versioning they're safe to cache long)
+location ~* \.(css|js)$ {
+    try_files $uri =404;
+    
+    expires 1y;
+    add_header Cache-Control "public, no-transform";
+    add_header Vary Accept;
+    access_log off;
+    
+    etag on;
+}
+
+# Cache WordPress common files (minified JS/CSS, emoji JS) - 1 year since they're versioned
 location ~* /wp-content/.*\.(min\.(css|js)|wp-emoji-release\.min\.js)$ {
     try_files $uri =404;
-    expires 7d;
+    expires 1y;
     add_header Cache-Control "public, no-transform";
 }


### PR DESCRIPTION
This pull request includes updates to improve caching configurations for static files and adjusts the provisioning commands for consistency in the documentation. The most significant changes focus on extending cache durations for various file types and reorganizing caching rules for better clarity and precedence.

### Improvements to caching configurations:
* **Increased cache duration for SVG files:** Updated the `expires` directive for SVG files from `30d` to `1y` to align with other static file caching policies. (`browser-caching/nginx-includes/all/assets-expiry.conf.j2`, [browser-caching/nginx-includes/all/assets-expiry.conf.j2L6-R6](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L6-R6))
* **Separated caching rules by file type:** Reorganized caching rules to group images, fonts, CSS, and JS files into distinct blocks, each with a cache duration of `1y`. This improves maintainability and ensures proper precedence. (`browser-caching/nginx-includes/all/assets-expiry.conf.j2`, [[1]](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L15-R19) [[2]](diffhunk://#diff-74ad472369c87c7f9575280b7b848420d7e57d8b4e9777b2087df0e242baf991L29-R43)

### Documentation consistency:
* **Updated provisioning commands:** Adjusted the order of arguments in the provisioning commands for consistency across environments (production, staging, development) in the documentation. (`browser-caching/README.md`, [browser-caching/README.mdL43-R49](diffhunk://#diff-0ed4cb001c58653f81c69053df747478449f91e72c9f6c27e5986248f088f251L43-R49))