### PR TITLE
Add domain arg to run-monitoring.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-06-14
+
+### Added
+
+- **scripts/monitoring/run-monitoring.sh** - Added an optional `domain` argument (after `hours`) so the script can target a different site's logs on multi-site servers (e.g. `./run-monitoring.sh 24 othersite.com`). When a non-default domain is passed, report filenames get a `-<domain>` suffix to avoid collisions between sites, and the summary report now includes the site name. Documented in [`scripts/README.md`](scripts/README.md).
+
 ## [2.11.0] - 2026-06-04
 
 ### Added

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1417,18 +1417,22 @@ Orchestrator that runs all three monitoring scripts in sequence and generates a 
   - `security-monitor.sh` — security threat detection
   - `ai-bot-monitor.sh` — AI crawler analysis
 
-- **Timestamped Output Files**:
+- **Timestamped Output Files** (for the default site):
   - `traffic-monitor-YYYY-MM-DD-HHmmss.txt`
   - `security-monitor-YYYY-MM-DD-HHmmss.txt`
   - `ai-bot-monitor-YYYY-MM-DD-HHmmss.txt`
   - `monitoring-summary-YYYY-MM-DD.md` — consolidated markdown report
 
+  When a non-default `domain` argument is passed, each filename gets a
+  `-<domain>` suffix (e.g. `traffic-monitor-othersite.com-YYYY-MM-DD-HHmmss.txt`)
+  so reports for multiple sites on the same server don't collide.
+
 - **Auto-Detects Context**:
-  - Production server (`/srv/www` present): saves to `~/monitoring/`
+  - Production server (`/srv/www/<domain>` present): saves to `~/monitoring/`
   - Local or other context: saves to `./monitoring-reports/`
 
 - **Summary Report Includes**:
-  - Total requests, real user traffic, unique visitors, bandwidth
+  - Site name, total requests, real user traffic, unique visitors, bandwidth
   - Security alert and warning counts with top alerts listed
   - AI crawler share of traffic and bandwidth
   - Top 10 most requested pages (real users)
@@ -1443,8 +1447,12 @@ ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
 # Remote with custom hours window
 ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 48
 
+# Remote, for a different site on the same server
+ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 24 othersite.com
+
 # Local execution on production server
 ./run-monitoring.sh 24
+./run-monitoring.sh 24 othersite.com
 ```
 
 ---

--- a/scripts/monitoring/run-monitoring.sh
+++ b/scripts/monitoring/run-monitoring.sh
@@ -6,12 +6,15 @@
 # and saves timestamped reports to an output directory.
 #
 # Usage:
-#   ssh web@example.com 'bash -s' < ./run-monitoring.sh [hours]
+#   ssh web@example.com 'bash -s' < ./run-monitoring.sh [hours] [domain]
 #   ./run-monitoring.sh 24              # Run locally on production server
 #
 # Examples:
 #   # From local machine (recommended):
 #   ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+#
+#   # For a different site on the same server:
+#   ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 24 othersite.com
 #
 #   # On production server:
 #   cd /srv/www/example.com/current
@@ -25,12 +28,13 @@ set -e
 # ============================================================================
 
 HOURS="${1:-24}"
-LOG_FILE="/srv/www/example.com/logs/access.log"
+DOMAIN="${2:-example.com}"
+LOG_FILE="/srv/www/${DOMAIN}/logs/access.log"
 TIMESTAMP=$(date +"%Y-%m-%d-%H%M%S")
 DATESTAMP=$(date +"%Y-%m-%d")
 
 # Output directory (adjust based on execution context)
-if [[ -d "/srv/www/example.com" ]]; then
+if [[ -d "/srv/www/${DOMAIN}" ]]; then
     # Running on production server
     OUTPUT_DIR="${HOME}/monitoring"
     mkdir -p "$OUTPUT_DIR"
@@ -40,10 +44,17 @@ else
     mkdir -p "$OUTPUT_DIR"
 fi
 
-TRAFFIC_REPORT="${OUTPUT_DIR}/traffic-monitor-${TIMESTAMP}.txt"
-SECURITY_REPORT="${OUTPUT_DIR}/security-monitor-${TIMESTAMP}.txt"
-AI_BOT_REPORT="${OUTPUT_DIR}/ai-bot-monitor-${TIMESTAMP}.txt"
-SUMMARY_REPORT="${OUTPUT_DIR}/monitoring-summary-${DATESTAMP}.md"
+# Only suffix filenames with the domain when it's not the default site
+if [[ "$DOMAIN" == "example.com" ]]; then
+    DOMAIN_SUFFIX=""
+else
+    DOMAIN_SUFFIX="-${DOMAIN}"
+fi
+
+TRAFFIC_REPORT="${OUTPUT_DIR}/traffic-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
+SECURITY_REPORT="${OUTPUT_DIR}/security-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
+AI_BOT_REPORT="${OUTPUT_DIR}/ai-bot-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
+SUMMARY_REPORT="${OUTPUT_DIR}/monitoring-summary${DOMAIN_SUFFIX}-${DATESTAMP}.md"
 
 # Colors for output
 GREEN='\033[0;32m'
@@ -134,6 +145,7 @@ generate_summary() {
 # Monitoring Summary Report
 
 **Generated:** $(date)
+**Site:** ${DOMAIN}
 **Period:** Last ${HOURS} hours
 **Log File:** ${LOG_FILE}
 


### PR DESCRIPTION
This release adds multi-site support to `run-monitoring.sh`, allowing the monitoring orchestrator to target logs and report directories for any site on a shared server via an optional `domain` argument, rather than being hardcoded to `example.com`. Report filenames are now suffixed with the domain when targeting a non-default site, preventing collisions between reports for different sites, and the summary report header now identifies which site was monitored. Documentation in `scripts/README.md` and `CHANGELOG.md` has been updated accordingly to reflect version 2.11.1.

**Monitoring Script Enhancements:**

- Added an optional `domain` argument (positional, after `hours`) to `run-monitoring.sh`, defaulting to `example.com` for backward compatibility.
- Derived `LOG_FILE` and the production-server detection check (`/srv/www/<domain>`) from the new `DOMAIN` variable instead of hardcoded paths.
- Introduced a `DOMAIN_SUFFIX` that is appended to traffic, security, AI-bot, and summary report filenames only when a non-default domain is specified, avoiding filename collisions when monitoring multiple sites on one server.
- Added a `**Site:**` line to the generated summary report so each report clearly identifies the monitored domain.

**Documentation and Changelog:**

- Updated `scripts/README.md` with new usage examples for running the script against a different site (e.g., `./run-monitoring.sh 24 othersite.com`) and clarified the auto-detection and output filename behavior for multi-site setups.
- Updated the "Summary Report Includes" section to note that the site name is now part of the generated report.
- Added a CHANGELOG entry for version 2.11.1 describing the new `domain` argument and its effect on report naming and content.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/update/run-monitoring-domain-suffix/CHANGELOG.md) (Modified)
- [`scripts/README.md`](https://github.com/imagewize/wp-ops/blob/update/run-monitoring-domain-suffix/scripts/README.md) (Modified)
- [`scripts/monitoring/run-monitoring.sh`](https://github.com/imagewize/wp-ops/blob/update/run-monitoring-domain-suffix/scripts/monitoring/run-monitoring.sh) (Modified)