### PR TITLE
tar.gz compression

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -48,20 +48,26 @@ cd /srv/www/example.com/current
 # Create backup directory in current WordPress directory (matches Trellis playbooks)
 mkdir -p database_backup
 
-# Export database
-wp db export database_backup/database-$(date +%Y%m%d_%H%M%S).sql
+# Export database (uncompressed)
+wp db export database_backup/database-$(date +%Y%m%d_%H%M%S).sql --add-drop-table
 
-# Export with compression
-wp db export database_backup/database-$(date +%Y%m%d_%H%M%S).sql.gz --add-drop-table
+# Export with compression (Mac-friendly .tar.gz extension)
+BACKUP_FILE="database_backup/database-$(date +%Y%m%d_%H%M%S)"
+wp db export ${BACKUP_FILE}.sql --add-drop-table
+gzip ${BACKUP_FILE}.sql
+mv ${BACKUP_FILE}.sql.gz ${BACKUP_FILE}.tar.gz
 ```
 
 ### Database Backup with Search & Replace
 
 ```bash
-# Export database and replace URLs for local development
-wp db export database_backup/database-$(date +%Y%m%d_%H%M%S).sql \
+# Export database and replace URLs for local development (with Mac-friendly compression)
+BACKUP_FILE="database_backup/database-$(date +%Y%m%d_%H%M%S)"
+wp db export ${BACKUP_FILE}.sql \
   --add-drop-table \
   --search-replace=https://example.com,http://example.test
+gzip ${BACKUP_FILE}.sql
+mv ${BACKUP_FILE}.sql.gz ${BACKUP_FILE}.tar.gz
 ```
 
 ## Method 2: Shell Script Database Backup
@@ -246,11 +252,14 @@ sudo crontab -e
 ### Database Restoration
 
 ```bash
-# Using WP-CLI
-wp db import database_backup/database_20231201_020000.sql.gz
+# Using WP-CLI (uncompressed)
+wp db import database_backup/database_20231201_020000.sql
 
-# Using mysql directly
-gunzip < database_backup/database_20231201_020000.sql.gz | mysql -u username -p database_name
+# Using WP-CLI (compressed .tar.gz)
+gunzip -c database_backup/database_20231201_020000.tar.gz | wp db import -
+
+# Using mysql directly (compressed)
+gunzip < database_backup/database_20231201_020000.tar.gz | mysql -u username -p database_name
 ```
 
 ### File Restoration


### PR DESCRIPTION
This pull request updates the database backup and restoration instructions in the `backup/README.md` file to improve compatibility and clarity, particularly for Mac users. The main changes involve switching to `.tar.gz` file extensions for compressed backups and updating the corresponding backup and restore commands.

**Backup process improvements:**

* Updated the database export commands to first create an uncompressed `.sql` file, then compress it with `gzip`, and finally rename the compressed file to use a `.tar.gz` extension for better compatibility with Mac systems.
* Modified the search & replace backup example to follow the same compression and renaming process for consistency.

**Restoration process improvements:**

* Updated restoration instructions to show how to import both uncompressed `.sql` files and compressed `.tar.gz` files using WP-CLI and `mysql`, reflecting the new backup file naming convention.