### PR TITLE
Database Export Message Fix

### DIFF
--- a/backup/trellis/database-backup.yml
+++ b/backup/trellis/database-backup.yml
@@ -43,7 +43,7 @@
       mode: 0755
     become: no
 
-  - name: Export development database
+  - name: Export {{ env }} database
     delegate_to: localhost
     shell: wp db export - | gzip > database_backup/{{ backup_file }}
     args:


### PR DESCRIPTION
This pull request updates the database backup process to make it environment-agnostic by adjusting the task name to reflect the specific environment being backed up.

- Improved clarity in the backup process:
  * Changed the task name from "Export development database" to "Export {{ env }} database" in `backup/trellis/database-backup.yml` to accurately indicate which environment's database is being exported.