### PR TITLE
Bedrock Local Package Development & WP CLI Config

### DIFF
--- a/.vibe/prompts/wp-ops.md
+++ b/.vibe/prompts/wp-ops.md
@@ -2,7 +2,7 @@ You are working in the **wp-ops** repository, a WordPress operations toolkit for
 
 ## Project Structure
 - **trellis/** - Trellis-specific: `backup/`, `monitoring/`, `provision/`, `security/`, `updater/`
-- **bedrock/** - Bedrock/Composer development workflows: `local-package-development/`
+- **bedrock/** - Bedrock/Composer development workflows: `local-package-development/`, `wp-cli-config/`
 - **wp-cli/** - WordPress CLI tools: `content-creation/`, `diagnostics/`, `migration/`, `security/`
 - **nginx/** - Server configs: `browser-caching/`, `image-optimization/`, `redirects/`
 - **scripts/** - Utilities: `backup/`, `monitoring/`, `woocommerce/`, `batch-resize.sh`, `convert-to-webp.sh`, `create-pr.sh`, `find-and-replace-files.sh`, `git-log-oneline.sh`, `release-plugin.sh`, `release-theme.sh`, `rsync-theme.sh`

--- a/.vibe/prompts/wp-ops.md
+++ b/.vibe/prompts/wp-ops.md
@@ -2,6 +2,7 @@ You are working in the **wp-ops** repository, a WordPress operations toolkit for
 
 ## Project Structure
 - **trellis/** - Trellis-specific: `backup/`, `monitoring/`, `provision/`, `security/`, `updater/`
+- **bedrock/** - Bedrock/Composer development workflows: `local-package-development/`
 - **wp-cli/** - WordPress CLI tools: `content-creation/`, `diagnostics/`, `migration/`, `security/`
 - **nginx/** - Server configs: `browser-caching/`, `image-optimization/`, `redirects/`
 - **scripts/** - Utilities: `backup/`, `monitoring/`, `woocommerce/`, `batch-resize.sh`, `convert-to-webp.sh`, `create-pr.sh`, `find-and-replace-files.sh`, `git-log-oneline.sh`, `release-plugin.sh`, `release-theme.sh`, `rsync-theme.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - VCS repository alternative for pushed branches (no local checkout needed)
   - Revert and cleanup steps for after the release is tagged
 
+### Added
+
+- **Bedrock WP-CLI Config** - New [`bedrock/wp-cli-config/`](bedrock/wp-cli-config/) with a standard `wp-cli.yml` and a `wp pattern validate` WP-CLI command for Bedrock projects:
+  - `wp-cli.yml` sets `path: web/wp` and `server.docroot: web` for Bedrock's directory layout, and auto-requires the validator on every `wp` call
+  - `wp-cli-pattern-validate.php` round-trips block pattern files through WordPress's own `parse_blocks()` / `serialize_blocks()` to produce canonical markup — supports `--fix`, `--diff`, `--log`, and `--log-dir` flags
+  - WooCommerce-bundled patterns automatically skipped; `--compliance` / `--compliance-only` hooks for project-specific static analysis
+  - Exit codes: `0` (all pass / fixed), `1` (issues found in dry-run)
+  - Log output written to `docs/pattern-logs/<date>/` with per-file diffs and a `summary.md`
+
 ### Documentation
 
-- **README.md** - Added Bedrock section linking to the new local package development guide
-- **CLAUDE.md** - Added `bedrock/local-package-development/` to the repository structure
+- **README.md** - Added Bedrock section linking to the new local package development guide; added WP-CLI Config row to the Bedrock table
+- **CLAUDE.md** - Added `bedrock/local-package-development/` and `bedrock/wp-cli-config/` to the repository structure
+- **.vibe/prompts/wp-ops.md** - Added `wp-cli-config/` to the bedrock entry in Project Structure
 
 ## [2.9.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-05-30
+
+### Added
+
+- **Bedrock Local Package Development Guide** - New [`bedrock/local-package-development/README.md`](bedrock/local-package-development/README.md) for testing an in-development plugin or theme branch inside a Bedrock site via a Composer `path` repository, before tagging a release:
+  - Covers the `symlink: false` requirement (symlinks break plugin/theme activation because `realpath` resolves outside `web/app`)
+  - Branch-based constraint setup (`dev-<branch>` form) with inline alias support for cross-package semver constraints
+  - Re-sync workflow for keeping the copied mirror up to date during development (`composer update vendor/package`)
+  - VCS repository alternative for pushed branches (no local checkout needed)
+  - Revert and cleanup steps for after the release is tagged
+
+### Documentation
+
+- **README.md** - Added Bedrock section linking to the new local package development guide
+- **CLAUDE.md** - Added `bedrock/local-package-development/` to the repository structure
+
 ## [2.9.0] - 2026-05-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This is a collection of tools, scripts, and documentation for WordPress operatio
   - `trellis/updater/` - Safe Trellis update scripts
 - **bedrock/** - Bedrock/Composer development workflows
   - `bedrock/local-package-development/` - Test a local plugin/theme branch in a Bedrock site via a Composer `path` repository
+  - `bedrock/wp-cli-config/` - Standard `wp-cli.yml` for Bedrock path setup and `wp pattern validate` command for canonicalizing block pattern files
 - **wp-cli/** - WordPress command-line operations
   - `wp-cli/content-creation/` - WP-CLI content creation and block patterns
   - `wp-cli/diagnostics/` - WordPress diagnostic tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ This is a collection of tools, scripts, and documentation for WordPress operatio
   - `trellis/provision/` - Provisioning guides and command reference
   - `trellis/security/` - fail2ban WordPress protection and manual IP blocking guides
   - `trellis/updater/` - Safe Trellis update scripts
+- **bedrock/** - Bedrock/Composer development workflows
+  - `bedrock/local-package-development/` - Test a local plugin/theme branch in a Bedrock site via a Composer `path` repository
 - **wp-cli/** - WordPress command-line operations
   - `wp-cli/content-creation/` - WP-CLI content creation and block patterns
   - `wp-cli/diagnostics/` - WordPress diagnostic tools

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 | Tool | Description | Docs |
 |------|-------------|------|
 | **Local Package Development** | Test an in-development plugin/theme branch in a Bedrock site via a Composer `path` repository, before tagging a release | [→](bedrock/local-package-development/README.md) |
+| **WP-CLI Config** | Standard `wp-cli.yml` for Bedrock path setup plus a `wp pattern validate` command for canonicalizing block pattern files | [→](bedrock/wp-cli-config/README.md) |
 
 ## WP-CLI
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 ## Contents
 
 - [Trellis](#trellis)
+- [Bedrock](#bedrock)
 - [WP-CLI](#wp-cli)
 - [Nginx](#nginx)
 - [Scripts](#scripts)
@@ -28,6 +29,12 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 | **Monitoring** | Nginx log monitoring for traffic analysis and security threat detection | [→](trellis/monitoring/README.md) |
 | **Security** | fail2ban IP blocking and manual deny rules | [→](trellis/security/README.md) |
 | **Troubleshooting** | Diagnose PHP-FPM, MariaDB, and server issues | [→](troubleshooting/README.md) |
+
+## Bedrock
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| **Local Package Development** | Test an in-development plugin/theme branch in a Bedrock site via a Composer `path` repository, before tagging a release | [→](bedrock/local-package-development/README.md) |
 
 ## WP-CLI
 

--- a/bedrock/local-package-development/README.md
+++ b/bedrock/local-package-development/README.md
@@ -1,0 +1,184 @@
+# Local Package Development (Composer path repository)
+
+Test an in-development plugin or theme inside a [Bedrock](https://roots.io/bedrock/)
+site **before tagging a release**, by pointing the site's Composer dependency at
+your local git working copy / branch instead of Packagist (or a private repo such
+as wp-packages.org).
+
+This is purely a local-dev change to the site's `composer.json` — **do not commit
+it to the site repository**. Revert it once the package release is tagged.
+
+## TL;DR
+
+```bash
+# In the Bedrock site's composer.json:
+#  1. add a "path" repository pointing at your local package checkout
+#  2. change the package constraint to the branch:  "dev-<branch>"
+# Then:
+cd /path/to/bedrock-site
+composer update vendor/package-name
+```
+
+## Setup
+
+### 1. Add a `path` repository
+
+In the site's `composer.json`, add a `path` repository to the **top** of the
+`repositories` array (entries are evaluated in order; listing it first lets it win
+over Packagist / private repos for this package):
+
+```json
+"repositories": [
+  {
+    "type": "path",
+    "url": "../../my-plugin",
+    "options": {
+      "symlink": false
+    }
+  },
+  {
+    "name": "wp-packages",
+    "type": "composer",
+    "url": "https://repo.wp-packages.org"
+  }
+],
+```
+
+- `url` is the path to your local package checkout, relative to the site's
+  `composer.json` (absolute paths also work, but relative is more portable).
+- **`symlink: false` is important** — see [Why `symlink: false`](#why-symlink-false-not-true) below.
+
+### 2. Point the constraint at your branch
+
+Change the package's version constraint to Composer's `dev-<branch>` form:
+
+```json
+"require": {
+  "vendor/my-plugin": "dev-feature-xyz"
+}
+```
+
+A `path` repository derives the package version from the **currently checked-out
+branch** of that local repo, so the constraint must match that branch. Branch
+`feature-xyz` → constraint `dev-feature-xyz`. (Slashes are kept: branch
+`feat/xyz` → `dev-feat/xyz`.)
+
+Bedrock ships with `"minimum-stability": "dev"` and `"prefer-stable": true`, so a
+`dev-` constraint resolves fine. If some *other* package depends on yours with a
+semver range (e.g. `^2.0`), add an inline alias so both resolve:
+
+```json
+"vendor/my-plugin": "dev-feature-xyz as 2.0.99"
+```
+
+### 3. Install
+
+```bash
+cd /path/to/bedrock-site
+composer update vendor/my-plugin
+```
+
+You should see `Mirroring from ../../my-plugin`. The package lands as a **real
+copied directory** in `web/app/plugins/` (or `web/app/themes/`), which WordPress
+activates normally.
+
+## Why `symlink: false` (not `true`)
+
+Composer's `path` repository defaults to **symlinking** the package into place. For
+a Bedrock plugin/theme that breaks activation:
+
+> The plugin `my-plugin/my-plugin.php` has been deactivated due to an error:
+> Plugin file does not exist.
+
+WordPress calls `realpath()` on the plugin file, which resolves the symlink to its
+target **outside** `web/app/plugins/` (e.g. `/Users/you/code/my-plugin`).
+`plugin_basename()` then computes a slug that no longer matches the stored
+activation record (`my-plugin/my-plugin.php`), so WordPress decides the file is
+missing and deactivates it. Themes hit the analogous problem.
+
+`symlink: false` makes Composer **mirror (copy)** the package instead, giving
+WordPress a real directory inside the install. Trade-off: see re-syncing below.
+
+## Re-syncing after local edits
+
+Because the package is **copied**, edits in your local checkout do **not** appear
+in the site automatically. Composer also won't re-mirror when the commit hash is
+unchanged, so force it:
+
+```bash
+cd /path/to/bedrock-site
+rm -rf web/app/plugins/my-plugin && composer update vendor/my-plugin
+```
+
+Commit (or at least stage) changes in the package repo first — the mirror reflects
+the working tree at mirror time.
+
+## Alternative: `vcs` repository (pushed branch)
+
+If you've pushed the branch to GitHub and prefer not to reference a local path
+(e.g. so a teammate can reproduce), use a `vcs` repository instead. This installs a
+normal git checkout — no symlink, so no activation bug:
+
+```json
+"repositories": [
+  {
+    "type": "vcs",
+    "url": "https://github.com/vendor/my-plugin"
+  }
+]
+```
+
+```json
+"vendor/my-plugin": "dev-feature-xyz"
+```
+
+Trade-off: edits require `git push` + `composer update` to reach the site (no live
+local working copy).
+
+## Revert / cleanup
+
+When the package release is tagged, undo the local-dev wiring:
+
+1. Remove the `path` (or `vcs`) repository entry from the site's `composer.json`.
+2. Restore the normal constraint (e.g. `^2.0`).
+3. `composer update vendor/my-plugin`.
+
+## Gotchas
+
+- **Don't commit the change to the site repo** — the `path` `url` is specific to
+  your machine. Keep it on a local-only branch or `git stash` / revert it.
+- **`symlink: true` breaks plugin/theme activation** — always use `false` for
+  Bedrock. (See above.)
+- **Stale mirror** — Composer skips re-mirroring an unchanged commit hash;
+  `rm -rf` the installed dir to force a fresh copy.
+- **Compiled assets** — if the package ships a build artifact (e.g. a webpack
+  bundle in `dist/`), make sure it's built/committed in the package before
+  mirroring; the site loads the committed artifact, not your `src/`.
+- **`minimum-stability`** — `dev-` constraints need `dev` (or a per-package
+  `@dev` flag) allowed. Bedrock defaults to `"minimum-stability": "dev"`.
+
+## Worked example
+
+Testing the `issues-30-05-26` branch of `imagewize/warder-cookie-consent` in a
+Bedrock site located at `code/imagewize.com/demo`, with the plugin checked out at
+`code/warder-cookie-consent`:
+
+```json
+"repositories": [
+  {
+    "type": "path",
+    "url": "../../warder-cookie-consent",
+    "options": { "symlink": false }
+  }
+],
+"require": {
+  "imagewize/warder-cookie-consent": "dev-issues-30-05-26"
+}
+```
+
+```bash
+cd code/imagewize.com/demo
+composer update imagewize/warder-cookie-consent
+# - Installing imagewize/warder-cookie-consent (dev-issues-30-05-26 7290d6d):
+#   Mirroring from ../../warder-cookie-consent
+```

--- a/bedrock/wp-cli-config/README.md
+++ b/bedrock/wp-cli-config/README.md
@@ -1,0 +1,135 @@
+# Bedrock WP-CLI Configuration
+
+Standard `wp-cli.yml` for a [Bedrock](https://roots.io/bedrock/) site plus a custom
+`wp pattern validate` command for keeping block pattern files in canonical form.
+
+Place both files in your **Bedrock site root** (the directory that contains `composer.json`).
+
+---
+
+## `wp-cli.yml`
+
+```yaml
+path: web/wp
+server:
+  docroot: web
+require:
+  - wp-cli-pattern-validate.php
+```
+
+| Key | Purpose |
+|-----|---------|
+| `path` | Tells WP-CLI where WordPress core lives in a Bedrock layout — saves you `--path=web/wp` on every command |
+| `server.docroot` | Used by `wp server` (built-in dev server) to serve from Bedrock's public root |
+| `require` | Auto-loads `wp-cli-pattern-validate.php` on every `wp` call so the `pattern validate` command is always available without an explicit `--require` flag |
+
+---
+
+## `wp-cli-pattern-validate.php`
+
+A WP-CLI command that round-trips block pattern files through WordPress's own
+`parse_blocks()` / `serialize_blocks()` to produce the exact markup WordPress
+would write after a Gutenberg save. Ideal for enforcing consistent formatting
+across a block theme's `patterns/` directory in CI or as a pre-commit check.
+
+### How it works
+
+1. Reads each `.php` pattern file and extracts the block HTML (supports both the
+   `return 'string';` format and the PHP docblock + raw HTML format).
+2. Passes the block HTML through `parse_blocks()` then `serialize_blocks()`.
+3. Reverses the unicode escapes WordPress adds to `<`, `>`, `&`, and `--` so that
+   PHP open/close tags, CSS custom properties (`--wp--…`), and literal `&` survive
+   round-tripping unchanged.
+4. Compares original vs canonical — reports PASS / FAIL, optionally diffs or fixes.
+
+### Usage
+
+```bash
+# Validate all patterns — dry run, shows PASS/FAIL per file
+wp pattern validate web/app/themes/your-theme/patterns/
+
+# Show a unified diff for each file that needs changes (no writes)
+wp pattern validate web/app/themes/your-theme/patterns/ --diff
+
+# Auto-fix all structural issues in-place
+wp pattern validate web/app/themes/your-theme/patterns/ --fix
+
+# Fix and save per-file diff logs + a summary to docs/pattern-logs/<date>/
+wp pattern validate web/app/themes/your-theme/patterns/ --fix --log
+
+# Override the log output directory
+wp pattern validate web/app/themes/your-theme/patterns/ --fix --log --log-dir=/tmp/pattern-logs
+
+# Validate a single file
+wp pattern validate web/app/themes/your-theme/patterns/hero.php --fix
+
+# Validate a subdirectory only
+wp pattern validate web/app/themes/your-theme/patterns/woocommerce/ --fix
+```
+
+If `wp-cli-pattern-validate.php` is **not** auto-loaded via `wp-cli.yml`, pass it explicitly:
+
+```bash
+wp --require=wp-cli-pattern-validate.php pattern validate web/app/themes/your-theme/patterns/
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--fix` | Rewrite each non-canonical file in-place |
+| `--diff` | Print a unified diff to stdout (dry-run, no writes) |
+| `--log` | Write per-file `.diff` logs and a `summary.md` to `docs/pattern-logs/<date>/` |
+| `--log-dir=<path>` | Override the default log directory |
+| `--compliance` | Run project-specific compliance checks after structural validation |
+| `--compliance-only` | Skip Gutenberg round-trip; run only compliance checks |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All files pass (or all issues fixed) |
+| `1` | One or more files need changes (dry-run) or a write error occurred |
+
+### WooCommerce patterns
+
+Files under a `woocommerce/patterns/` path are automatically skipped — they follow
+WooCommerce's own standards rather than your theme's.
+
+### Compliance hook
+
+The `--compliance` and `--compliance-only` flags call `run_compliance_checks()`, which
+is a stub in the distributed file. Adapt it to point at your project's own static-analysis
+script (e.g. a checker that enforces theme-specific block rules):
+
+```php
+// Inside run_compliance_checks():
+$checker = dirname( __FILE__ ) . '/scripts/pattern-check/class-compliancechecker.php';
+```
+
+Projects that don't need this can leave the stub as-is — the flags will emit a warning
+and exit cleanly.
+
+### Log output structure
+
+With `--log`, each run creates:
+
+```
+docs/pattern-logs/
+└── 2026-05-30/
+    ├── hero.php.diff
+    ├── card.php.diff
+    └── summary.md
+```
+
+`summary.md` contains a per-file status table (PASS / FIXED / NEEDS_FIX) and counts.
+
+---
+
+## Requirements
+
+- WP-CLI 2.x
+- PHP 7.4+
+- `diff` binary available in `$PATH` (standard on macOS and Linux)
+- WordPress must be bootstrapped for `parse_blocks()` / `serialize_blocks()` to be
+  available — run `wp` from the Bedrock site root as usual

--- a/bedrock/wp-cli-config/wp-cli-pattern-validate.php
+++ b/bedrock/wp-cli-config/wp-cli-pattern-validate.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * WP-CLI command for validating and fixing pattern files using WordPress core parser.
+ *
+ * Uses parse_blocks() + serialize_blocks() to round-trip pattern content through
+ * WordPress's own serializer. The output IS the canonical form WordPress would store
+ * after a save — so --fix writes back exactly what WP expects, with no browser needed.
+ *
+ * PHP tags inside block HTML are treated as literal text by parse_blocks() and
+ * round-trip cleanly — no stripping required.
+ *
+ * Place this file in your Bedrock site root alongside wp-cli.yml so it is
+ * auto-required on every `wp` invocation (see wp-cli.yml's `require` key).
+ *
+ * ## EXAMPLES
+ *
+ *     # Validate all patterns (dry run, shows what would change)
+ *     wp pattern validate web/app/themes/your-theme/patterns/
+ *
+ *     # Show unified diff without fixing
+ *     wp pattern validate web/app/themes/your-theme/patterns/ --diff
+ *
+ *     # Auto-fix all structural issues in-place
+ *     wp pattern validate web/app/themes/your-theme/patterns/ --fix
+ *
+ *     # Fix and write logs to docs/pattern-logs/
+ *     wp pattern validate web/app/themes/your-theme/patterns/ --fix --log
+ *
+ *     # Fix a single file
+ *     wp pattern validate web/app/themes/your-theme/patterns/hero.php --fix
+ *
+ *     # Fix a subdirectory only
+ *     wp pattern validate web/app/themes/your-theme/patterns/woocommerce/ --fix
+ *
+ *     # If not auto-required via wp-cli.yml, pass --require explicitly:
+ *     wp --require=wp-cli-pattern-validate.php pattern validate web/app/themes/your-theme/patterns/
+ */
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	exit;
+}
+
+/**
+ * Validates and fixes WordPress block pattern files using the WordPress block parser.
+ */
+class Pattern_Validate_Command extends WP_CLI_Command {
+
+	/**
+	 * Validates (and optionally fixes) pattern files using WordPress block parser.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <path>...
+	 * : Pattern file or directory. Directories are scanned recursively.
+	 *
+	 * [--fix]
+	 * : Rewrite each file with the canonical serialized output in-place.
+	 *
+	 * [--diff]
+	 * : Print a unified diff for each file that needs changes (dry-run).
+	 *
+	 * [--log]
+	 * : Write per-pattern diff files and a summary to docs/pattern-logs/<date>/.
+	 *
+	 * [--log-dir=<path>]
+	 * : Override the log directory (default: <site-root>/docs/pattern-logs/).
+	 *
+	 * [--compliance]
+	 * : Also run project-specific compliance checks after structural validation.
+	 *
+	 * [--compliance-only]
+	 * : Skip Gutenberg validation and only run compliance checks.
+	 *
+	 * @subcommand validate
+	 */
+	public function validate( $args, $assoc_args ) {
+		$fix             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'fix', false );
+		$diff            = \WP_CLI\Utils\get_flag_value( $assoc_args, 'diff', false );
+		$log             = \WP_CLI\Utils\get_flag_value( $assoc_args, 'log', false );
+		$compliance      = \WP_CLI\Utils\get_flag_value( $assoc_args, 'compliance', false );
+		$compliance_only = \WP_CLI\Utils\get_flag_value( $assoc_args, 'compliance-only', false );
+
+		$repo_root       = dirname( __FILE__ );
+		$default_log_dir = $repo_root . '/docs/pattern-logs';
+		$log_dir         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'log-dir', $default_log_dir );
+
+		$files = $this->get_pattern_files( $args );
+
+		if ( empty( $files ) ) {
+			WP_CLI::error( 'No pattern files found. Specify a .php pattern file or directory.' );
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( WP_CLI::colorize( '%BPattern Validation — ' . count( $files ) . ' file(s)%n' ) );
+		WP_CLI::line( str_repeat( '-', 55 ) );
+
+		if ( $compliance_only ) {
+			$this->run_compliance_checks( $files, $fix );
+			exit( 0 );
+		}
+
+		$result = $this->validate_with_gutenberg( $files, $fix, $diff, $log ? $log_dir : null );
+
+		if ( $compliance && ! $result['error'] ) {
+			$this->run_compliance_checks( $files, $fix );
+		}
+
+		exit( $result['has_issues'] ? 1 : 0 );
+	}
+
+	/**
+	 * Collect all .php pattern files from the given paths, recursively.
+	 *
+	 * @param array $args Paths from CLI arguments.
+	 * @return array Unique list of absolute file paths.
+	 */
+	private function get_pattern_files( $args ) {
+		$files = array();
+
+		foreach ( $args as $path ) {
+			$path = rtrim( $path, '/' );
+
+			if ( is_dir( $path ) ) {
+				$iter = new RecursiveIteratorIterator(
+					new RecursiveDirectoryIterator( $path, RecursiveDirectoryIterator::SKIP_DOTS )
+				);
+				foreach ( $iter as $file ) {
+					if ( $file->getExtension() === 'php' && $this->is_valid_pattern_file( $file->getPathname() ) ) {
+						$files[] = $file->getPathname();
+					}
+				}
+			} elseif ( is_file( $path ) && pathinfo( $path, PATHINFO_EXTENSION ) === 'php' ) {
+				if ( $this->is_valid_pattern_file( $path ) ) {
+					$files[] = $path;
+				}
+			}
+		}
+
+		sort( $files );
+		return array_unique( $files );
+	}
+
+	/**
+	 * Skip WooCommerce plugin-bundled patterns — those follow WC standards, not theme rules.
+	 *
+	 * @param string $file Absolute path.
+	 * @return bool True if the file should be validated.
+	 */
+	private function is_valid_pattern_file( $file ) {
+		$skip = array(
+			'/wp-content/plugins/woocommerce/patterns/',
+			'/woocommerce/patterns/',
+		);
+		foreach ( $skip as $needle ) {
+			if ( false !== strpos( $file, $needle ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Core validation loop: parse → serialize → compare → optionally fix and log.
+	 *
+	 * @param array       $files   Pattern files to process.
+	 * @param bool        $fix     Rewrite files in-place.
+	 * @param bool        $diff    Print unified diff to stdout.
+	 * @param string|null $log_dir Write log files here, or null to skip.
+	 * @return array { has_issues: bool, error: bool, fixed: int, needs_review: int }
+	 */
+	private function validate_with_gutenberg( $files, $fix, $diff, $log_dir ) {
+		$has_issues   = false;
+		$fixed_count  = 0;
+		$review_count = 0;
+		$pass_count   = 0;
+		$error        = false;
+		$date_slug    = gmdate( 'Y-m-d' );
+		$log_entries  = array();
+
+		if ( $log_dir ) {
+			$run_log_dir = $log_dir . '/' . $date_slug;
+			if ( ! is_dir( $run_log_dir ) ) {
+				wp_mkdir_p( $run_log_dir );
+			}
+		}
+
+		foreach ( $files as $file ) {
+			$basename = basename( $file );
+			$raw      = file_get_contents( $file );
+
+			// Extract block content.
+			// Format 1: return 'string'; (some WP core patterns)
+			// Format 2: PHP docblock header ending with closing tag, raw block HTML follows
+			if ( preg_match( '/return\s+[\'"](.+?)[\'"]\s*;/s', $raw, $m ) ) {
+				$block_content = $m[1];
+				$header        = '';
+				$format        = 'return';
+			} elseif ( preg_match( '/^([\s\S]*?\?>)([\s\S]*)$/s', $raw, $m ) ) {
+				$header        = $m[1];
+				$block_content = ltrim( $m[2] );
+				$format        = 'standard';
+			} else {
+				WP_CLI::warning( "Cannot extract block content from: {$basename}" );
+				$log_entries[ $basename ] = 'SKIP — no extractable block content';
+				continue;
+			}
+
+			// Round-trip through WordPress's own serializer.
+			$parsed    = parse_blocks( $block_content );
+			$canonical = serialize_blocks( $parsed );
+
+			// serialize_block_attributes() unicode-escapes <, >, &, and -- to keep block
+			// comment delimiters safe in HTML. Reverse these for PHP source files so that
+			// PHP open/close tags, CSS variables (--wp--...), and & in metadata stay literal.
+			$canonical = str_replace(
+				array( '<', '>', '&', '--' ),
+				array( '<', '>', '&', '--' ),
+				$canonical
+			);
+
+			$canonical = rtrim( $canonical );
+			$original  = rtrim( $block_content );
+
+			if ( $original === $canonical ) {
+				WP_CLI::line( WP_CLI::colorize( '%GPASS%n  ' ) . $basename );
+				$pass_count++;
+				$log_entries[ $basename ] = 'PASS';
+				continue;
+			}
+
+			$has_issues = true;
+			$diff_text  = $this->generate_diff( $original, $canonical );
+
+			if ( $fix ) {
+				if ( 'return' === $format ) {
+					$new_raw = str_replace( $block_content, $canonical, $raw );
+				} else {
+					$new_raw = $header . "\n" . $canonical . "\n";
+				}
+
+				$written = file_put_contents( $file, $new_raw );
+				if ( false !== $written ) {
+					$fixed_count++;
+					WP_CLI::line( WP_CLI::colorize( '%YFIXED%n ' ) . $basename );
+					$log_entries[ $basename ] = 'FIXED';
+				} else {
+					$error = true;
+					WP_CLI::warning( "Could not write: {$basename}" );
+					$log_entries[ $basename ] = 'ERROR — write failed';
+				}
+			} else {
+				$review_count++;
+				WP_CLI::line( WP_CLI::colorize( '%RFAIL%n  ' ) . $basename );
+				$log_entries[ $basename ] = 'NEEDS_FIX';
+			}
+
+			if ( $diff && ! $fix ) {
+				WP_CLI::line( $diff_text );
+			}
+
+			if ( $log_dir && ! empty( $diff_text ) ) {
+				file_put_contents( $run_log_dir . '/' . $basename . '.diff', $diff_text );
+			}
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( str_repeat( '-', 55 ) );
+		WP_CLI::line( WP_CLI::colorize( '%BSummary%n' ) );
+		WP_CLI::line( str_repeat( '-', 55 ) );
+		WP_CLI::line( WP_CLI::colorize( '%GPass:%n        ' ) . $pass_count );
+		if ( $fix ) {
+			WP_CLI::line( WP_CLI::colorize( '%YFixed:%n       ' ) . $fixed_count );
+		} else {
+			WP_CLI::line( WP_CLI::colorize( '%RNeeds fix:%n   ' ) . $review_count );
+		}
+
+		if ( $log_dir ) {
+			$this->write_summary( $run_log_dir, $date_slug, $log_entries, $pass_count, $fixed_count, $review_count );
+			WP_CLI::line( '' );
+			WP_CLI::line( "Logs written to: {$run_log_dir}/" );
+		}
+
+		return array(
+			'has_issues'   => $has_issues,
+			'error'        => $error,
+			'fixed'        => $fixed_count,
+			'needs_review' => $review_count,
+		);
+	}
+
+	/**
+	 * Generate a unified diff between two strings, returned as a string.
+	 *
+	 * @param string $old Original content.
+	 * @param string $new Canonical content.
+	 * @return string Unified diff output.
+	 */
+	private function generate_diff( $old, $new ) {
+		$old_file = tempnam( sys_get_temp_dir(), 'wp_pat_old_' );
+		$new_file = tempnam( sys_get_temp_dir(), 'wp_pat_new_' );
+
+		file_put_contents( $old_file, $old );
+		file_put_contents( $new_file, $new );
+
+		$output = array();
+		exec( 'diff -u ' . escapeshellarg( $old_file ) . ' ' . escapeshellarg( $new_file ), $output );
+
+		unlink( $old_file );
+		unlink( $new_file );
+
+		return implode( "\n", array_slice( $output, 2 ) );
+	}
+
+	/**
+	 * Write a markdown summary file to the log directory.
+	 *
+	 * @param string $dir       Log run directory.
+	 * @param string $date_slug Date string for the heading.
+	 * @param array  $entries   basename => status string.
+	 * @param int    $pass      Pass count.
+	 * @param int    $fixed     Fixed count.
+	 * @param int    $review    Needs-review count.
+	 */
+	private function write_summary( $dir, $date_slug, $entries, $pass, $fixed, $review ) {
+		$lines = array(
+			"# Pattern Validation — {$date_slug}",
+			'',
+			'| Status | Count |',
+			'|--------|------:|',
+			"| Pass   | {$pass} |",
+			"| Fixed  | {$fixed} |",
+			"| Review | {$review} |",
+			'',
+			'## Per-Pattern Results',
+			'',
+		);
+
+		foreach ( $entries as $file => $status ) {
+			$lines[] = "- `{$file}` — {$status}";
+		}
+
+		file_put_contents( $dir . '/summary.md', implode( "\n", $lines ) . "\n" );
+	}
+
+	/**
+	 * Hook for project-specific compliance checks (pass-2 static analysis).
+	 *
+	 * The default implementation is a stub — adapt this method for your project's
+	 * own compliance checker (e.g. a custom PHP script that enforces theme-specific
+	 * block rules). The --compliance and --compliance-only flags trigger this method.
+	 *
+	 * @param array $files Pattern files.
+	 * @param bool  $fix   Apply compliance auto-fixes.
+	 */
+	private function run_compliance_checks( $files, $fix ) {
+		WP_CLI::line( '' );
+		WP_CLI::line( WP_CLI::colorize( '%BCompliance checks%n' ) );
+		WP_CLI::line( str_repeat( '-', 55 ) );
+
+		// Point $checker at your project's compliance script.
+		// Example: dirname( __FILE__ ) . '/scripts/pattern-check/class-compliancechecker.php'
+		$checker = null;
+
+		if ( ! $checker || ! file_exists( $checker ) ) {
+			WP_CLI::warning( 'No compliance checker configured — adapt run_compliance_checks() for your project.' );
+			return;
+		}
+
+		$cmd    = 'php ' . escapeshellarg( $checker ) . ' ' . implode( ' ', array_map( 'escapeshellarg', $files ) );
+		$cmd   .= $fix ? ' --autofix' : '';
+		$output = array();
+		$code   = 0;
+		exec( $cmd, $output, $code );
+
+		foreach ( $output as $line ) {
+			WP_CLI::line( $line );
+		}
+
+		if ( $code !== 0 ) {
+			WP_CLI::warning( "Compliance check exited with code {$code}." );
+		}
+	}
+}
+
+$_cmd = new Pattern_Validate_Command();
+WP_CLI::add_command( 'pattern validate', array( $_cmd, 'validate' ) );

--- a/bedrock/wp-cli-config/wp-cli.yml
+++ b/bedrock/wp-cli-config/wp-cli.yml
@@ -1,0 +1,5 @@
+path: web/wp
+server:
+  docroot: web
+require:
+  - wp-cli-pattern-validate.php


### PR DESCRIPTION
This release (v2.10.0) introduces a new `bedrock/` section to the repository, adding two developer workflow guides covering local Composer package development and WP-CLI configuration for Bedrock-based WordPress projects. The `bedrock/local-package-development/` guide documents how to wire a local plugin or theme branch into a Bedrock site using a Composer `path` repository, enabling iterative development without publishing to Packagist. The `bedrock/wp-cli-config/` area provides a standard `wp-cli.yml` for Bedrock path setup alongside a custom `wp pattern validate` command (`wp-cli-pattern-validate.php`) that canonicalizes block pattern files by normalizing dev-environment URLs before they are committed or pushed. All supporting index files — `CLAUDE.md`, `README.md`, and the vibe prompt — have been updated to reflect the new structure.

**Bedrock Local Package Development:**
- Added `bedrock/local-package-development/README.md` documenting the Composer `path` repository workflow for testing local plugin or theme branches inside a Bedrock site without publishing a release.
- The guide covers `composer.json` configuration, symlinking behavior, and teardown steps to restore production package sources after local testing is complete.

**Bedrock WP-CLI Configuration and Pattern Validation:**
- Added `bedrock/wp-cli-config/wp-cli.yml` providing a standard WP-CLI configuration file that sets the correct `path` for Bedrock's `web/wp` WordPress installation layout.
- Added `bedrock/wp-cli-config/wp-cli-pattern-validate.php`, a custom WP-CLI command that validates block pattern files and canonicalizes hardcoded dev-environment URLs, addressing the documented issue where `get_template_directory_uri()` embeds environment-specific URLs into pattern content.

**Documentation and Repository Index Updates:**
- Updated `CLAUDE.md` and `README.md` to include the `bedrock/` directory in the repository structure overview, with descriptions for both subdirectories.
- Updated `.vibe/prompts/wp-ops.md` to reflect the expanded project structure, and bumped `CHANGELOG.md` to version 2.10.0 with a summary of the new Bedrock guides.

**Files Changed:**

- [`.vibe/prompts/wp-ops.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/.vibe/prompts/wp-ops.md) (Modified)
- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/CLAUDE.md) (Modified)
- [`README.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/README.md) (Modified)
- [`bedrock/local-package-development/README.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/bedrock/local-package-development/README.md) (Added)
- [`bedrock/wp-cli-config/README.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/bedrock/wp-cli-config/README.md) (Added)
- [`bedrock/wp-cli-config/wp-cli-pattern-validate.php`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/bedrock/wp-cli-config/wp-cli-pattern-validate.php) (Added)
- [`bedrock/wp-cli-config/wp-cli.yml`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-local-package-development/bedrock/wp-cli-config/wp-cli.yml) (Added)