### PR TITLE
PHP Upgrade Additions

### DIFF
--- a/provision/README.md
+++ b/provision/README.md
@@ -38,10 +38,17 @@ trellis provision production
 ## PHP Version Upgrade Process
 
 1. Update `php_version` in `trellis/group_vars/all/main.yml`
-2. Run with `php`, `nginx`, and `wordpress-setup` tags (avoids 502 errors):
+2. Run with `php`, `nginx`, `wordpress-setup`, `users`, and `memcached` tags:
 
 ```bash
-trellis provision --tags php,nginx,wordpress-setup production
+trellis provision --tags php,nginx,wordpress-setup,users,memcached production
 ```
 
-This installs PHP, updates Nginx config, and creates the WordPress PHP-FPM pool. The `wordpress-setup` tag creates `/etc/php/X.X/fpm/pool.d/wordpress.conf`.
+**Why these tags are required:**
+- `php` - Installs new PHP version and extensions
+- `nginx` - Updates Nginx configuration for new PHP-FPM socket
+- `wordpress-setup` - Creates `/etc/php/X.X/fpm/pool.d/wordpress.conf`
+- `users` - **Critical**: Regenerates sudoers with new PHP version for passwordless `php-fpm reload`
+- `memcached` - Installs PHP version-specific memcached extension (e.g., `php8.3-memcached`)
+
+**Note:** Without the `users` tag, deployments will fail when trying to reload PHP-FPM because the sudoers configuration still references the old PHP version.


### PR DESCRIPTION
This pull request updates the PHP version upgrade instructions in the `provision/README.md` to clarify the required tags and their purposes when running `trellis provision` for production. The main goal is to prevent deployment failures by ensuring all necessary components are updated when upgrading PHP.

Provisioning process improvements:

* The recommended `trellis provision` command now includes the `users` and `memcached` tags in addition to `php`, `nginx`, and `wordpress-setup`, ensuring all relevant configurations and extensions are updated for the new PHP version.
* Added explanations for each tag, emphasizing that the `users` tag is critical for regenerating the sudoers configuration, which is necessary for passwordless PHP-FPM reloads after a PHP upgrade.
* Included a note that omitting the `users` tag will cause deployments to fail due to outdated sudoers configuration referencing the old PHP version.