### PR TITLE
 tar -czf for backups

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -51,23 +51,23 @@ mkdir -p database_backup
 # Export database (uncompressed)
 wp db export database_backup/database-$(date +%Y%m%d_%H%M%S).sql --add-drop-table
 
-# Export with compression (Mac-friendly .tar.gz extension)
+# Export with compression (proper tar.gz archive - industry standard)
 BACKUP_FILE="database_backup/database-$(date +%Y%m%d_%H%M%S)"
 wp db export ${BACKUP_FILE}.sql --add-drop-table
-gzip ${BACKUP_FILE}.sql
-mv ${BACKUP_FILE}.sql.gz ${BACKUP_FILE}.tar.gz
+tar -czf ${BACKUP_FILE}.tar.gz -C database_backup $(basename ${BACKUP_FILE}.sql)
+rm ${BACKUP_FILE}.sql
 ```
 
 ### Database Backup with Search & Replace
 
 ```bash
-# Export database and replace URLs for local development (with Mac-friendly compression)
+# Export database and replace URLs for local development (proper tar.gz archive)
 BACKUP_FILE="database_backup/database-$(date +%Y%m%d_%H%M%S)"
 wp db export ${BACKUP_FILE}.sql \
   --add-drop-table \
   --search-replace=https://example.com,http://example.test
-gzip ${BACKUP_FILE}.sql
-mv ${BACKUP_FILE}.sql.gz ${BACKUP_FILE}.tar.gz
+tar -czf ${BACKUP_FILE}.tar.gz -C database_backup $(basename ${BACKUP_FILE}.sql)
+rm ${BACKUP_FILE}.sql
 ```
 
 ## Method 2: Shell Script Database Backup
@@ -255,11 +255,15 @@ sudo crontab -e
 # Using WP-CLI (uncompressed)
 wp db import database_backup/database_20231201_020000.sql
 
-# Using WP-CLI (compressed .tar.gz)
-gunzip -c database_backup/database_20231201_020000.tar.gz | wp db import -
+# Using WP-CLI (compressed tar.gz archive)
+tar -xzf database_backup/database_20231201_020000.tar.gz
+wp db import database_20231201_020000.sql
+
+# Or in one command
+tar -xzOf database_backup/database_20231201_020000.tar.gz | wp db import -
 
 # Using mysql directly (compressed)
-gunzip < database_backup/database_20231201_020000.tar.gz | mysql -u username -p database_name
+tar -xzOf database_backup/database_20231201_020000.tar.gz | mysql -u username -p database_name
 ```
 
 ### File Restoration

--- a/backup/scripts/site-backup.sh
+++ b/backup/scripts/site-backup.sh
@@ -61,9 +61,11 @@ cd "$SITE_PATH/current" || {
 
 # 1. Database backup using WP-CLI
 log "Backing up database..."
-if wp db export "$BACKUP_DIR/database/db_$DATE.sql" --add-drop-table --quiet; then
-    gzip "$BACKUP_DIR/database/db_$DATE.sql"
-    log "Database backup completed: db_$DATE.sql.gz"
+TEMP_SQL="/tmp/db_$DATE.sql"
+if wp db export "$TEMP_SQL" --add-drop-table --quiet; then
+    tar -czf "$BACKUP_DIR/database/db_$DATE.sql.tar.gz" -C /tmp "db_$DATE.sql"
+    rm "$TEMP_SQL"
+    log "Database backup completed: db_$DATE.sql.tar.gz"
 else
     error "Database backup failed"
     exit 1

--- a/backup/trellis/README.md
+++ b/backup/trellis/README.md
@@ -277,10 +277,10 @@ Verify backup integrity:
 
 ```bash
 # Test backup file
-gunzip -t /path/to/backup.sql.gz
+tar -tzf /path/to/backup.sql.tar.gz
 
 # Check backup contents
-gunzip -c /path/to/backup.sql.gz | head -20
+tar -xzOf /path/to/backup.sql.tar.gz | head -20
 ```
 
 ### Log Monitoring


### PR DESCRIPTION
This pull request standardizes and improves the database backup process by switching from `.sql.gz` (gzip-compressed SQL files) to `.sql.tar.gz` (tarball archives with gzip compression) across backup scripts and documentation. This update ensures better compatibility, aligns with industry standards, and simplifies both backup and restore procedures.

**Backup and Compression Improvements:**

* All backup scripts (`db-backup.sh`, `site-backup.sh`) now create database backups as `.sql.tar.gz` archives using `tar` instead of `.sql.gz` files with `gzip`, improving portability and standardization. Temporary `.sql` files are cleaned up after archiving. [[1]](diffhunk://#diff-3c628aa29f5dda798c54b95e0e942b490503f9da14ccac6dbf8f71d3c69a090dL73-R85) [[2]](diffhunk://#diff-c0108ed7dd1ea6a00fefdacc16c39d2e8da0d4d45aed5977b99dba4e1fd0d345L64-R68)
* URL-replaced backups also use the `.sql.tar.gz` format, with consistent naming and cleanup of temporary files. [[1]](diffhunk://#diff-3c628aa29f5dda798c54b95e0e942b490503f9da14ccac6dbf8f71d3c69a090dL110-R115) [[2]](diffhunk://#diff-3c628aa29f5dda798c54b95e0e942b490503f9da14ccac6dbf8f71d3c69a090dL128-R138)

**Restore and Usage Documentation Updates:**

* Documentation in `backup/README.md` and `backup/trellis/README.md` has been updated to reflect the new archive format, including instructions for extracting and importing from `.sql.tar.gz` files and verifying backup integrity. [[1]](diffhunk://#diff-69b4b92f637e7adc6c4dd35b51d75188e388ee170c5e015ca99c6ed0e31d3eb6L54-R70) [[2]](diffhunk://#diff-69b4b92f637e7adc6c4dd35b51d75188e388ee170c5e015ca99c6ed0e31d3eb6L258-R266) [[3]](diffhunk://#diff-87dcd6d8eb73cf0988d00c58ee7ddba4fab592c3e3b908fb6dafd0c8fe650882L280-R283)

**Script and Info File Adjustments:**

* Backup info files now reference the new `.sql.tar.gz` filenames for both main and URL-replaced backups.
* Cleanup routines and recent backup listings in scripts are updated to target `.sql.tar.gz` files, ensuring old backups are properly managed and recent ones are displayed correctly. [[1]](diffhunk://#diff-3c628aa29f5dda798c54b95e0e942b490503f9da14ccac6dbf8f71d3c69a090dL175-R178) [[2]](diffhunk://#diff-3c628aa29f5dda798c54b95e0e942b490503f9da14ccac6dbf8f71d3c69a090dL192-R195)