### PR TITLE
Feature/404 Checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] - 2026-05-22
+
+### Added
+
+- **404 Checker Script** - New [`scripts/monitoring/404-checker.sh`](scripts/monitoring/404-checker.sh) for scanning internal links for broken responses:
+  - **Global mode** (default) — fetches homepage, extracts and checks all internal links (~30s)
+  - **Spider mode** — recursive `wget` spider to configurable depth (default: 3, ~5-10 min)
+  - Filters out assets (CSS, JS, images, fonts), feeds, sitemaps, and WordPress admin/API paths to avoid noise
+  - Color-coded output (green OK, yellow warnings, red errors, cyan progress)
+  - `--output FILE` flag to append broken-link results to a file alongside stdout
+  - `--timeout N` flag to control per-request curl max-time (default: 10s)
+  - `--level N` flag to control spider recursion depth
+  - Exit codes: `0` (no broken links), `1` (broken links found), `2` (usage error / missing dependency)
+  - Cross-platform: uses `bash` parameter expansion instead of GNU-specific `sed` flags for macOS/BSD compatibility
+
 ## [2.7.3] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 
 | Tool | Description | Docs |
 |------|-------------|------|
+| **404 Checker** | Internal broken-link checker — homepage scan or recursive spider | [→](scripts/README.md#404-checkersh) |
 | **PR Creation** | AI-powered GitHub PR descriptions (Claude/Codex) | [→](CREATE-PR.md) |
 | **Plugin Release** | AI-powered version bumping and changelog generation for plugins | [→](scripts/release-plugin.sh) |
 | **Theme Release** | AI-powered version bumping and changelog generation for themes | [→](scripts/release-theme.sh) |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ scripts/
 │   ├── db-backup.sh            # Database-only backup with URL replacement
 │   └── site-backup.sh          # Complete site backup (DB + files + config)
 ├── monitoring/                  # Server monitoring and alerting
+│   ├── 404-checker.sh          # Internal broken-link checker (homepage scan or recursive spider)
 │   ├── ai-bot-monitor.sh       # AI crawler traffic analysis (GPTBot, ClaudeBot, etc.)
 │   ├── redirect-check.sh       # Mass URL redirect checker using curl
 │   ├── run-monitoring.sh       # Orchestrator: runs all monitors and generates summary
@@ -75,6 +76,12 @@ scripts/
 
 # Backup WordPress database
 ./scripts/backup/db-backup.sh example.com production
+
+# Check homepage links for broken URLs (~30s)
+./scripts/monitoring/404-checker.sh https://example.com
+
+# Full spider check (recursive, depth 3, ~5-10 min)
+./scripts/monitoring/404-checker.sh --mode spider https://example.com
 
 # Check a list of URLs for redirects
 ./scripts/monitoring/redirect-check.sh https://example.com/old-path/ https://example.com/another/
@@ -1139,6 +1146,58 @@ Analyzes AI crawler traffic from Nginx logs, with per-bot breakdowns, bandwidth 
 # Syntax
 ./ai-bot-monitor.sh [LOG_FILE] [HOURS] [OUTPUT_FILE]
 ```
+
+---
+
+### 404-checker.sh
+
+Internal broken-link checker for WordPress sites. Scans for pages and links that return 4xx or 5xx responses. Two modes: a fast homepage scan (~30 s) that catches global footer/nav issues, and a recursive wget spider (~5–10 min) that traverses the whole site.
+
+#### Features
+
+- **Global mode** (default): fetches the homepage and checks every internal link found — catches header/footer/nav links that appear on every page
+- **Spider mode**: recursive `wget --spider` crawl to configurable depth — covers the full site including blog posts and service pages
+- **Color-coded output**: green OK, yellow warnings, red broken links
+- **Exit code 1** when broken links are found — suitable for CI/deploy hooks
+- **Optional output file**: append broken links to a file for audit trails
+- **Configurable timeout and spider depth**
+
+#### Usage
+
+```bash
+# Fast homepage scan — covers all global (header/footer/nav) links
+./scripts/monitoring/404-checker.sh https://example.com
+
+# Full recursive spider, depth 3
+./scripts/monitoring/404-checker.sh --mode spider https://example.com
+
+# Save broken links to a file
+./scripts/monitoring/404-checker.sh --output /tmp/broken-links.txt https://example.com
+
+# Spider with custom depth and timeout
+./scripts/monitoring/404-checker.sh --mode spider --level 4 --timeout 15 https://example.com
+```
+
+#### Example Output
+
+```
+[10:05:12] Fetching homepage: https://example.com
+[10:05:13] Found 42 internal links — checking each...
+404  https://example.com/old-page/
+410  https://example.com/?page_id=3330
+[WARN] 2 broken link(s) found.
+```
+
+#### Integration ideas
+
+- **After every page deletion**: `./404-checker.sh https://example.com` to catch stale footer/nav links before Ahrefs does
+- **Post-deploy hook**: add to a Makefile target or Trellis deploy callback
+- **CI pipeline**: exit code 1 on broken links blocks a deploy
+
+#### Requirements
+
+- `curl` (standard on macOS/Linux)
+- `wget` — only required for `--mode spider` (`brew install wget` on macOS)
 
 ---
 

--- a/scripts/monitoring/404-checker.sh
+++ b/scripts/monitoring/404-checker.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# 404-checker.sh — Check internal links for broken responses (4xx/5xx)
+#
+# Usage: ./404-checker.sh [OPTIONS] <site-url>
+#
+# Modes:
+#   global  (default) — fetch homepage, check all internal links (~30s)
+#   spider             — recursive wget spider, depth 3 (~5-10 min)
+#
+# Examples:
+#   ./404-checker.sh https://imagewize.com
+#   ./404-checker.sh --mode spider https://imagewize.com
+#   ./404-checker.sh --output results.txt https://imagewize.com
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+MODE="global"
+OUTPUT=""
+TIMEOUT=10
+LEVEL=3
+SITE=""
+BROKEN=0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] <site-url>
+
+Options:
+  --mode global   Check all links found on the homepage (fast, ~30s) [default]
+  --mode spider   Recursive wget spider to depth $LEVEL (slow, ~5-10 min)
+  --output FILE   Append broken-link results to FILE (default: stdout only)
+  --timeout N     curl max-time per request in seconds (default: $TIMEOUT)
+  --level N       Spider depth for --mode spider (default: $LEVEL)
+  -h, --help      Show this help
+
+Exit codes:
+  0   No broken links found
+  1   One or more broken links found
+  2   Usage error or missing dependency
+EOF
+  exit 2
+}
+
+log()  { printf "${CYAN}[%s]${NC} %s\n" "$(date +%H:%M:%S)" "$*" >&2; }
+ok()   { printf "${GREEN}[OK]${NC} %s\n" "$*" >&2; }
+warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$*" >&2; }
+err()  { printf "${RED}[ERR]${NC} %s\n" "$*" >&2; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)    MODE="$2";    shift 2 ;;
+    --output)  OUTPUT="$2";  shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --level)   LEVEL="$2";   shift 2 ;;
+    -h|--help) usage ;;
+    http*)     SITE="${1%/}"; shift ;;
+    *)         err "Unknown option: $1"; usage ;;
+  esac
+done
+
+if [[ -z "$SITE" ]]; then
+  err "Site URL is required."
+  usage
+fi
+
+# Use bash parameter expansion — avoids BSD vs GNU sed \? differences
+DOMAIN="${SITE#*://}"   # strip scheme (https:// or http://)
+DOMAIN="${DOMAIN%%/*}"  # strip any path component
+
+# Escape dots in domain for use in grep regex
+DOMAIN_RE="${DOMAIN/./\\.}"
+
+# ── Output helper ─────────────────────────────────────────────────────────────
+report() {
+  if [[ -n "$OUTPUT" ]]; then
+    printf '%s\n' "$1" | tee -a "$OUTPUT"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+report_header() {
+  if [[ -n "$OUTPUT" ]]; then
+    printf '=== 404 Checker: %s | mode=%s | %s ===\n' \
+      "$SITE" "$MODE" "$(date '+%Y-%m-%d %H:%M:%S')" >> "$OUTPUT"
+  fi
+}
+
+# ── Single URL check ──────────────────────────────────────────────────────────
+check_url() {
+  local url="$1" status
+  status=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" -L "$url" 2>/dev/null) \
+    || status="ERR"
+  printf '%s  %s' "$status" "$url"
+}
+
+# ── Mode: global (homepage links) ────────────────────────────────────────────
+run_global() {
+  log "Fetching homepage: $SITE"
+
+  local raw_html=""
+  raw_html=$(curl -s --max-time 20 "$SITE" 2>/dev/null) || true
+
+  if [[ -z "$raw_html" ]]; then
+    warn "Could not fetch homepage — check the URL and your connection."
+    return
+  fi
+
+  # Extract, filter, and normalise internal links.
+  # Pipe through grep/sed in a subshell so non-zero exit codes don't abort.
+  local raw_links=""
+  raw_links=$(
+    printf '%s\n' "$raw_html" \
+      | grep -Eo 'href="[^"#]+"' \
+      | sed 's/href="//;s/"$//' \
+      | grep -vE '^(mailto:|tel:|javascript:|#|$)' \
+      | grep -E "^(/|https?://${DOMAIN_RE})" \
+      | grep -vE '\.(css|js|woff2?|ttf|eot|png|jpg|jpeg|gif|webp|svg|ico|xml|pdf)(\?|$)' \
+      | grep -vE '/(wp-json|wp/xmlrpc|xmlrpc\.php|feed|sitemap)' \
+      | sed "s|^/|${SITE}/|g" \
+      | sed "s|${SITE}//|${SITE}/|g" \
+      | sort -u
+  ) 2>/dev/null || true
+
+  local count=0
+  if [[ -n "$raw_links" ]]; then
+    count=$(printf '%s\n' "$raw_links" | wc -l | tr -d ' \t')
+  fi
+  log "Found $count internal links — checking each..."
+
+  if [[ "$count" -eq 0 ]]; then
+    warn "No internal links found on homepage. Check the URL and try again."
+    return
+  fi
+
+  while IFS= read -r url; do
+    [[ -z "$url" ]] && continue
+    local result status
+    result=$(check_url "$url")
+    status="${result%%  *}"
+    if [[ "$status" =~ ^[45] ]] || [[ "$status" == "ERR" ]]; then
+      report "$result"
+      err "Broken: $result"
+      BROKEN=$((BROKEN + 1))
+    fi
+  done <<< "$raw_links"
+
+  if [[ $BROKEN -eq 0 ]]; then
+    ok "All $count links OK."
+  else
+    warn "$BROKEN broken link(s) found."
+  fi
+}
+
+# ── Mode: spider (wget recursive) ────────────────────────────────────────────
+run_spider() {
+  if ! command -v wget &>/dev/null; then
+    err "wget is required for spider mode. Install: brew install wget"
+    exit 2
+  fi
+
+  local tmpfile
+  tmpfile=$(mktemp /tmp/404-spider-XXXXXX.txt)
+  trap 'rm -f "$tmpfile"' EXIT
+
+  log "Starting recursive spider (depth $LEVEL) on $SITE ..."
+  log "This may take several minutes."
+
+  wget \
+    --spider \
+    --recursive \
+    --level="$LEVEL" \
+    --no-verbose \
+    --output-file="$tmpfile" \
+    --domains="$DOMAIN" \
+    --reject-regex="(wp-admin|wp-login|feed|sitemap|\.xml$|\.pdf$|\.jpg$|\.jpeg$|\.png$|\.gif$|\.webp$|\.css$|\.js$|\.woff)" \
+    "$SITE" 2>/dev/null || true
+
+  log "Spider done — extracting broken links from log..."
+
+  local prev_url=""
+  while IFS= read -r line; do
+    if echo "$line" | grep -qE 'https?://'; then
+      prev_url=$(echo "$line" | grep -oE 'https?://[^[:space:]]+' | head -1) || true
+    fi
+    if echo "$line" | grep -qiE '(404|broken|Remote file does not exist|No such file)'; then
+      if [[ -n "$prev_url" ]]; then
+        report "404  $prev_url"
+        err "Broken: 404  $prev_url"
+        BROKEN=$((BROKEN + 1))
+        prev_url=""
+      fi
+    fi
+  done < "$tmpfile"
+
+  if [[ $BROKEN -eq 0 ]]; then
+    ok "Spider complete — no broken links found."
+  else
+    warn "$BROKEN broken link(s) found."
+  fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+main() {
+  report_header
+
+  case "$MODE" in
+    global) run_global ;;
+    spider) run_spider ;;
+    *)      err "Unknown mode: $MODE"; usage ;;
+  esac
+
+  if [[ $BROKEN -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+main


### PR DESCRIPTION
This release introduces `404-checker.sh`, an internal broken-link scanner added to the monitoring scripts collection, and bumps the project to version 2.8.0. The script provides automated detection of broken links within WordPress installations or web projects without requiring external services. Documentation across three files — `CHANGELOG.md`, `README.md`, and `scripts/README.md` — has been updated to reflect the new tooling and its usage patterns. The addition brings the monitoring utilities in line with the existing operational toolkit, giving operators a self-contained diagnostic option for identifying 404 errors at the infrastructure level.

**New Monitoring Tooling:**
- Added `scripts/monitoring/404-checker.sh`, a standalone shell script for scanning and reporting broken internal links, intended for use in server-side or CI-adjacent workflows where external link-checking services are unavailable or undesirable.

**Documentation and Release Tracking:**
- Updated `CHANGELOG.md` to record the v2.8.0 release entry, including a description of the new script's purpose and invocation patterns.
- Updated `README.md` and `scripts/README.md` to include `404-checker.sh` in the scripts inventory with usage guidance, ensuring the tool is discoverable alongside the existing monitoring utilities.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/feature/404-checker/CHANGELOG.md) (Modified)
- [`README.md`](https://github.com/imagewize/wp-ops/blob/feature/404-checker/README.md) (Modified)
- [`scripts/README.md`](https://github.com/imagewize/wp-ops/blob/feature/404-checker/scripts/README.md) (Modified)
- [`scripts/monitoring/404-checker.sh`](https://github.com/imagewize/wp-ops/blob/feature/404-checker/scripts/monitoring/404-checker.sh) (Added)