### PR TITLE
Fix create-pr.sh usage docs: --no-interactive required for scripted use

### DIFF
--- a/.vibe/prompts/wp-ops.md
+++ b/.vibe/prompts/wp-ops.md
@@ -45,8 +45,9 @@ You are working in the **wp-ops** repository, a WordPress operations toolkit for
 4. **Push branch** to origin:
    - `git push origin add/feature-name`
 5. **Create Pull Request** using the helper script:
-   - `bash scripts/create-pr.sh --ai=vibe` (interactive mode)
-   - Or `bash scripts/create-pr.sh main "PR title" --ai=claude` (non-interactive)
+   - `bash scripts/create-pr.sh --ai=vibe` (interactive — prompts for branch, title, and AI choice)
+   - `bash scripts/create-pr.sh --no-interactive main "PR title" --ai=claude` (fully non-interactive)
+   - Passing positional args without `--no-interactive` still triggers prompts
    - Script auto-generates AI-powered description and creates PR via GitHub CLI
 
 ### Important Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2026-05-12
+
+### Documentation
+
+- **CLAUDE.md create-pr.sh usage** - Corrected GitHub PR Creation examples to show `--no-interactive` flag:
+  - Passing positional args alone does not suppress the AI prompt; `--no-interactive` is required for scripted use
+  - Added explicit examples for non-interactive AI, no-AI, and update-mode invocations
+
+- **.vibe/prompts/wp-ops.md create-pr.sh usage** - Updated Git Workflow step 5 to reflect the same fix:
+  - Clarified interactive vs. fully non-interactive invocation
+  - Added note that positional args without `--no-interactive` still trigger prompts
+
 ## [2.7.1] - 2026-05-12
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,18 +149,20 @@ find . -type f -name "*.jpg" -exec cwebp -q 80 {} -o {}.webp \;
 The create-pr.sh script uses Claude CLI to generate AI-powered PR descriptions:
 
 ```bash
-# Interactive mode with AI description
+# Interactive mode (prompts for base branch, title, and AI choice)
 ./scripts/create-pr.sh
 
-# Non-interactive with arguments
-./scripts/create-pr.sh main "Add feature name"
+# Non-interactive: must pass --no-interactive to suppress all prompts
+./scripts/create-pr.sh --no-interactive main "Add feature name" --ai=claude
 
-# Skip AI generation (0 tokens)
-./scripts/create-pr.sh --no-ai
+# Skip AI generation entirely
+./scripts/create-pr.sh --no-interactive main "Add feature name" --no-ai
 
-# Update existing PR
-./scripts/create-pr.sh --update
+# Update existing PR description
+./scripts/create-pr.sh --update --no-interactive --ai=claude
 ```
+
+**Important:** Passing positional arguments alone (`main "title"`) does NOT disable prompts. Always use `--no-interactive` for scripted or automated invocations.
 
 ## Architecture and Patterns
 


### PR DESCRIPTION
This update corrects the documentation for `create-pr.sh` to accurately reflect that `--no-interactive` is required when suppressing prompts in scripted or automated contexts. Previously, the usage docs implied that passing positional arguments alone (e.g., `main "title"`) would disable interactive prompts, which was incorrect and could cause CI/automated workflows to hang. The fix aligns the documented usage with the actual script behavior, preventing confusion for developers integrating the script into pipelines. Changes are reflected across the project documentation files and the prompt template used for AI-assisted PR generation.

**Documentation Corrections:**

- Updated `CLAUDE.md` to explicitly document that `--no-interactive` must always be passed for non-interactive invocations, not just positional arguments, with corrected usage examples.
- Updated `.vibe/prompts/wp-ops.md` to reflect the same corrected usage pattern, ensuring consistency across all documentation sources.

**Changelog:**

- Added an entry to `CHANGELOG.md` recording the documentation fix for the `create-pr.sh` scripted usage requirement.

**Files Changed:**

- [`.vibe/prompts/wp-ops.md`](https://github.com/imagewize/wp-ops/blob/fix/create-pr-usage-docs/.vibe/prompts/wp-ops.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/fix/create-pr-usage-docs/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/wp-ops/blob/fix/create-pr-usage-docs/CLAUDE.md) (Modified)