### PR TITLE
Add Mistral and DeepSeek bot detection to ai-bot-monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-06-26
+
+### Changed
+
+- **scripts/monitoring/ai-bot-monitor.sh** - Expanded AI crawler detection to cover three previously untracked bots:
+  - `MistralAI-User` (Mistral's live Le Chat fetcher) and `MistralAI-Index` (Mistral's indexing crawler)
+  - `DeepSeekBot` (DeepSeek's web crawler)
+  - Added all three to both the `AI_BOTS` display array and the aggregate `AI_PATTERN` matcher, so they now appear in per-bot request/bandwidth counts, scraped-page lists, and robots.txt compliance checks. Verified against two months of production logs: DeepSeekBot was actively crawling (and probing for `.env`/build manifests) but went uncounted, while neither Mistral bot has appeared at all.
+
 ## [2.14.0] - 2026-06-23
 
 ### Added

--- a/scripts/monitoring/ai-bot-monitor.sh
+++ b/scripts/monitoring/ai-bot-monitor.sh
@@ -54,6 +54,9 @@ declare -a AI_BOTS=(
     "anthropic-ai|Anthropic anthropic-ai"
     "Google-Extended|Google-Extended (Gemini training)"
     "PerplexityBot|PerplexityBot"
+    "MistralAI-User|Mistral MistralAI-User (live fetch)"
+    "MistralAI-Index|Mistral MistralAI-Index (crawler)"
+    "DeepSeekBot|DeepSeek DeepSeekBot"
     "CCBot|Common Crawl CCBot"
     "Bytespider|ByteDance Bytespider"
     "Amazonbot|Amazon Amazonbot"
@@ -70,7 +73,7 @@ declare -a AI_BOTS=(
 )
 
 # Combined pattern for matching any AI bot (used for aggregate queries)
-AI_PATTERN='GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Google-Extended|PerplexityBot|CCBot|Bytespider|Amazonbot|cohere-ai|YouBot|Diffbot|meta-externalagent|Applebot-Extended|ImagesiftBot|omgilibot|AI2Bot|iaskspider|Kangaroo Bot'
+AI_PATTERN='GPTBot|ChatGPT-User|OAI-SearchBot|ClaudeBot|anthropic-ai|Google-Extended|PerplexityBot|MistralAI-User|MistralAI-Index|DeepSeekBot|CCBot|Bytespider|Amazonbot|cohere-ai|YouBot|Diffbot|meta-externalagent|Applebot-Extended|ImagesiftBot|omgilibot|AI2Bot|iaskspider|Kangaroo Bot'
 
 # Static file extensions to exclude from page analysis
 STATIC_PATTERN='\.(css|js|jpg|jpeg|png|gif|ico|woff|woff2|svg|webp|avif|ttf|eot|map|txt|xml)($|\?)'


### PR DESCRIPTION
## Summary

Expands `scripts/monitoring/ai-bot-monitor.sh` to detect three previously untracked AI crawlers:

- `MistralAI-User` — Mistral's live Le Chat fetcher
- `MistralAI-Index` — Mistral's indexing crawler
- `DeepSeekBot` — DeepSeek's web crawler

All three are added to both the `AI_BOTS` display array and the aggregate `AI_PATTERN` matcher, so they now show up in per-bot request/bandwidth counts, scraped-page lists, and robots.txt compliance checks.

## Why

Verified against ~2 months of production access logs across two WordPress sites:

- **DeepSeekBot** was actively crawling — real page fetches plus probes for `/.env.production` and framework build manifests — but went completely uncounted because the script never matched it.
- **Neither Mistral bot** has appeared at all (Mistral appears to rely on Common Crawl rather than running its own broad crawl), so reports were silently blind to whether it ever does.

## Changes

- `scripts/monitoring/ai-bot-monitor.sh` — add the three UA patterns to `AI_BOTS` + `AI_PATTERN`
- `CHANGELOG.md` — `[2.15.0] - 2026-06-26`

## Test

- `bash -n scripts/monitoring/ai-bot-monitor.sh` passes (no syntax errors)