### PR TITLE
Backup Playbooks Trellis Conventions

### DIFF
--- a/backup/trellis/database-backup.yml
+++ b/backup/trellis/database-backup.yml
@@ -1,61 +1,71 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: database-backup.yml
+
 - name: Backup {{ site }} {{ env }} database
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
-    local_bedrock_dir: "{{ wordpress_sites[site].local_path }}"
+    project_local_path: "{{ project.local_path }}"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_{{ current_date_and_time }}.sql.gz"
 
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
+
+    - name: Check if {{ site }} local folder exists
+      delegate_to: localhost
+      stat:
+        path: "{{ project_local_path }}"
+      register: result
+      become: no
+
+    - name: Abort if {{ site }} local folder doesn't exist
+      fail:
+        msg: "ERROR: {{ site }} is not a valid site (local folder {{ project_local_path }} does not exist)."
+      when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+
   tasks:
-  - name: Check if {{ site }} local folder exists
+  - name: Create local database_backup directory if it doesn't exist
     delegate_to: localhost
-    stat:
-      path: "{{ local_bedrock_dir }}"
-    register: result
+    file:
+      path: "{{ project_local_path }}/database_backup"
+      state: directory
+      mode: 0755
     become: no
 
-  - name: Abort if {{ site }} local folder doesn't exist
-    fail:
-      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
-    when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+  - name: Export development database
+    delegate_to: localhost
+    shell: wp db export - | gzip > database_backup/{{ backup_file }}
+    args:
+      chdir: "{{ project_local_path }}/web/wp"
+    become: no
+    when: env is defined and env == "development"
 
-  - block:
-    - name: Create local database_backup directory if it doesn't exist
-      delegate_to: localhost
-      file:
-        path: "{{ local_bedrock_dir }}/database_backup"
-        state: directory
-        mode: 0755
-      become: no
+  - name: Export {{ env }} database
+    shell: wp db export - | gzip > {{ backup_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
+    when: env is defined and env != "development"
 
-    - name: Export development database
-      delegate_to: localhost
-      shell: wp db export - | gzip > database_backup/{{ backup_file }}
-      args:
-        chdir: "{{ local_bedrock_dir }}/web/wp"
-      become: no
-      when: env is defined and env == "development"
+  - name: Pull exported database from {{ env }} to local
+    fetch:
+      src: "{{ project_web_dir }}/{{ backup_file }}"
+      dest: "{{ project_local_path }}/database_backup/"
+      flat: yes
+    when: env is defined and env != "development"
 
-    - name: Export {{ env }} database
-      shell: wp db export - | gzip > {{ backup_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
-      when: env is defined and env != "development"
-
-    - name: Pull exported database from {{ env }} to local
-      fetch:
-        src: "{{ project_web_dir }}/{{ backup_file }}"
-        dest: "{{ local_bedrock_dir }}/database_backup/"
-        flat: yes
-      when: env is defined and env != "development"
-
-    - name: Delete exported database from {{ env }}
-      shell: rm -f {{ backup_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
-      when: env is defined and env != "development"
-    when: result.stat.exists is defined and result.stat.exists and result.stat.isdir is defined and result.stat.isdir
+  - name: Delete exported database from {{ env }}
+    shell: rm -f {{ backup_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
+    when: env is defined and env != "development"

--- a/backup/trellis/database-pull.yml
+++ b/backup/trellis/database-pull.yml
@@ -1,4 +1,8 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: database-pull.yml
+
 - name: Pull {{ site }} database from {{ env }} to development
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
@@ -7,85 +11,91 @@
     - group_vars/development/wordpress_sites.yml
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
-    url_from: "{{ wordpress_sites[site].site_hosts.0.canonical }}"
+    url_from: "{{ project.site_hosts.0.canonical }}"
     dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
     url_to: "{{ dev_wordpress_sites.wordpress_sites[site].site_hosts.0.canonical }}"
-    local_bedrock_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
+    project_local_path: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
     dump_file: "{{ site | regex_replace('\\.+', '_') }}_db_dump.sql.gz"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_development_{{ current_date_and_time }}.sql.gz"
 
-  tasks:
-  - name: Abort if environment variable is equal to development
-    fail:
-      msg: "ERROR: development is not a valid environment for this mode (you can't pull from development to development)."
-    when: env == "development"
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
 
-  - name: Check if {{ site }} local folder exists
+    - name: Abort if environment variable is equal to development
+      fail:
+        msg: "ERROR: development is not a valid environment for this mode (you can't pull from development to development)."
+      when: env == "development"
+
+    - name: Check if {{ site }} local folder exists
+      delegate_to: localhost
+      stat:
+        path: "{{ project_local_path }}"
+      register: result
+      become: no
+
+    - name: Abort if {{ site }} local folder doesn't exist
+      fail:
+        msg: "ERROR: {{ site }} is not a valid site (local folder {{ project_local_path }} does not exist)."
+      when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+
+  tasks:
+  - name: Create local database_backup directory if it doesn't exist
     delegate_to: localhost
-    stat:
-      path: "{{ local_bedrock_dir }}"
-    register: result
+    file:
+      path: "{{ project_local_path }}/database_backup"
+      state: directory
+      mode: 0755
     become: no
 
-  - name: Abort if {{ site }} local folder doesn't exist
-    fail:
-      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
-    when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+  - name: Create database dump on {{ env }}
+    shell: wp db export --allow-root - | gzip > {{ dump_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
 
-  - block:
-    - name: Create local database_backup directory if it doesn't exist
-      delegate_to: localhost
-      file:
-        path: "{{ local_bedrock_dir }}/database_backup"
-        state: directory
-        mode: 0755
-      become: no
+  - name: Pull database dump from {{ env }} to development
+    fetch:
+      src: "{{ project_web_dir }}/{{ dump_file }}"
+      dest: "{{ project_local_path }}/"
+      flat: yes
 
-    - name: Create database dump on {{ env }}
-      shell: wp db export --allow-root - | gzip > {{ dump_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
+  - name: Delete database dump from {{ env }}
+    shell: rm -f {{ dump_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
 
-    - name: Pull database dump from {{ env }} to development
-      fetch:
-        src: "{{ project_web_dir }}/{{ dump_file }}"
-        dest: "{{ local_bedrock_dir }}/"
-        flat: yes
+  - name: Export development database before importing dump (backup)
+    delegate_to: localhost
+    shell: wp db export - | gzip > database_backup/{{ backup_file }}
+    args:
+      chdir: "{{ project_local_path }}/web/wp"
+    become: no
 
-    - name: Delete database dump from {{ env }}
-      shell: rm -f {{ dump_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
+  - name: Import database dump on development
+    delegate_to: localhost
+    shell: gzip -c -d {{ dump_file }} | wp db import -
+    args:
+      chdir: "{{ project_local_path }}/web/wp"
+    become: no
 
-    - name: Export development database before importing dump (backup)
-      delegate_to: localhost
-      shell: wp db export - | gzip > database_backup/{{ backup_file }}
-      args:
-        chdir: "{{ local_bedrock_dir }}/web/wp"
-      become: no
+  - name: Delete database dump from development
+    delegate_to: localhost
+    shell: rm -f {{ dump_file }}
+    args:
+      chdir: "{{ project_local_path }}"
+    become: no
 
-    - name: Import database dump on development
-      delegate_to: localhost
-      shell: gzip -c -d {{ dump_file }} | wp db import -
-      args:
-        chdir: "{{ local_bedrock_dir }}/web/wp"
-      become: no
-
-    - name: Delete database dump from development
-      delegate_to: localhost
-      shell: rm -f {{ dump_file }}
-      args:
-        chdir: "{{ local_bedrock_dir }}"
-      become: no
-
-    - name: Search for {{ url_from }} and replace with {{ url_to }} on development
-      delegate_to: localhost
-      command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise
-      args:
-        chdir: "{{ local_bedrock_dir }}/web/wp"
-      become: no
-      tags: ['search-replace']
-    when: result.stat.exists is defined and result.stat.exists and result.stat.isdir is defined and result.stat.isdir
+  - name: Search for {{ url_from }} and replace with {{ url_to }} on development
+    delegate_to: localhost
+    command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise
+    args:
+      chdir: "{{ project_local_path }}/web/wp"
+    become: no
+    tags: ['search-replace']

--- a/backup/trellis/database-push.yml
+++ b/backup/trellis/database-push.yml
@@ -1,4 +1,8 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: database-push.yml
+
 - name: Push {{ site }} database from development to {{ env }}
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
@@ -7,91 +11,97 @@
     - group_vars/development/wordpress_sites.yml
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     project_web_dir: "{{ project_root }}/current"
     dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
     url_from: "{{ dev_wordpress_sites.wordpress_sites[site].site_hosts.0.canonical }}"
-    url_to: "{{ wordpress_sites[site].site_hosts.0.canonical }}"
-    local_bedrock_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
+    url_to: "{{ project.site_hosts.0.canonical }}"
+    project_local_path: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}"
     dump_file: "{{ site | regex_replace('\\.+', '_') }}_db_dump.sql.gz"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_file: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_{{ current_date_and_time }}.sql.gz"
 
-  tasks:
-  - name: Abort if environment variable is equal to development
-    fail:
-      msg: "ERROR: development is not a valid environment for this mode (you can't push from development to development)."
-    when: env == "development"
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
 
-  - name: Check if {{ site }} local folder exists
+    - name: Abort if environment variable is equal to development
+      fail:
+        msg: "ERROR: development is not a valid environment for this mode (you can't push from development to development)."
+      when: env == "development"
+
+    - name: Check if {{ site }} local folder exists
+      delegate_to: localhost
+      stat:
+        path: "{{ project_local_path }}"
+      register: result
+      become: no
+
+    - name: Abort if {{ site }} local folder doesn't exist
+      fail:
+        msg: "ERROR: {{ site }} is not a valid site (local folder {{ project_local_path }} does not exist)."
+      when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+
+  tasks:
+  - name: Create local database_backup directory if it doesn't exist
     delegate_to: localhost
-    stat:
-      path: "{{ local_bedrock_dir }}"
-    register: result
+    file:
+      path: "{{ project_local_path }}/database_backup"
+      state: directory
+      mode: 0755
     become: no
 
-  - name: Abort if {{ site }} local folder doesn't exist
-    fail:
-      msg: "ERROR: {{ site }} is not a valid site (local folder {{ local_bedrock_dir }} does not exist)."
-    when: result.stat.exists is defined and result.stat.exists == false or result.stat.isdir is defined and result.stat.isdir == false
+  - name: Create database dump on development
+    delegate_to: localhost
+    shell: wp db export --allow-root - | gzip > {{ dump_file }}
+    args:
+      chdir: "{{ project_local_path }}/web/wp"
+    become: no
 
-  - block:
-    - name: Create local database_backup directory if it doesn't exist
-      delegate_to: localhost
-      file:
-        path: "{{ local_bedrock_dir }}/database_backup"
-        state: directory
-        mode: 0755
-      become: no
+  - name: Push database dump from development to {{ env }}
+    copy:
+      src: "{{ project_local_path }}/{{ dump_file }}"
+      dest: "{{ project_web_dir }}/{{ dump_file }}"
 
-    - name: Create database dump on development
-      delegate_to: localhost
-      shell: wp db export --allow-root - | gzip > {{ dump_file }}
-      args:
-        chdir: "{{ local_bedrock_dir }}/web/wp"
-      become: no
+  - name: Delete database dump from development
+    delegate_to: localhost
+    shell: rm -f {{ dump_file }}
+    args:
+      chdir: "{{ project_local_path }}"
+    become: no
 
-    - name: Push database dump from development to {{ env }}
-      copy:
-        src: "{{ local_bedrock_dir }}/{{ dump_file }}"
-        dest: "{{ project_web_dir }}/{{ dump_file }}"
+  - name: Export {{ env }} database before importing dump (backup)
+    shell: wp db export - | gzip > {{ backup_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
 
-    - name: Delete database dump from development
-      delegate_to: localhost
-      shell: rm -f {{ dump_file }}
-      args:
-        chdir: "{{ local_bedrock_dir }}"
-      become: no
+  - name: Pull exported database from {{ env }} to development (backup)
+    fetch:
+      src: "{{project_web_dir}}/{{ backup_file }}"
+      dest: "{{ project_local_path }}/database_backup/"
+      flat: yes
 
-    - name: Export {{ env }} database before importing dump (backup)
-      shell: wp db export - | gzip > {{ backup_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
+  - name: Delete exported database from {{ env }} (backup)
+    shell: rm -f {{ backup_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
 
-    - name: Pull exported database from {{ env }} to development (backup)
-      fetch:
-        src: "{{project_web_dir}}/{{ backup_file }}"
-        dest: "{{ local_bedrock_dir }}/database_backup/"
-        flat: yes
+  - name: Import database dump on {{ env }}
+    shell: gzip -c -d {{ dump_file }} | wp db import -
+    args:
+      chdir: "{{ project_web_dir }}"
 
-    - name: Delete exported database from {{ env }} (backup)
-      shell: rm -f {{ backup_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
+  - name: Delete database dump from {{ env }}
+    shell: rm -f {{ dump_file }}
+    args:
+      chdir: "{{ project_web_dir }}"
 
-    - name: Import database dump on {{ env }}
-      shell: gzip -c -d {{ dump_file }} | wp db import -
-      args:
-        chdir: "{{ project_web_dir }}"
-
-    - name: Delete database dump from {{ env }}
-      shell: rm -f {{ dump_file }}
-      args:
-        chdir: "{{ project_web_dir }}"
-
-    - name: Search for {{ url_from }} and replace with {{ url_to }} on development
-      command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise
-      args:
-        chdir: "{{ project_web_dir }}"
-      tags: ['search-replace']
-    when: result.stat.exists is defined and result.stat.exists and result.stat.isdir is defined and result.stat.isdir
+  - name: Search for {{ url_from }} and replace with {{ url_to }} on development
+    command: wp search-replace '//{{ url_from }}' '//{{ url_to }}' --allow-root --all-tables --precise
+    args:
+      chdir: "{{ project_web_dir }}"
+    tags: ['search-replace']

--- a/backup/trellis/files-backup.yml
+++ b/backup/trellis/files-backup.yml
@@ -1,49 +1,59 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: files-backup.yml
+
 - name: Backup {{ site }} {{ env }} files (uploads)
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     shared_uploads_dir: "{{ project_root }}/shared/uploads"
-    local_bedrock_dir: "{{ wordpress_sites[site].local_path }}"
+    project_local_path: "{{ project.local_path }}"
     current_date_and_time: "{{ ansible_date_time.date | regex_replace('\\-+', '_') }}_{{ ansible_date_time.hour }}_{{ ansible_date_time.minute }}_{{ ansible_date_time.second }}"
     backup_filename: "{{ site | regex_replace('\\.+', '_') }}_{{ env }}_uploads_{{ current_date_and_time }}.tar.gz"
-    backup_dir: "{{ local_bedrock_dir }}/files_backup"
+    backup_dir: "{{ project_local_path }}/files_backup"
+
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
+
+    - name: Check if {{ site }} uploads folder exists
+      stat:
+        path: "{{ shared_uploads_dir }}"
+      register: uploads_check
+
+    - name: Abort if {{ site }} uploads folder doesn't exist
+      fail:
+        msg: "ERROR: Uploads folder does not exist at {{ shared_uploads_dir }}"
+      when: uploads_check.stat.exists is defined and uploads_check.stat.exists == false
 
   tasks:
-  - name: Check if {{ site }} uploads folder exists
-    stat:
-      path: "{{ shared_uploads_dir }}"
-    register: uploads_check
+  - name: Create local files_backup directory if it doesn't exist
+    delegate_to: localhost
+    file:
+      path: "{{ backup_dir }}"
+      state: directory
+      mode: 0755
+    become: no
 
-  - name: Abort if {{ site }} uploads folder doesn't exist
-    fail:
-      msg: "ERROR: Uploads folder does not exist at {{ shared_uploads_dir }}"
-    when: uploads_check.stat.exists is defined and uploads_check.stat.exists == false
+  - name: Create temporary archive of uploads on {{ env }}
+    shell: tar -czf /tmp/{{ backup_filename }} -C {{ shared_uploads_dir }} .
 
-  - block:
-    - name: Create local files_backup directory if it doesn't exist
-      delegate_to: localhost
-      file:
-        path: "{{ backup_dir }}"
-        state: directory
-        mode: 0755
-      become: no
+  - name: Pull uploads archive from {{ env }} to local files_backup
+    fetch:
+      src: "/tmp/{{ backup_filename }}"
+      dest: "{{ backup_dir }}/"
+      flat: yes
 
-    - name: Create temporary archive of uploads on {{ env }}
-      shell: tar -czf /tmp/{{ backup_filename }} -C {{ shared_uploads_dir }} .
+  - name: Delete temporary archive from {{ env }}
+    shell: rm -f /tmp/{{ backup_filename }}
 
-    - name: Pull uploads archive from {{ env }} to local files_backup
-      fetch:
-        src: "/tmp/{{ backup_filename }}"
-        dest: "{{ backup_dir }}/"
-        flat: yes
-
-    - name: Delete temporary archive from {{ env }}
-      shell: rm -f /tmp/{{ backup_filename }}
-
-    - name: Show backup location
-      debug:
-        msg: "Files backup saved to: {{ backup_dir }}/{{ backup_filename }}"
-    when: uploads_check.stat.exists is defined and uploads_check.stat.exists
+  - name: Show backup location
+    debug:
+      msg: "Files backup saved to: {{ backup_dir }}/{{ backup_filename }}"

--- a/backup/trellis/files-pull.yml
+++ b/backup/trellis/files-pull.yml
@@ -1,29 +1,41 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: files-pull.yml
+
 - name: Pull {{ site }} uploads from {{ env }} to development
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     remote_uploads_dir: "{{ project_root }}/shared/uploads/"
     local_uploads_dir: "{{ hostvars.development_host.wordpress_sites[site].local_path }}/web/app/uploads/"
 
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
+
+    - name: Abort if environment variable is equal to development
+      fail:
+        msg: "ERROR: development is not a valid environment for this mode (you can't pull from development to development)."
+      when: env == "development"
+
+    - name: Check if remote uploads folder exists
+      stat:
+        path: "{{ remote_uploads_dir }}"
+      register: remote_uploads_check
+
+    - name: Abort if remote uploads folder doesn't exist
+      fail:
+        msg: "ERROR: Uploads folder does not exist at {{ remote_uploads_dir }}"
+      when: remote_uploads_check.stat.exists is defined and remote_uploads_check.stat.exists == false
+
   tasks:
-  - name: Abort if environment variable is equal to development
-    fail:
-      msg: "ERROR: development is not a valid environment for this mode (you can't pull from development to development)."
-    when: env == "development"
-
-  - name: Check if remote uploads folder exists
-    stat:
-      path: "{{ remote_uploads_dir }}"
-    register: remote_uploads_check
-
-  - name: Abort if remote uploads folder doesn't exist
-    fail:
-      msg: "ERROR: Uploads folder does not exist at {{ remote_uploads_dir }}"
-    when: remote_uploads_check.stat.exists is defined and remote_uploads_check.stat.exists == false
-
   - name: Ensure local uploads directory exists
     delegate_to: development_host
     file:

--- a/backup/trellis/files-push.yml
+++ b/backup/trellis/files-push.yml
@@ -1,30 +1,42 @@
 ---
+- import_playbook: variable-check.yml
+  vars:
+    playbook: files-push.yml
+
 - name: Push {{ site }} uploads from development to {{ env }}
   hosts: web:&{{ env }}
   remote_user: "{{ web_user }}"
 
   vars:
+    project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     remote_uploads_dir: "{{ project_root }}/shared/uploads/"
     local_uploads_dir: "{{ hostvars.development_host.wordpress_sites[site].local_path }}/web/app/uploads/"
 
+  pre_tasks:
+    - name: Ensure site is valid
+      delegate_to: localhost
+      fail:
+        msg: "Site `{{ site | default('') }}` is not valid. Available sites: {{ wordpress_sites.keys() | join(', ') }}"
+      when: wordpress_sites[site | default('')] is not defined
+
+    - name: Abort if environment variable is equal to development
+      fail:
+        msg: "ERROR: development is not a valid environment for this mode (you can't push from development to development)."
+      when: env == "development"
+
+    - name: Check if local uploads folder exists
+      delegate_to: development_host
+      stat:
+        path: "{{ local_uploads_dir }}"
+      register: local_uploads_check
+
+    - name: Abort if local uploads folder doesn't exist
+      fail:
+        msg: "ERROR: Local uploads folder does not exist at {{ local_uploads_dir }}"
+      when: local_uploads_check.stat.exists is defined and local_uploads_check.stat.exists == false
+
   tasks:
-  - name: Abort if environment variable is equal to development
-    fail:
-      msg: "ERROR: development is not a valid environment for this mode (you can't push from development to development)."
-    when: env == "development"
-
-  - name: Check if local uploads folder exists
-    delegate_to: development_host
-    stat:
-      path: "{{ local_uploads_dir }}"
-    register: local_uploads_check
-
-  - name: Abort if local uploads folder doesn't exist
-    fail:
-      msg: "ERROR: Local uploads folder does not exist at {{ local_uploads_dir }}"
-    when: local_uploads_check.stat.exists is defined and local_uploads_check.stat.exists == false
-
   - name: Ensure remote uploads directory exists
     file:
       path: "{{ remote_uploads_dir }}"


### PR DESCRIPTION
This pull request refactors all Trellis backup and migration playbooks to improve code consistency, error handling, and maintainability. The main improvements include standardizing variable usage, introducing pre-task validation for site existence, and importing a shared variable-check playbook at the start of each playbook. These changes make the playbooks more robust and easier to maintain.

**Playbook structure and validation improvements:**

* All playbooks (`database-backup.yml`, `database-pull.yml`, `database-push.yml`, `files-backup.yml`, `files-pull.yml`, `files-push.yml`) now import a shared `variable-check.yml` playbook at the top to centralize variable validation. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aR2-R41) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296R2-R5) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfR2-R5) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aR2-L14) [[5]](diffhunk://#diff-17f6626e3c2e8876395517a76f56a739ba5e384dd96f8810c63db75e376f7a9eR2-R22) [[6]](diffhunk://#diff-ab07e4144630525b3308d00268bdc856d87f3287d70e743bf965d956ce5a4c13R2-R22)
* Added `pre_tasks` to each playbook to validate that the specified `site` exists in `wordpress_sites`, failing early with a clear error message if not. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aR2-R41) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296R14-R31) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfR14-R31) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aR2-L14) [[5]](diffhunk://#diff-17f6626e3c2e8876395517a76f56a739ba5e384dd96f8810c63db75e376f7a9eR2-R22) [[6]](diffhunk://#diff-ab07e4144630525b3308d00268bdc856d87f3287d70e743bf965d956ce5a4c13R2-R22)

**Variable standardization and code consistency:**

* Standardized the use of `project` and `project_local_path` variables instead of directly referencing `wordpress_sites[site]` and `local_bedrock_dir`, improving readability and reducing duplication. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aR2-R41) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296R14-R31) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfR14-R31) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aR2-L14)
* Updated all relevant tasks to use the new variable names for paths and project references. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL39-R50) [[2]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL52-R63) [[3]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L29-R53) [[4]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL29-R53) [[5]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL51-R74) [[6]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL74-R85) [[7]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aL25-R36) [[8]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L55-R66) [[9]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L67-L91)

**Task organization and error handling:**

* Moved site and environment validation steps into `pre_tasks` for early failure and better separation of concerns. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aR2-R41) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296R14-R31) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfR14-R31) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aR2-L14) [[5]](diffhunk://#diff-17f6626e3c2e8876395517a76f56a739ba5e384dd96f8810c63db75e376f7a9eR2-R22) [[6]](diffhunk://#diff-ab07e4144630525b3308d00268bdc856d87f3287d70e743bf965d956ce5a4c13R2-R22)
* Improved error messages for invalid site or missing local/remote directories, making troubleshooting easier. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aR2-R41) [[2]](diffhunk://#diff-9d1f46a18f64a3f917ff8cdc71405a07d1b4b47d1881308c965d508ec8a7b296L29-R53) [[3]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL29-R53) [[4]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aR2-L14) [[5]](diffhunk://#diff-17f6626e3c2e8876395517a76f56a739ba5e384dd96f8810c63db75e376f7a9eR38) [[6]](diffhunk://#diff-ab07e4144630525b3308d00268bdc856d87f3287d70e743bf965d956ce5a4c13R39)

**General cleanup:**

* Removed redundant `when` conditions at the end of playbooks and streamlined task blocks for clarity. [[1]](diffhunk://#diff-fcbcb28ce98ea02b9427b8259947f489e6d4179b4d14b124cf3840f2dc88d34aL61) [[2]](diffhunk://#diff-a51a460cf3ca36a15dce80cb0d7cc5c86070fa0379d4d69c6b197bc70760a5dfL97) [[3]](diffhunk://#diff-1ce1bce7bba95970ac15bf6228f688feca10cdad21e413185bce3bb3ae70398aL49)

These changes collectively make the backup and migration playbooks more robust, maintainable, and user-friendly.