### PR TITLE
Feature/wporg Svn Deploy Script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **scripts/deploy-plugin-wporg.sh** - New script to publish a plugin from its Git working tree to the WordPress.org plugin directory via SVN: syncs `trunk/`, creates `tags/<version>/`, and uploads the marketing `assets/` (banners, icon, screenshots) from `.wordpress-org/`. Respects `.distignore` (same filter as the release zip), auto-detects the main plugin file and version, guards against overwriting a published tag, and is safe by default (stages and prints the `svn ci` command; only commits with `--commit`). Documented in [`scripts/README.md`](scripts/README.md).
+
 ## [2.10.1] - 2026-05-30
 
 ### Documentation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,10 +4,10 @@ Production-ready Bash and PHP scripts for WordPress operations, GitHub integrati
 
 ## Overview
 
-This directory contains 20 utility scripts organized into six functional areas:
+This directory contains 21 utility scripts organized into six functional areas:
 
 - **GitHub Integration** - AI-powered pull request creation and manual GitHub release asset uploads
-- **WordPress Management** - Plugin and theme release automation, file synchronization
+- **WordPress Management** - Plugin and theme release automation, WordPress.org SVN deployment, file synchronization
 - **WooCommerce** - Product variation bulk creation
 - **Image Utilities** - WebP conversion optimized for WordPress and Facebook OG images
 - **Git Utilities** - Quick access to recent commit history
@@ -35,6 +35,7 @@ scripts/
 ├── batch-resize.sh            # Batch resize and center-crop images for featured images
 ├── convert-to-webp.sh          # JPG to WebP conversion with center-crop (Facebook OG)
 ├── create-pr.sh                # AI-powered GitHub PR creation
+├── deploy-plugin-wporg.sh      # Publish a plugin to the WordPress.org directory via SVN
 ├── upload-release-asset.sh    # Manual GitHub release zip upload (fallback for failed Actions)
 ├── find-and-replace-files.sh  # Batch find and replace files across directory trees
 ├── git-log-oneline.sh          # Show recent git commits as one-liners
@@ -74,6 +75,10 @@ scripts/
 
 # Release WordPress theme version
 ./scripts/release-theme.sh theme-name 1.2.5
+
+# Publish a plugin to WordPress.org via SVN (stage + review, then commit)
+cd ~/code/my-plugin
+~/code/wp-ops/scripts/deploy-plugin-wporg.sh my-plugin --build "npm ci && npx webpack"
 
 # Backup WordPress database
 ./scripts/backup/db-backup.sh example.com production
@@ -613,6 +618,105 @@ export OPENAI_API_KEY="your-key-here"
 - **With AI**: 500-1,500 tokens depending on diff size
 - **Without AI**: Manual changelog editing required
 - **Cost**: ~$0.01-0.05 per release (Claude Sonnet)
+
+---
+
+### deploy-plugin-wporg.sh
+
+Publishes a plugin from its Git working tree to the **WordPress.org plugin directory (SVN)** — syncs `trunk/`, creates `tags/<version>/`, and uploads the marketing `assets/` (banners, icon, screenshots). Generic: works for any plugin, for both the first publish and later updates. Complements `release-plugin.sh` (version bump) and `upload-release-asset.sh` (GitHub) by handling the WordPress.org side.
+
+#### Features
+
+- **Same filter as the release zip**: respects `.distignore`, so `trunk`/`tags` contain exactly what ships (falls back to "everything except `.git/`" if absent)
+- **Marketing assets convention**: uploads `.wordpress-org/` (banners, icon, screenshots) to SVN `/assets`, kept out of the plugin download
+- **Auto-detection**: finds the main plugin file (`Plugin Name:` header) and reads the version from its `Version:` header (or pass it explicitly)
+- **Safe by default**: stages everything and prints the exact `svn ci` command for review; only commits with `--commit`
+- **Idempotent**: re-running with no source changes produces an empty `svn status` (rsync + `svn add`/`svn rm` reconciliation handles adds, edits, and deletions)
+- **Tag guard**: refuses to overwrite an already-published `tags/<version>` unless `--force`
+- **Optional build**: `--build "npm ci && npx webpack"` runs before packaging
+
+#### Usage
+
+```bash
+# Prepare a release (stage + review), then commit manually
+cd ~/code/warder-cookie-consent
+~/code/wp-ops/scripts/deploy-plugin-wporg.sh warder-cookie-consent --build "npm ci && npx webpack"
+
+# One shot: build, stage, and commit (prompts for SVN password)
+~/code/wp-ops/scripts/deploy-plugin-wporg.sh warder-cookie-consent 2.1.4 \
+  --build "npm ci && npx webpack" --username Rhand --commit
+
+# Explicit paths / custom checkout location
+~/code/wp-ops/scripts/deploy-plugin-wporg.sh my-plugin 1.0.0 \
+  --plugin-dir ~/code/my-plugin --assets-dir ~/code/my-plugin/.wordpress-org \
+  --svn-dir /tmp/my-plugin-svn --commit
+```
+
+#### Example Output
+
+```
+=== WordPress.org SVN Deploy: warder-cookie-consent ===
+
+  ✓ Main plugin file: warder-cookie-consent.php
+  ✓ Version: 2.1.4
+Checking remote for existing tag 2.1.4 ...
+  ✓ tags/2.1.4 is free
+Checking out https://plugins.svn.wordpress.org/warder-cookie-consent ...
+  ✓ Working copy: /Users/me/code/warder-cookie-consent-svn
+Assembling filtered payload ...
+  ✓ Filtered via .distignore
+Syncing trunk/ ...
+  ✓ trunk/ synced
+Building tags/2.1.4/ ...
+  ✓ tags/2.1.4/ staged
+Syncing assets/ from .wordpress-org/ ...
+  ✓ assets/ synced (10 files)
+
+=== svn status (what will be committed) ===
+  A   trunk/readme.txt
+  ...
+
+=== Staged and ready. Review above, then commit: ===
+  svn ci "/Users/me/code/warder-cookie-consent-svn" -m "Release 2.1.4" --username Rhand
+```
+
+#### Manual SVN equivalent (without the script)
+
+The same publish done by hand — useful for understanding or one-off fixes:
+
+```bash
+# 1. Check out the plugin's SVN repo (on a first publish, trunk/tags/assets are empty)
+svn co https://plugins.svn.wordpress.org/<slug> <slug>-svn
+cd <slug>-svn
+
+# 2. Sync the plugin into trunk/ (source = your .distignore-filtered build, e.g. the release zip contents)
+rsync -a --delete --exclude='.svn' /path/to/plugin-payload/ trunk/
+
+# 3. Freeze a version tag (copy of trunk)
+rsync -a --delete --exclude='.svn' trunk/ tags/<version>/      # or: svn cp trunk tags/<version>
+
+# 4. Upload marketing assets (banners, icon, screenshots) to the top-level /assets — NOT trunk
+rsync -a --delete --exclude='.svn' /path/to/.wordpress-org/ assets/
+
+# 5. Schedule adds, remove anything deleted, review, then commit
+svn add --force trunk tags assets
+svn status | awk '/^!/{print $2}' | xargs -r svn rm      # remove files dropped from the plugin
+svn status                                               # review what will be committed
+svn ci -m "Release <version>" --username Rhand           # prompts for SVN password
+```
+
+Key points: WordPress.org SVN is a **release system, not Git** — only push finished versions. `trunk/` is the current version, `tags/<version>/` are immutable releases users download, and `/assets` (banners/icon/screenshots) is a separate top-level dir that never ships in the plugin download.
+
+#### Notes
+
+- **SVN usernames are case-sensitive** (e.g. `Rhand`, not `rhand`). Find yours at profiles.wordpress.org → Account & Security, where you can also generate a dedicated SVN password (recommended over your account login password).
+- The SVN checkout is kept (default `<plugin-dir>/../<slug>-svn`) and reused/updated on the next run; delete it anytime.
+- Pairs with the `.wordpress-org/` + `.distignore` setup in the plugin repo: the same assets are version-controlled in Git and pushed to SVN here.
+
+#### Requirements
+
+- `svn`, `zip`, `rsync` (standard on macOS/Linux; `brew install subversion` if `svn` is missing)
+- Active WordPress.org plugin SVN commit access
 
 ---
 

--- a/scripts/deploy-plugin-wporg.sh
+++ b/scripts/deploy-plugin-wporg.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+
+# WordPress.org SVN Plugin Deploy Script
+# Publishes a plugin from its Git working tree to the WordPress.org plugin
+# directory (SVN): syncs trunk/, creates tags/<version>/, and uploads the
+# marketing assets/ (banners, icon, screenshots).
+#
+# Generic — works for any plugin. It reuses the same conventions as the
+# imagewize GitHub release flow:
+#   - .distignore   → files excluded from trunk/tags (same filter as the release zip)
+#   - .wordpress-org/ → banners, icon, screenshots uploaded to SVN /assets
+#
+# Usage:
+#   ./deploy-plugin-wporg.sh <slug> [version] [options]
+#
+#   <slug>      WordPress.org plugin slug (e.g. warder-cookie-consent)
+#   [version]   Release version (default: read from the main plugin file's Version: header)
+#
+# Options:
+#   --plugin-dir <path>   Plugin git working tree (default: current directory)
+#   --assets-dir <path>   Marketing assets dir (default: <plugin-dir>/.wordpress-org)
+#   --build "<cmd>"       Build command to run first (e.g. "npm ci && npx webpack")
+#   --svn-dir <path>      SVN checkout location (default: <plugin-dir>/../<slug>-svn)
+#   --username <user>     WordPress.org SVN username (case-sensitive!)
+#   -m, --message <msg>   Commit message (default: "Release <version>")
+#   --commit              Actually run `svn ci` (prompts for SVN password).
+#                         Without this, the script stages everything and prints
+#                         the exact commit command for you to run/review.
+#   --force               Allow re-deploying a tag that already exists (rare).
+#   -h, --help            Show this help.
+#
+# Examples:
+#   # Prepare a release (stage + review), then commit manually:
+#   cd ~/code/warder-cookie-consent
+#   ~/code/wp-ops/scripts/deploy-plugin-wporg.sh warder-cookie-consent --build "npm ci && npx webpack"
+#
+#   # One shot, build + commit:
+#   ~/code/wp-ops/scripts/deploy-plugin-wporg.sh warder-cookie-consent 2.1.4 \
+#     --build "npm ci && npx webpack" --username Rhand --commit
+#
+# Requirements: svn, zip, rsync, and (if --build is used) the build toolchain.
+
+set -e
+
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+
+err()  { echo -e "${RED}✗ $1${NC}" >&2; }
+ok()   { echo -e "${GREEN}  ✓ $1${NC}"; }
+info() { echo -e "${BLUE}$1${NC}"; }
+warn() { echo -e "${YELLOW}⚠ $1${NC}"; }
+
+SVN_BASE="https://plugins.svn.wordpress.org"
+
+# Defaults
+PLUGIN_DIR="$(pwd)"
+ASSETS_DIR=""
+BUILD_CMD=""
+SVN_DIR=""
+SVN_USER=""
+COMMIT_MSG=""
+DO_COMMIT=false
+FORCE=false
+SLUG=""
+VERSION=""
+
+# Parse args
+POSITIONAL=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --plugin-dir) PLUGIN_DIR="$2"; shift 2;;
+        --assets-dir) ASSETS_DIR="$2"; shift 2;;
+        --build)      BUILD_CMD="$2"; shift 2;;
+        --svn-dir)    SVN_DIR="$2"; shift 2;;
+        --username)   SVN_USER="$2"; shift 2;;
+        -m|--message) COMMIT_MSG="$2"; shift 2;;
+        --commit)     DO_COMMIT=true; shift;;
+        --force)      FORCE=true; shift;;
+        -h|--help)    sed -n '3,46p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+        -*)           err "Unknown option: $1"; exit 1;;
+        *)            POSITIONAL+=("$1"); shift;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+SLUG="${1:-}"
+VERSION="${2:-}"
+
+# Validate prerequisites
+for bin in svn zip rsync; do
+    command -v "$bin" >/dev/null 2>&1 || { err "'$bin' is required but not installed."; exit 1; }
+done
+
+[ -n "$SLUG" ] || { err "Plugin slug is required. Usage: $0 <slug> [version] [options]"; exit 1; }
+
+PLUGIN_DIR="$(cd "$PLUGIN_DIR" && pwd)"
+cd "$PLUGIN_DIR"
+[ -z "$ASSETS_DIR" ] && ASSETS_DIR="$PLUGIN_DIR/.wordpress-org"
+
+info "=== WordPress.org SVN Deploy: $SLUG ==="
+echo ""
+
+# Locate the main plugin file (root-level .php containing "Plugin Name:")
+MAIN_FILE=""
+for f in "$PLUGIN_DIR"/*.php; do
+    [ -f "$f" ] || continue
+    if grep -q "Plugin Name:" "$f"; then MAIN_FILE="$f"; break; fi
+done
+[ -n "$MAIN_FILE" ] || { err "Could not find the main plugin file (a root *.php with 'Plugin Name:')."; exit 1; }
+ok "Main plugin file: $(basename "$MAIN_FILE")"
+
+# Resolve version from the header if not given
+if [ -z "$VERSION" ]; then
+    VERSION="$(grep -m1 -E '^[[:space:]]*\*?[[:space:]]*Version:' "$MAIN_FILE" | sed -E 's/.*Version:[[:space:]]*//' | tr -d '[:space:]')"
+fi
+[ -n "$VERSION" ] || { err "Could not determine version. Pass it explicitly: $0 $SLUG <version>"; exit 1; }
+ok "Version: $VERSION"
+[ -z "$COMMIT_MSG" ] && COMMIT_MSG="Release $VERSION"
+
+# Optional build
+if [ -n "$BUILD_CMD" ]; then
+    info "Running build: $BUILD_CMD"
+    ( eval "$BUILD_CMD" )
+    ok "Build complete"
+fi
+
+# Guard: refuse to overwrite an already-published tag unless --force
+info "Checking remote for existing tag $VERSION ..."
+if svn ls "$SVN_BASE/$SLUG/tags/$VERSION/" >/dev/null 2>&1; then
+    if [ "$FORCE" = true ]; then
+        warn "tags/$VERSION already exists on the remote — proceeding because --force was given."
+    else
+        err "tags/$VERSION is already published. Bump the version, or pass --force to overwrite."
+        exit 1
+    fi
+else
+    ok "tags/$VERSION is free"
+fi
+
+# Checkout (or update) the SVN working copy
+[ -z "$SVN_DIR" ] && SVN_DIR="$PLUGIN_DIR/../$SLUG-svn"
+if [ -d "$SVN_DIR/.svn" ]; then
+    info "Updating existing SVN checkout: $SVN_DIR"
+    svn up "$SVN_DIR" >/dev/null
+else
+    info "Checking out $SVN_BASE/$SLUG ..."
+    svn co "$SVN_BASE/$SLUG" "$SVN_DIR" >/dev/null
+fi
+SVN_DIR="$(cd "$SVN_DIR" && pwd)"
+mkdir -p "$SVN_DIR/trunk" "$SVN_DIR/tags" "$SVN_DIR/assets"
+ok "Working copy: $SVN_DIR"
+
+# Build a clean, .distignore-filtered payload (identical to the release zip)
+PAYLOAD="$(mktemp -d)"
+trap 'rm -rf "$PAYLOAD"' EXIT
+info "Assembling filtered payload ..."
+if [ -f "$PLUGIN_DIR/.distignore" ]; then
+    ( cd "$PLUGIN_DIR" && zip -r -q "$PAYLOAD/p.zip" . -x@.distignore )
+    ok "Filtered via .distignore"
+else
+    warn "No .distignore found — shipping everything except .git/"
+    ( cd "$PLUGIN_DIR" && zip -r -q "$PAYLOAD/p.zip" . -x '.git/*' )
+fi
+mkdir -p "$PAYLOAD/files"
+unzip -q "$PAYLOAD/p.zip" -d "$PAYLOAD/files"
+
+# Reconcile a versioned dir with SVN: schedule adds for new files, deletes for missing
+svn_reconcile() {
+    local dir="$1"
+    ( cd "$dir" && svn add --force . --quiet >/dev/null 2>&1 || true )
+    # Remove files that disappeared from the working copy
+    ( cd "$dir" && svn status | awk '/^!/{ $1=""; sub(/^[[:space:]]+/,""); print }' \
+        | while IFS= read -r missing; do [ -n "$missing" ] && svn rm --quiet "$missing" >/dev/null 2>&1 || true; done )
+}
+
+# Sync trunk
+info "Syncing trunk/ ..."
+rsync -a --delete --exclude='.svn' "$PAYLOAD/files/" "$SVN_DIR/trunk/"
+svn_reconcile "$SVN_DIR/trunk"
+ok "trunk/ synced"
+
+# Create the version tag (fresh copy of the payload)
+info "Building tags/$VERSION/ ..."
+rsync -a --delete --exclude='.svn' "$PAYLOAD/files/" "$SVN_DIR/tags/$VERSION/"
+svn_reconcile "$SVN_DIR/tags/$VERSION"
+ok "tags/$VERSION/ staged"
+
+# Sync marketing assets
+if [ -d "$ASSETS_DIR" ] && [ -n "$(ls -A "$ASSETS_DIR" 2>/dev/null)" ]; then
+    info "Syncing assets/ from $(basename "$ASSETS_DIR")/ ..."
+    rsync -a --delete --exclude='.svn' "$ASSETS_DIR/" "$SVN_DIR/assets/"
+    svn_reconcile "$SVN_DIR/assets"
+    ok "assets/ synced ($(ls -1 "$SVN_DIR/assets" | grep -v '^.svn$' | wc -l | tr -d ' ') files)"
+else
+    warn "No assets dir at $ASSETS_DIR — skipping banners/icon/screenshots"
+fi
+
+# Review
+echo ""
+info "=== svn status (what will be committed) ==="
+svn status "$SVN_DIR" | sed 's/^/  /'
+echo ""
+
+# Commit or print the command
+if [ "$DO_COMMIT" = true ]; then
+    info "Committing to WordPress.org ..."
+    if [ -n "$SVN_USER" ]; then
+        svn ci "$SVN_DIR" -m "$COMMIT_MSG" --username "$SVN_USER"
+    else
+        svn ci "$SVN_DIR" -m "$COMMIT_MSG"
+    fi
+    echo ""
+    ok "Committed. Verify: $SVN_BASE/$SLUG/tags/"
+    info "Public page: https://wordpress.org/plugins/$SLUG (assets appear within minutes)"
+else
+    info "=== Staged and ready. Review above, then commit: ==="
+    USER_FLAG=""; [ -n "$SVN_USER" ] && USER_FLAG=" --username $SVN_USER"
+    echo -e "  ${GREEN}svn ci \"$SVN_DIR\" -m \"$COMMIT_MSG\"$USER_FLAG${NC}"
+    echo ""
+    warn "Nothing was uploaded yet (no --commit). The checkout is kept at: $SVN_DIR"
+fi


### PR DESCRIPTION
This PR adds a new deployment script for publishing WordPress plugins to the official WordPress.org plugin repository via SVN. The `deploy-plugin-wporg.sh` script (330 lines) automates the multi-step SVN workflow required to push releases from a Git-based development environment to the WordPress.org plugin directory, including exporting plugin files, syncing them into the SVN `trunk`, and tagging stable releases. This addresses the friction of manually managing SVN operations, which differ significantly from the Git workflows used elsewhere in this repository. The change is documentation-focused and additive, with supporting updates to the scripts README and CHANGELOG. No existing functionality is modified.

**Deployment Tooling:**
- Added `scripts/deploy-plugin-wporg.sh` to automate WordPress.org SVN publishing, bridging Git-based plugin development with the SVN-based WordPress.org plugin repository.
- The script handles the standard WordPress.org release flow: exporting plugin files, populating SVN `trunk`, and creating versioned `tags` for stable releases.

**Documentation:**
- Updated `scripts/README.md` to document the new deployment script, its usage, and its place among the repository's utility scripts.
- Updated `CHANGELOG.md` to record the addition of the WordPress.org deployment tooling for release tracking.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/feature/wporg-svn-deploy-script/CHANGELOG.md) (Modified)
- [`scripts/README.md`](https://github.com/imagewize/wp-ops/blob/feature/wporg-svn-deploy-script/scripts/README.md) (Modified)
- [`scripts/deploy-plugin-wporg.sh`](https://github.com/imagewize/wp-ops/blob/feature/wporg-svn-deploy-script/scripts/deploy-plugin-wporg.sh) (Added)