### PR TITLE
Add/upstream Change Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-06-20
+
+### Added
+
+- **Trellis Updater Upstream Change Detection** - Extended [trellis/updater/trellis-updater.sh](trellis/updater/trellis-updater.sh) with post-sync diff analysis for excluded files:
+  - Compares each excluded file against the fresh upstream Trellis clone after rsync
+  - Saves per-file diffs to `~/trellis-diff/excluded-file-diffs/` for review
+  - Reports count of excluded files with upstream changes
+  - Detects new upstream files not yet present locally
+  - Suggests reviewing diffs with Claude Code to cherry-pick upstream fixes without losing customizations
+  - Updated summary steps to include excluded file diff review
+
 ## [2.12.0] - 2026-06-14
 
 ### Added

--- a/trellis/updater/trellis-updater.sh
+++ b/trellis/updater/trellis-updater.sh
@@ -110,7 +110,65 @@ rsync -av --delete \
 
 echo "✓ Trellis files updated"
 
-# Step 6b: Verify critical files were preserved
+# Step 6b: Diff excluded files against upstream to catch missed updates
+echo ""
+echo "=== Checking excluded files for upstream changes ==="
+EXCLUDED_FILES=(
+  "ansible.cfg"
+  "group_vars/all/main.yml"
+  "group_vars/all/mail.yml"
+  "group_vars/all/security.yml"
+  "group_vars/all/users.yml"
+  "group_vars/production/main.yml"
+  "group_vars/staging/main.yml"
+  "group_vars/development/main.yml"
+  "group_vars/development/wordpress_sites.yml"
+  "group_vars/production/wordpress_sites.yml"
+  "group_vars/staging/wordpress_sites.yml"
+  "roles/wordpress-setup/templates/php-fpm-pool-wordpress.conf.j2"
+)
+
+UPSTREAM_CHANGES_DIR=$DIFF_DIR/excluded-file-diffs
+mkdir -p $UPSTREAM_CHANGES_DIR
+UPSTREAM_CHANGE_COUNT=0
+
+for file in "${EXCLUDED_FILES[@]}"; do
+  UPSTREAM="$TEMP_DIR/trellis/$file"
+  LOCAL="$TRELLIS_DIR/$file"
+
+  # Skip files that don't exist upstream (our custom additions)
+  if [ ! -f "$UPSTREAM" ]; then
+    continue
+  fi
+
+  # Skip files that don't exist locally yet
+  if [ ! -f "$LOCAL" ]; then
+    echo "  NEW upstream: $file (not present locally)"
+    cp "$UPSTREAM" "$UPSTREAM_CHANGES_DIR/$(echo $file | tr '/' '_').new"
+    UPSTREAM_CHANGE_COUNT=$((UPSTREAM_CHANGE_COUNT + 1))
+    continue
+  fi
+
+  # Generate diff if files differ
+  if ! diff -q "$UPSTREAM" "$LOCAL" > /dev/null 2>&1; then
+    diff -u "$LOCAL" "$UPSTREAM" > "$UPSTREAM_CHANGES_DIR/$(echo $file | tr '/' '_').diff" || true
+    echo "  CHANGED upstream: $file"
+    UPSTREAM_CHANGE_COUNT=$((UPSTREAM_CHANGE_COUNT + 1))
+  fi
+done
+
+if [ "$UPSTREAM_CHANGE_COUNT" -eq 0 ]; then
+  echo "✓ No upstream changes in excluded files"
+else
+  echo ""
+  echo "⚠ $UPSTREAM_CHANGE_COUNT excluded file(s) have upstream changes."
+  echo "  Diffs saved to: $UPSTREAM_CHANGES_DIR/"
+  echo "  Review these diffs to cherry-pick upstream fixes without losing customizations."
+  echo "  Tip: ask Claude Code to review the diffs in $UPSTREAM_CHANGES_DIR/"
+fi
+echo ""
+
+# Step 6c: Verify critical files were preserved
 echo ""
 echo "=== Verifying critical files ==="
 if [ ! -f "$TRELLIS_DIR/.vault_pass" ]; then
@@ -147,9 +205,11 @@ echo "=== Update Summary ==="
 echo "Next steps:"
 echo "1. Review changes: cd $PROJECT_DIR && git diff trellis/"
 echo "2. Check diff summary: cat $DIFF_DIR/changes.txt"
-echo "3. Update Galaxy roles: cd $TRELLIS_DIR && ansible-galaxy install -r galaxy.yml --force"
-echo "4. Test in development (if applicable)"
-echo "5. Commit changes: git add trellis/ && git commit -m 'Update Trellis to latest version'"
+echo "3. Review excluded file diffs: ls $DIFF_DIR/excluded-file-diffs/"
+echo "   (or ask Claude Code to review them for upstream fixes you should merge)"
+echo "4. Update Galaxy roles: cd $TRELLIS_DIR && ansible-galaxy install -r galaxy.yml --force"
+echo "5. Test in development (if applicable)"
+echo "6. Commit changes: git add trellis/ && git commit -m 'Update Trellis to latest version'"
 echo ""
 echo "Backup location: $BACKUP_DIR"
 echo "Temp directory: $TEMP_DIR (manually remove when done)"


### PR DESCRIPTION
This update enhances the Trellis updater script with upstream change detection for excluded files, addressing a blind spot in the existing update workflow. When the updater syncs a Trellis project to the latest upstream version, files excluded from rsync (such as `ansible.cfg`, `group_vars` site configurations, and custom templates) are intentionally preserved to protect local customizations. However, this means upstream improvements to those same files go unnoticed. The new post-sync diff analysis compares each excluded file against the fresh upstream clone, saves per-file diffs to a dedicated directory, and reports which files have diverged — enabling operators to selectively merge upstream fixes without losing their customizations.

**Upstream Change Detection:**
- Added a post-sync step (6b) that iterates over 12 known excluded files and diffs each one against the upstream Trellis clone before the temporary directory is removed
- Generates unified diffs saved to `~/trellis-diff/excluded-file-diffs/` with filenames derived from the original path (slashes replaced with underscores)
- Handles three cases: files that exist only upstream (flagged as NEW and copied), files that differ (diffed), and files with no changes (silently skipped)
- Reports a summary count of excluded files with upstream changes, with guidance to review the diffs

**Updated Workflow and Summary Steps:**
- Renumbered the verification step from 6b to 6c to accommodate the new diff analysis step
- Extended the post-update summary from 5 steps to 6, inserting a new step 3 that directs users to review the excluded file diffs directory
- Added a suggestion to use Claude Code for reviewing the generated diffs to identify upstream fixes worth cherry-picking

**Changelog:**
- Added version 2.13.0 entry documenting the upstream change detection feature with a detailed breakdown of capabilities

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/add/upstream-change-detection/CHANGELOG.md) (Modified)
- [`trellis/updater/trellis-updater.sh`](https://github.com/imagewize/wp-ops/blob/add/upstream-change-detection/trellis/updater/trellis-updater.sh) (Modified)