### PR TITLE
Release 2.11.0: deploy-plugin-wporg.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-06-04
+
 ### Added
 
 - **scripts/deploy-plugin-wporg.sh** - New script to publish a plugin from its Git working tree to the WordPress.org plugin directory via SVN: syncs `trunk/`, creates `tags/<version>/`, and uploads the marketing `assets/` (banners, icon, screenshots) from `.wordpress-org/`. Respects `.distignore` (same filter as the release zip), auto-detects the main plugin file and version, guards against overwriting a published tag, and is safe by default (stages and prints the `svn ci` command; only commits with `--commit`). Documented in [`scripts/README.md`](scripts/README.md).


### PR DESCRIPTION
Versions the changelog entry for the new `scripts/deploy-plugin-wporg.sh` (added under `[Unreleased]` in the prior PR) as **2.11.0** — a minor bump following v2.10.1, since it adds a new feature script.

## Changes
- `CHANGELOG.md`: move the `deploy-plugin-wporg.sh` entry under a versioned `## [2.11.0] - 2026-06-04` heading; keep `[Unreleased]` empty.

After merge, tag the release:
```
git checkout main && git pull
git tag v2.11.0 && git push origin v2.11.0
```