### PR TITLE
Pattern Creation Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2025-12-15
+
+### Changed
+- Updated `content-creation/PATTERN-REQUIREMENTS.md` to clarify metadata is recommended (not required), add guidance on block comment vs rendered HTML validation, extend checklist, and bump document version to 1.2
+
 ## [1.13.0] - 2025-12-15
 
 ### Added

--- a/content-creation/PATTERN-REQUIREMENTS.md
+++ b/content-creation/PATTERN-REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # WordPress Block Pattern Requirements & Best Practices
 
-**Version:** 1.1
-**Last Updated:** December 15, 2024
+**Version:** 1.2
+**Last Updated:** December 15, 2025
 **Analysis Based On:** 43 Elayne patterns + 98 Ollie patterns (141 total) + Official WordPress documentation
 
 This document provides a comprehensive checklist and guidelines for creating WordPress block patterns that follow modern best practices and avoid common validation errors.
@@ -16,7 +16,7 @@ This document provides a comprehensive checklist and guidelines for creating Wor
 ## Table of Contents
 
 1. [Pattern Header Requirements](#1-pattern-header-requirements)
-2. [Metadata Attribute (Critical)](#2-metadata-attribute-critical)
+2. [Metadata Attribute (Recommended)](#2-metadata-attribute-recommended)
 3. [Structural Patterns](#3-structural-patterns)
 4. [Spacing and Styling](#4-spacing-and-styling)
 5. [Image Handling](#5-image-handling)
@@ -122,11 +122,11 @@ Every pattern file must begin with a PHP comment block containing:
 
 ---
 
-## 2. Metadata Attribute (Critical)
+## 2. Metadata Attribute (Recommended)
 
-### Universal Requirement
+### Recommendation & Context
 
-**Every pattern's outermost block MUST include a metadata attribute** containing pattern identification and categorization information.
+Including a `metadata` attribute on the outermost block is **strongly recommended** for discoverability and portability (copy/paste) even though it is not a strict validation requirement.
 
 According to [WordPress Gutenberg GitHub Issue #71687](https://github.com/wordpress/gutenberg/issues/71687), when inserting any pattern from the main inserter sidebar, WordPress automatically sets metadata attributes on the inserted block, including `categories`, `patternName`, and `name`.
 
@@ -178,19 +178,23 @@ According to [WordPress Gutenberg GitHub Issue #71687](https://github.com/wordpr
 <!-- /wp:group -->
 ```
 
-### Why It's Critical
+### Why to Include It
 
 **Pattern Discovery:** WordPress uses metadata for categorization and search
 - The metadata enables WordPress to classify and organize patterns for discovery and filtering
 - Users can filter patterns by category in the block inserter
 
-**Validation:** Missing metadata causes "Block validation failed" errors in console
-- When a block's save function runs, WordPress compares output from save function with database
-- Missing or incorrect metadata triggers validation errors visible in browser console
-
 **Editor UI:** Ensures pattern appears correctly in the patterns inserter
 - Pattern identity is maintained when inserted into content
 - Supports WordPress features like "contentOnly patterns" which require consistent metadata
+
+**Copy/Paste Portability:** Keeps pattern identity intact when moving markup between sites
+- When copying pattern HTML into another site, metadata preserves categories and the pattern name so it appears in the inserter as expected
+- WordPress often injects metadata when inserting patterns; keeping it in the saved markup prevents identity loss if the content is reused elsewhere
+
+**Validation Note:** Metadata is not required for block validity
+- Missing metadata alone typically does **not** trigger block validation errors
+- If metadata is present, ensure its values match the header fields to avoid inconsistent labeling
 
 **Consistency:** Metadata fields must match header fields exactly
 - `name` must match `Title:` header field
@@ -199,7 +203,7 @@ According to [WordPress Gutenberg GitHub Issue #71687](https://github.com/wordpr
 
 ### Common Issues
 
-- ❌ **Metadata attribute missing entirely** - Causes validation errors and pattern discovery issues
+- ❌ **Metadata attribute missing entirely** - Does not usually break validation but reduces discoverability and portability
 - ❌ **Category names don't match registered categories** in `functions.php`
   - Example: Using `"hero"` when only `"elayne/hero"` is registered
 - ❌ **`patternName` doesn't match the `Slug:` header field**
@@ -983,58 +987,63 @@ WordPress documentation states: "To both escape the text for security and make i
    - Causes: Block validation errors
    - Fix: Move `backgroundColor`, `layout`, `align` to root level
 
-4. **❌ `align="full"` with `"layout":{"type":"constrained"}` on same group**
+4. **❌ Block comment attributes don't match rendered HTML**
+   - Example: Padding declared in block JSON (`left/right`) not present in rendered `style` attributes
+   - Causes: Block validation errors because serialized markup differs from saved HTML
+   - Fix: Ensure rendered HTML includes all declared padding/margin/border attributes; compare saved HTML to block comment JSON
+
+5. **❌ `align="full"` with `"layout":{"type":"constrained"}` on same group**
    - Causes: Horizontal gaps, overflow issues
    - Fix: Use `"layout":{"type":"default"}` on outer alignfull group
 
-5. **❌ Using `wp:columns` for responsive multi-column layouts**
+6. **❌ Using `wp:columns` for responsive multi-column layouts**
    - Causes: Cramped tablet layout (3→3→1 instead of 3→2→1)
    - Fix: Use `"layout":{"type":"grid","minimumColumnWidth":"20rem"}`
 
-6. **❌ Missing metadata attribute on outermost block**
-   - Causes: Pattern discovery issues, validation errors
-   - Fix: Add metadata with name, categories, patternName
-
 ### Best Practice Violations
 
-7. **❌ Hardcoded colors/sizes instead of theme variables**
+7. **❌ Missing metadata attribute on outermost block**
+   - Causes: Reduced pattern discovery/copy-paste portability (not typically a validation blocker)
+   - Fix: Add metadata with name, categories, patternName to keep inserter labeling intact
+
+8. **❌ Hardcoded colors/sizes instead of theme variables**
    - Example: `"style":{"color":{"background":"#f0f0f0"}}`
    - Fix: Use `"backgroundColor":"tertiary"` or theme color variables
 
-8. **❌ Missing margin reset on background patterns**
+9. **❌ Missing margin reset on background patterns**
    - Causes: Unwanted gaps between adjacent patterns
    - Fix: Add `"margin":{"top":"0","bottom":"0"}`
 
-9. **❌ No alt text on images**
-   - Causes: Accessibility violations, SEO issues
-   - Fix: Add descriptive `alt="..."` to all images with proper escaping
+10. **❌ No alt text on images**
+    - Causes: Accessibility violations, SEO issues
+    - Fix: Add descriptive `alt="..."` to all images with proper escaping
 
-10. **❌ Untranslated user-facing text**
+11. **❌ Untranslated user-facing text**
     - Causes: Non-translatable interface, missing security escaping
     - Fix: Wrap all text in `esc_html_e()` or combine with `__()` + escaping functions
 
-11. **❌ Inconsistent spacing/padding between sections**
+12. **❌ Inconsistent spacing/padding between sections**
     - Causes: Visual rhythm issues
     - Fix: Use consistent spacing variables from theme.json
 
-12. **❌ Using HTML blocks instead of native WordPress blocks**
+13. **❌ Using HTML blocks instead of native WordPress blocks**
     - Example: `<!-- wp:html --><div class="custom">...</div><!-- /wp:html -->`
     - Causes: Non-editable in block editor, breaks pattern editing
     - Fix: Use `wp:group`, `wp:list`, `wp:separator` with CSS classes
 
-13. **❌ Font sizes in pixels instead of responsive units**
+14. **❌ Font sizes in pixels instead of responsive units**
     - Example: `"fontSize":"16px"`
     - Fix: Use font size variables or `clamp()` values
 
-14. **❌ Missing border-radius on cards/buttons**
+15. **❌ Missing border-radius on cards/buttons**
     - Causes: Sharp corners inconsistent with design
     - Fix: Add `"border":{"radius":"5px"}` or `"8px"`
 
-15. **❌ Layout type mismatches**
+16. **❌ Layout type mismatches**
     - Example: Full-width section with constrained inner layout directly
     - Fix: Always nest: alignfull (default) → constrained group → content
 
-16. **❌ Using query-dependent PHP functions in patterns**
+17. **❌ Using query-dependent PHP functions in patterns**
     - Example: `<?php if ( is_page() ) { ... } ?>` (WRONG - not available during init)
     - Causes: Functions not available during pattern registration on `init` hook
     - Fix: Only use functions available during `init` (helper functions, theme functions, translations)
@@ -1047,8 +1056,8 @@ WordPress documentation states: "To both escape the text for security and make i
 
 #### Header & Metadata
 - [ ] Header has Title, Slug, Description, Categories
-- [ ] Outermost block includes metadata attribute
-- [ ] Metadata fields match header (name = Title, patternName = Slug)
+- [ ] Outermost block includes metadata attribute (recommended for discovery/copy-paste, not required for validation)
+- [ ] If metadata is present, fields match header (name = Title, patternName = Slug)
 - [ ] Slug format: `elayne/pattern-slug` (theme-prefixed)
 - [ ] Categories registered in `functions.php`
 
@@ -1056,6 +1065,7 @@ WordPress documentation states: "To both escape the text for security and make i
 - [ ] Full-width groups use `"layout":{"type":"default"}`
 - [ ] Nested groups use `"layout":{"type":"constrained"}` with contentSize
 - [ ] Multi-column layouts use grid (not columns) for responsive behavior
+- [ ] Block comment attributes match rendered HTML (padding, margin, border) to avoid validation errors
 - [ ] Background sections have margin reset: `"margin":{"top":"0","bottom":"0"}`
 - [ ] Consistent padding: typically x-large or xx-large for sections
 
@@ -1112,6 +1122,7 @@ WordPress documentation states: "To both escape the text for security and make i
 - [Block Pattern API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/) - Technical API reference
 - [Block Editor Handbook](https://developer.wordpress.org/block-editor/) - Block editor fundamentals
 - [Theme.json Reference](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/) - Theme configuration and design tokens
+- [Block Serialization & Validation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-serialization/) - How block attributes map to saved HTML
 - [Metadata in block.json](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) - Block metadata structure
 - [WordPress Gutenberg Issue #71687](https://github.com/wordpress/gutenberg/issues/71687) - Pattern metadata attribute implementation
 
@@ -1128,10 +1139,11 @@ WordPress documentation states: "To both escape the text for security and make i
 
 ---
 
-**Document Version:** 1.1
-**Last Updated:** December 15, 2024
+**Document Version:** 1.2
+**Last Updated:** December 15, 2025
 **Maintained By:** Imagewize Development Team
 
 **Changelog:**
+- **v1.2 (Dec 15, 2025):** Clarified metadata as recommended (not required), documented block comment vs rendered HTML validation issues, added block serialization reference, and updated checklist accordingly
 - **v1.1 (Dec 15, 2024):** Added official WordPress documentation on PHP patterns, security requirements, pattern registration timing, metadata attribute details, template types, and PHP execution context limitations
 - **v1.0 (Dec 15, 2024):** Initial version based on analysis of 141 production patterns


### PR DESCRIPTION
Updated the content-creation standards to version 1.2, clarifying that block metadata on the outermost block is recommended for discovery and portability rather than a hard validation requirement, and documenting common validation pitfalls between block comments and rendered HTML. Added new guidance on ensuring serialized attributes (padding, margin, borders) match saved markup to avoid block validation errors and expanded the quick checklist accordingly. Linked to WordPress block serialization docs to reinforce the validation guidance and refreshed timestamps to December 15, 2025. Recorded these documentation changes in the changelog under release 1.13.1 dated 2025-12-15.

**Content Creation Standards**
- Bumped `content-creation/PATTERN-REQUIREMENTS.md` to version 1.2 with updated date and clarified metadata is recommended (not required) while maintaining discovery/copy-paste benefits.
- Added guidance to reconcile block comment JSON with rendered HTML styling to prevent validation failures and clarified metadata mismatch impacts.
- Expanded the quick checklist to include rendered-vs-saved HTML checks and updated metadata notes for consistency.

**References and Context**
- Linked the pattern requirements guide to the WordPress block serialization and validation reference to support the new guidance on saved markup alignment.

**Changelog**
- Added release entry `1.13.1` in `CHANGELOG.md` (2025-12-15) documenting the metadata clarification, validation guidance, checklist updates, and document version bump.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/trellis-tools/blob/pattern-creation-update/CHANGELOG.md) (Modified)
- [`content-creation/PATTERN-REQUIREMENTS.md`](https://github.com/imagewize/trellis-tools/blob/pattern-creation-update/content-creation/PATTERN-REQUIREMENTS.md) (Modified)