### PR TITLE
Add/multisite Search Replace Example

### DIFF
--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -43,6 +43,7 @@ temperature = 1.0
 input_price = 1.5
 output_price = 7.5
 thinking = "high"
+supports_images = true
 
 [[models]]
 name = "devstral-small-latest"
@@ -74,14 +75,6 @@ timeout_seconds = 2.0
 save_dir = "/Users/jasperfrumau/.vibe/logs/session"
 session_prefix = "session"
 enabled = true
-
-[tools.search_replace]
-permission = "ask"
-allowlist = []
-denylist = []
-max_content_size = 100000
-create_backup = false
-fuzzy_threshold = 0.9
 
 [tools.bash]
 permission = "ask"
@@ -170,13 +163,6 @@ exclude_patterns = [
 ]
 codeignore_file = ".vibeignore"
 
-[tools.read_file]
-permission = "always"
-allowlist = []
-denylist = []
-max_read_bytes = 64000
-max_state_history = 10
-
 [tools.todo]
 permission = "always"
 allowlist = []
@@ -189,3 +175,16 @@ allowlist = []
 denylist = []
 max_write_bytes = 64000
 create_parent_dirs = true
+
+[tools.read]
+permission = "always"
+allowlist = []
+denylist = []
+max_read_bytes = 64000
+max_state_history = 10
+
+[tools.edit]
+permission = "ask"
+allowlist = []
+denylist = []
+fuzzy_threshold = 0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-06-14
+
+### Added
+
+- **Multisite Search-Replace Practical Example** - Added a real-world HTTPS theme-asset migration example to [`trellis/backup/README.md`](trellis/backup/README.md) and [`wp-cli/migration/README.md`](wp-cli/migration/README.md):
+  - `wp search-replace` invocation with `--all-tables --precise --url=... --path=web/wp --dry-run --report-changed-only`
+  - Sample dry-run output showing replacements across the main site and multiple subsites (81 total replacements across 7 sites)
+  - Highlights that `--url=` does not scope the search to a single subsite — `--dry-run` is essential before running for real
+
 ## [2.11.1] - 2026-06-14
 
 ### Added

--- a/trellis/backup/README.md
+++ b/trellis/backup/README.md
@@ -208,6 +208,53 @@ echo '=== Database pull complete! ==='
 - Use `wp db query "UPDATE wp_blogs SET domain = REPLACE(domain, 'production.com', 'local.test');"` to update all blog domains
 - Both `wp search-replace` (for content/options) and `wp_blogs` update (for network domains) are required for proper multisite operation
 
+### Practical Example: HTTPS Migration for Theme Assets Across Multiple Subsites
+
+When migrating a multisite from HTTP to HTTPS, you may need to update hardcoded theme asset URLs. This practical example shows the replacement of HTTP theme paths across multiple subsites:
+
+```bash
+# ALWAYS run dry-run first to preview changes
+wp search-replace 'http://example.com/app/themes' 'https://example.com/app/themes' \
+  --all-tables \
+  --precise \
+  --url=https://example.com/spa \
+  --path=web/wp \
+  --dry-run \
+  --report-changed-only
+
+# If dry-run output looks correct, execute the actual replacement
+wp search-replace 'http://example.com/app/themes' 'https://example.com/app/themes' \
+  --all-tables \
+  --precise \
+  --url=https://example.com/spa \
+  --path=web/wp \
+  --report-changed-only
+```
+
+**Expected output shows replacements across main site and subsites:**
+```
++-------------+--------------+--------------+------+
+| Table       | Column       | Replacements | Type |
++-------------+--------------+--------------+------+
+| wp_10_posts | post_content | 8            | PHP  |
+| wp_2_posts  | post_content | 10           | PHP  |
+| wp_5_posts  | post_content | 13           | PHP  |
+| wp_6_posts  | post_content | 10           | PHP  |
+| wp_8_posts  | post_content | 11           | PHP  |
+| wp_9_posts  | post_content | 4            | PHP  |
+| wp_posts    | post_content | 25           | PHP  |
++-------------+--------------+--------------+------+
+Success: Made 81 replacements.
+```
+
+This command will:
+- Search across all tables (`--all-tables`)
+- Only replace exact matches (`--precise`)
+- Target the multisite context (`--url=...`)
+- Show a detailed report of changes (`--report-changed-only`)
+
+> **Critical:** Even when specifying `--url=`, WP-CLI may find matches across multiple subsites if the search string exists in their content. Always use `--dry-run` first!
+
 ### Database Push
 
 Pushes database from development to a remote environment with URL replacement.

--- a/wp-cli/migration/README.md
+++ b/wp-cli/migration/README.md
@@ -49,6 +49,53 @@ wp search-replace 'http://subsite.example.test' 'https://subsite.example.com' --
 wp search-replace 'http://subsite.example.test' 'https://subsite.example.com' --all-tables --network --url=subsite.example.test
 ```
 
+### Practical Example: HTTPS Migration Across Multiple Subsites
+
+When running search-replace on a multisite network, WP-CLI will process **all subsites** that contain the matching string. Here's a real-world example showing the importance of using `--dry-run` first:
+
+```bash
+# ALWAYS run dry-run first to preview changes
+wp search-replace 'http://example.com/app/themes' 'https://example.com/app/themes' \
+  --all-tables \
+  --precise \
+  --url=https://example.com/spa \
+  --path=web/wp \
+  --dry-run \
+  --report-changed-only
+
+# If dry-run looks correct, execute the actual replacement
+wp search-replace 'http://example.com/app/themes' 'https://example.com/app/themes' \
+  --all-tables \
+  --precise \
+  --url=https://example.com/spa \
+  --path=web/wp \
+  --report-changed-only
+```
+
+**Expected output:**
+```
++-------------+--------------+--------------+------+
+| Table       | Column       | Replacements | Type |
++-------------+--------------+--------------+------+
+| wp_10_posts | post_content | 8            | PHP  |
+| wp_2_posts  | post_content | 10           | PHP  |
+| wp_5_posts  | post_content | 13           | PHP  |
+| wp_6_posts  | post_content | 10           | PHP  |
+| wp_8_posts  | post_content | 11           | PHP  |
+| wp_9_posts  | post_content | 4            | PHP  |
+| wp_posts    | post_content | 25           | PHP  |
++-------------+--------------+--------------+------+
+Success: Made 81 replacements.
+```
+
+**Key observations:**
+- Even with `--url=https://example.com/spa`, WP-CLI found matches across **all subsites** because the search string existed in their content
+- The `--report-changed-only` flag shows exactly which tables were affected
+- Main site (`wp_posts`) had 25 replacements, subsites had varying counts (wp_2_posts, wp_5_posts, etc.)
+- **Total: 81 replacements** across 7 sites
+
+> **Best practice:** Use `--dry-run` first, then verify with `--dry-run` again after execution to confirm 0 remaining matches.
+
 ## Bedrock Path Conversion
 
 When migrating from a standard WordPress installation to a Bedrock-based installation, you'll need to update file paths in your database:


### PR DESCRIPTION
This commit adds a comprehensive practical example demonstrating WP-CLI multisite search-replace operations with dry-run capability across both the migration and backup documentation. The new section provides real-world guidance on safely updating theme asset URLs from HTTP to HTTPS in multisite networks, emphasizing the importance of previewing changes before execution. The example shows how WP-CLI's `--dry-run` flag, combined with `--report-changed-only`, reveals that replacements may affect multiple subsites even when targeting a specific URL, with the provided case showing 81 replacements across 7 sites. This addresses a common pain point where developers may not anticipate the breadth of database changes in multisite environments.

**Migration Documentation Enhancements:**
- Added "Practical Example: HTTPS Migration Across Multiple Subsites" section to `wp-cli/migration/README.md` with complete command examples using `--dry-run`, `--all-tables`, `--precise`, `--report-changed-only`, and `--url` flags
- Included expected output table showing replacements across main site and all subsites (wp_posts, wp_2_posts, wp_5_posts, etc.)
- Documented key observations about multisite behavior and the critical best practice of using `--dry-run` before and after execution

**Backup Documentation Enhancements:**
- Added identical practical example section to `trellis/backup/README.md` under the "Alternative: Direct Shell Script Method" area
- Provides consistency across documentation so developers see the same example regardless of their entry point
- Reinforces the critical nature of dry-run verification in both migration and backup workflows

**Configuration Update:**
- Updated `.vibe/config.toml` to reflect current project context settings

**Files Changed:**

- [`.vibe/config.toml`](https://github.com/imagewize/wp-ops/blob/add/multisite-search-replace-example/.vibe/config.toml) (Modified)
- [`trellis/backup/README.md`](https://github.com/imagewize/wp-ops/blob/add/multisite-search-replace-example/trellis/backup/README.md) (Modified)
- [`wp-cli/migration/README.md`](https://github.com/imagewize/wp-ops/blob/add/multisite-search-replace-example/wp-cli/migration/README.md) (Modified)