### PR TITLE
Docs/bedrock Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-05-30
+
+### Documentation
+
+- **bedrock/README.md** - Added top-level README for the `bedrock/` directory with a brief intro and summary links to each subdirectory: `local-package-development/` (Composer path repository workflow) and `wp-cli-config/` (standard `wp-cli.yml` and `wp pattern validate` command)
+
 ## [2.10.0] - 2026-05-30
 
 ### Added

--- a/bedrock/README.md
+++ b/bedrock/README.md
@@ -1,0 +1,13 @@
+# Bedrock
+
+Tools and workflows for [Bedrock](https://roots.io/bedrock/)-based WordPress sites.
+
+## Contents
+
+### [`local-package-development/`](local-package-development/)
+
+Test an in-development plugin or theme inside a Bedrock site before tagging a release, by pointing the site's Composer dependency at a local git working copy via a `path` repository. Covers setup, the `symlink: false` requirement, re-syncing after edits, and cleanup.
+
+### [`wp-cli-config/`](wp-cli-config/)
+
+Standard `wp-cli.yml` for Bedrock (sets `path: web/wp` so `--path` is never needed) plus a custom `wp pattern validate` command that round-trips block pattern files through WordPress's own parser to enforce canonical formatting.


### PR DESCRIPTION
This release adds a dedicated `README.md` for the `bedrock/` directory, providing an entry point for navigating the Bedrock-specific tooling and documentation consolidated in this repository. The addition accompanies a version 2.10.1 changelog entry that records the documentation update. The new file serves as a structural anchor for the `bedrock/` subdirectory, which contains workflows for local package development and WP-CLI configuration. This change improves repository discoverability for contributors working within the Bedrock ecosystem.

**Documentation:**
- Added `bedrock/README.md` to introduce the `bedrock/` directory and orient developers toward its sub-sections, including `local-package-development/` and `wp-cli-config/`.
- Updated `CHANGELOG.md` with a version 2.10.1 entry to formally record the new documentation alongside the existing project history.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-readme/CHANGELOG.md) (Modified)
- [`bedrock/README.md`](https://github.com/imagewize/wp-ops/blob/docs/bedrock-readme/bedrock/README.md) (Added)