### PR TITLE
Backup Playbooks Patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+backup/.DS_Store

--- a/backup/trellis/database-backup.yml
+++ b/backup/trellis/database-backup.yml
@@ -6,37 +6,38 @@
   vars:
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
-    host: "{{ env }}_host"
-    from_host: "{{ hostvars[host] }}"
-    local_bedrock_dir: "{{ from_host.wordpress_sites[site].local_path }}"
+    local_bedrock_dir: "{{ wordpress_sites[site].local_path }}"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_{{ current_date_and_time }}.sql.gz"
 
   tasks:
-  - name: Check if {{ site }} folder exists
-    delegate_to: development_host
+  - name: Check if {{ site }} local folder exists
+    delegate_to: localhost
     stat:
-      path: "{{ project_root }}"
+      path: "{{ local_bedrock_dir }}"
     register: result
+    become: no
 
-  - name: Abort if {{ site }} folder doesn't exist
+  - name: Abort if {{ site }} local folder doesn't exist
     fail:
-      msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
+      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
 
   - block:
-    - name: Create database_backup directory if it doesn't exist
-      delegate_to: development_host
+    - name: Create local database_backup directory if it doesn't exist
+      delegate_to: localhost
       file:
-        path: "{{ project_web_dir }}/database_backup"
+        path: "{{ local_bedrock_dir }}/database_backup"
         state: directory
         mode: 0755
+      become: no
 
     - name: Export development database
-      delegate_to: development_host
+      delegate_to: localhost
       shell: wp db export - | gzip > database_backup/{{ backup_file }}
       args:
-        chdir: "{{ project_web_dir }}"
+        chdir: "{{ local_bedrock_dir }}/web/wp"
+      become: no
       when: env is defined and env == "development"
 
     - name: Export {{ env }} database
@@ -45,7 +46,7 @@
         chdir: "{{ project_web_dir }}"
       when: env is defined and env != "development"
 
-    - name: Pull exported database from {{ env }} to development
+    - name: Pull exported database from {{ env }} to local
       fetch:
         src: "{{ project_web_dir }}/{{ backup_file }}"
         dest: "{{ local_bedrock_dir }}/database_backup/"
@@ -56,6 +57,5 @@
       shell: rm -f {{ backup_file }}
       args:
         chdir: "{{ project_web_dir }}"
-        warn: false
       when: env is defined and env != "development"
     when: result.stat.exists is defined and result.stat.exists and result.stat.isdir is defined and result.stat.isdir

--- a/backup/trellis/database-pull.yml
+++ b/backup/trellis/database-pull.yml
@@ -3,14 +3,16 @@
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
+  vars_files:
+    - group_vars/development/wordpress_sites.yml
+
   vars:
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
-    host: "{{ env }}_host"
-    from_host: "{{ hostvars[host] }}"
-    url_from: "{{ from_host.wordpress_sites[site].site_hosts.0.canonical }}"
-    url_to: "{{ hostvars.development_host.wordpress_sites[site].site_hosts.0.canonical }}"
-    local_bedrock_dir: "{{ hostvars.development_host.wordpress_sites[site].local_path }}"
+    url_from: "{{ wordpress_sites[site].site_hosts.0.canonical }}"
+    dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
+    url_to: "{{ dev_wordpress_sites.wordpress_sites[site].site_hosts.0.canonical }}"
+    local_bedrock_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
     dump_file: "{{ site | regex_replace('\\.+', '_') }}_db_dump.sql.gz"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_development_{{ current_date_and_time }}.sql.gz"
@@ -21,24 +23,26 @@
       msg: "ERROR: development is not a valid environment for this mode (you can't pull from development to development)."
     when: env == "development"
 
-  - name: Check if {{ site }} folder exists
-    delegate_to: development_host
+  - name: Check if {{ site }} local folder exists
+    delegate_to: localhost
     stat:
-      path: "{{ project_root }}"
+      path: "{{ local_bedrock_dir }}"
     register: result
+    become: no
 
-  - name: Abort if {{ site }} folder doesn't exist
+  - name: Abort if {{ site }} local folder doesn't exist
     fail:
-      msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
+      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
 
   - block:
-    - name: Create database_backup directory if it doesn't exist
-      delegate_to: development_host
+    - name: Create local database_backup directory if it doesn't exist
+      delegate_to: localhost
       file:
-        path: "{{ project_web_dir }}/database_backup"
+        path: "{{ local_bedrock_dir }}/database_backup"
         state: directory
         mode: 0755
+      become: no
 
     - name: Create database dump on {{ env }}
       shell: wp db export --allow-root - | gzip > {{ dump_file }}
@@ -55,31 +59,33 @@
       shell: rm -f {{ dump_file }}
       args:
         chdir: "{{ project_web_dir }}"
-        warn: false
 
     - name: Export development database before importing dump (backup)
-      delegate_to: development_host
+      delegate_to: localhost
       shell: wp db export - | gzip > database_backup/{{ backup_file }}
       args:
-        chdir: "{{ project_web_dir }}"
+        chdir: "{{ local_bedrock_dir }}/web/wp"
+      become: no
 
     - name: Import database dump on development
-      delegate_to: development_host
+      delegate_to: localhost
       shell: gzip -c -d {{ dump_file }} | wp db import -
       args:
-        chdir: "{{ project_web_dir }}"
+        chdir: "{{ local_bedrock_dir }}/web/wp"
+      become: no
 
     - name: Delete database dump from development
-      delegate_to: development_host
+      delegate_to: localhost
       shell: rm -f {{ dump_file }}
       args:
-        chdir: "{{ project_web_dir }}"
-        warn: false
+        chdir: "{{ local_bedrock_dir }}"
+      become: no
 
     - name: Search for {{ url_from }} and replace with {{ url_to }} on development
-      delegate_to: development_host
+      delegate_to: localhost
       command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise
       args:
-        chdir: "{{ project_web_dir }}"
+        chdir: "{{ local_bedrock_dir }}/web/wp"
+      become: no
       tags: ['search-replace']
     when: result.stat.exists is defined and result.stat.exists and result.stat.isdir is defined and result.stat.isdir

--- a/backup/trellis/database-push.yml
+++ b/backup/trellis/database-push.yml
@@ -3,14 +3,16 @@
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
+  vars_files:
+    - group_vars/development/wordpress_sites.yml
+
   vars:
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
-    host: "{{ env }}_host"
-    to_host: "{{ hostvars[host] }}"
-    url_from: "{{ hostvars.development_host.wordpress_sites[site].site_hosts.0.canonical }}"
-    url_to: "{{ to_host.wordpress_sites[site].site_hosts.0.canonical }}"
-    local_bedrock_dir: "{{ to_host.wordpress_sites[site].local_path }}"
+    dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
+    url_from: "{{ dev_wordpress_sites.wordpress_sites[site].site_hosts.0.canonical }}"
+    url_to: "{{ wordpress_sites[site].site_hosts.0.canonical }}"
+    local_bedrock_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
     dump_file: "{{ site | regex_replace('\\.+', '_') }}_db_dump.sql.gz"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_{{ current_date_and_time }}.sql.gz"
@@ -21,30 +23,33 @@
       msg: "ERROR: development is not a valid environment for this mode (you can't push from development to development)."
     when: env == "development"
 
-  - name: Check if {{ site }} folder exists
-    delegate_to: development_host
+  - name: Check if {{ site }} local folder exists
+    delegate_to: localhost
     stat:
-      path: "{{ project_root }}"
+      path: "{{ local_bedrock_dir }}"
     register: result
+    become: no
 
-  - name: Abort if {{ site }} folder doesn't exist
+  - name: Abort if {{ site }} local folder doesn't exist
     fail:
-      msg: "ERROR: {{ site }} is not a valid site name ({{ site }} folder does not exist)."
+      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
     when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
 
   - block:
-    - name: Create database_backup directory if it doesn't exist
-      delegate_to: development_host
+    - name: Create local database_backup directory if it doesn't exist
+      delegate_to: localhost
       file:
-        path: "{{ project_web_dir }}/database_backup"
+        path: "{{ local_bedrock_dir }}/database_backup"
         state: directory
         mode: 0755
+      become: no
 
     - name: Create database dump on development
-      delegate_to: development_host
+      delegate_to: localhost
       shell: wp db export --allow-root - | gzip > {{ dump_file }}
       args:
-        chdir: "{{ project_web_dir }}"
+        chdir: "{{ local_bedrock_dir }}/web/wp"
+      become: no
 
     - name: Push database dump from development to {{ env }}
       copy:
@@ -52,11 +57,11 @@
         dest: "{{ project_web_dir }}/{{ dump_file }}"
 
     - name: Delete database dump from development
-      delegate_to: development_host
+      delegate_to: localhost
       shell: rm -f {{ dump_file }}
       args:
-        chdir: "{{ project_web_dir }}"
-        warn: false
+        chdir: "{{ local_bedrock_dir }}"
+      become: no
 
     - name: Export {{ env }} database before importing dump (backup)
       shell: wp db export - | gzip > {{ backup_file }}
@@ -73,7 +78,6 @@
       shell: rm -f {{ backup_file }}
       args:
         chdir: "{{ project_web_dir }}"
-        warn: false
 
     - name: Import database dump on {{ env }}
       shell: gzip -c -d {{ dump_file }} | wp db import -
@@ -84,7 +88,6 @@
       shell: rm -f {{ dump_file }}
       args:
         chdir: "{{ project_web_dir }}"
-        warn: false
 
     - name: Search for {{ url_from }} and replace with {{ url_to }} on development
       command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise

--- a/backup/trellis/files-backup.yml
+++ b/backup/trellis/files-backup.yml
@@ -6,9 +6,7 @@
   vars:
     project_root: "{{ www_root }}/{{ site }}"
     shared_uploads_dir: "{{ project_root }}/shared/uploads"
-    host: "{{ env }}_host"
-    from_host: "{{ hostvars[host] }}"
-    local_bedrock_dir: "{{ from_host.wordpress_sites[site].local_path }}"
+    local_bedrock_dir: "{{ wordpress_sites[site].local_path }}"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_filename: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_uploads_{{ current_date_and_time }}.tar.gz"
     backup_dir: "{{ local_bedrock_dir }}/files_backup"
@@ -35,8 +33,6 @@
 
     - name: Create temporary archive of uploads on {{ env }}
       shell: tar -czf /tmp/{{ backup_filename }} -C {{ shared_uploads_dir }} .
-      args:
-        warn: false
 
     - name: Pull uploads archive from {{ env }} to local files_backup
       fetch:
@@ -46,8 +42,6 @@
 
     - name: Delete temporary archive from {{ env }}
       shell: rm -f /tmp/{{ backup_filename }}
-      args:
-        warn: false
 
     - name: Show backup location
       debug:


### PR DESCRIPTION
This pull request refactors the backup and database sync Ansible playbooks to consistently use the local machine (localhost) for all operations involving local files, rather than referencing a specific development host. It also streamlines how local paths and URLs are resolved, making the scripts more robust and easier to maintain. The changes affect the database backup, push, pull, and files backup playbooks.

Key changes include:

**Local Operations Refactoring**
* All tasks that interact with local files or directories now use `delegate_to: localhost` instead of `development_host`, and explicitly set `become: no` to avoid privilege escalation for local operations. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL9-R40) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L24-R45) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL24-R64)

**Path and Variable Resolution Improvements**
* Local Bedrock directory and site URLs are now resolved directly from the `wordpress_sites` variable or by loading the development configuration file, removing reliance on hostvars and making the playbooks more portable and predictable. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL9-R40) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296R6-R15) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfR6-R15) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aL9-R9)

**Error Handling and Messaging**
* Error messages and checks have been updated to refer to the existence of local folders rather than remote project directories, providing clearer feedback and preventing misconfigurations. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL9-R40) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L24-R45) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL24-R64)

**Code Simplification**
* Removed unnecessary `warn: false` arguments from shell commands, as they are not needed in this context. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL59) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L58-R89) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL76) [[4]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL87) [[5]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aL38-L39) [[6]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aL49-L50)

**Consistency and Naming**
* Task names and comments have been updated to clarify that actions are performed on the local machine, improving readability and maintainability. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL9-R40) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L24-R45) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL24-R64)

These changes make the backup and sync scripts more reliable for local development workflows and reduce the risk of errors due to environment misconfiguration.