### PR TITLE
Monitoring Improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-05-24
+
+### Changed
+
+- **Traffic Monitor Admin Path Filtering** - Updated [`scripts/monitoring/traffic-monitor.sh`](scripts/monitoring/traffic-monitor.sh) to exclude WordPress admin and API paths from page view analysis:
+  - Added `ADMIN_PATTERN` variable filtering `/wp/wp-login.php`, `/wp/wp-admin/`, `/wp-json/`, `/xmlrpc.php`, and `/wp-cron.php`
+  - Prevents admin/API traffic from skewing content page view statistics
+
 ## [2.8.0] - 2026-05-22
 
 ### Added

--- a/scripts/monitoring/traffic-monitor.sh
+++ b/scripts/monitoring/traffic-monitor.sh
@@ -36,6 +36,9 @@ STATIC_PATTERN='\.(css|js|jpg|jpeg|png|gif|ico|woff|woff2|svg|webp|avif|ttf|eot|
 # SEO-relevant bot patterns
 SEO_BOTS='Googlebot|bingbot|Baiduspider|YandexBot|DuckDuckBot|Slurp'
 
+# Admin and API paths to exclude from page view analysis
+ADMIN_PATTERN='^/wp/wp-login\.php|^/wp/wp-admin/|^/wp-json/|^/xmlrpc\.php|^/wp-cron\.php'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -410,6 +413,7 @@ main() {
         | grep -vE "$STATIC_PATTERN" \
         | awk '{print $7}' \
         | cut -d'?' -f1 \
+        | grep -vE "$ADMIN_PATTERN" \
         | sort \
         | uniq -c \
         | sort -rn \


### PR DESCRIPTION
The traffic monitor script has been enhanced with admin path filtering to improve the accuracy of page view analysis. The change adds a configurable `ADMIN_PATTERN` variable that excludes WordPress admin and API endpoints (`/wp/wp-login.php`, `/wp/wp-admin/`, `/wp-json/`, `/xmlrpc.php`, `/wp-cron.php`) from traffic statistics, preventing backend requests from distorting content-focused metrics. This refinement ensures that top pages reports reflect actual user-facing content rather than administrative activity. Version 2.8.1 documents this targeted filtering improvement.

**Traffic Analysis Enhancements**
- Added `ADMIN_PATTERN` variable to `scripts/monitoring/traffic-monitor.sh` with regex matching WordPress admin, login, JSON API, XML-RPC, and cron paths
- Applied filter to the Top 50 Most Requested Pages analysis via `grep -vE "$ADMIN_PATTERN"` to exclude backend traffic from content metrics

**Documentation Updates**
- Updated `CHANGELOG.md` with version 2.8.1 (2026-05-24) documenting the admin path filtering addition and its purpose

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/monitoring-improvement/CHANGELOG.md) (Modified)
- [`scripts/monitoring/traffic-monitor.sh`](https://github.com/imagewize/wp-ops/blob/monitoring-improvement/scripts/monitoring/traffic-monitor.sh) (Modified)