### PR TITLE
Add List Posts Snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-07-04
+
+### Added
+
+- **wp-cli/diagnostics/list-posts-count.sh** - New shell script snippet that lists all published posts via WP-CLI in CSV format and counts the results. Useful for content audits and diagnostics.
+
 ## [2.15.0] - 2026-06-26
 
 ### Changed

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -90,6 +90,9 @@ if [ "$AI_TOOL" != "claude" ] && [ "$AI_TOOL" != "codex" ] && [ "$AI_TOOL" != "v
 fi
 
 # CLI command names can be overridden via environment if needed
+# Availability is checked via `command -v` against the caller's PATH, so a tool
+# installed after the current shell started (e.g. vibe added to ~/.local/bin)
+# won't be detected until PATH is re-sourced (new terminal tab or `source ~/.zshrc`).
 CLAUDE_COMMAND=${CLAUDE_COMMAND:-claude}
 CODEX_COMMAND=${CODEX_COMMAND:-codex}
 VIBE_COMMAND=${VIBE_COMMAND:-vibe}

--- a/wp-cli/diagnostics/README.md
+++ b/wp-cli/diagnostics/README.md
@@ -128,7 +128,7 @@ wp eval-file web/app/themes/your-theme/diagnostic-transients.php --path=web/wp
 ./list-posts-count.sh
 
 # Or copy and run directly:
-ssh web@imagewize.com "cd /srv/www/imagewize.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
+ssh web@example.com "cd /srv/www/example.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
 wc -l /tmp/all_posts.csv
 ```
 

--- a/wp-cli/diagnostics/README.md
+++ b/wp-cli/diagnostics/README.md
@@ -8,6 +8,7 @@ WordPress diagnostic tools for troubleshooting common issues in Trellis/Bedrock 
 - [Installation](#installation)
 - [Available Tools](#available-tools)
   - [Transient Diagnostics](#transient-diagnostics)
+  - [Post Listing Script](#post-listing-script)
 - [Best Practices](#best-practices)
 - [Contributing](#contributing)
 
@@ -114,6 +115,35 @@ wp eval-file web/app/themes/your-theme/diagnostic-transients.php --path=web/wp
 - Need to share diagnostic results with clients or team members
 - Want detailed database performance metrics
 - Testing after server configuration changes
+
+### Post Listing Script
+
+#### 1. List Posts Count (`list-posts-count.sh`)
+
+**Purpose:** List all published WordPress posts via WP-CLI in CSV format and count the results. Useful for content audits, diagnostics, and verifying post counts.
+
+**Usage:**
+```bash
+# Run the script (connects to production server)
+./list-posts-count.sh
+
+# Or copy and run directly:
+ssh web@imagewize.com "cd /srv/www/imagewize.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
+wc -l /tmp/all_posts.csv
+```
+
+**What It Does:**
+- Connects via SSH to a WordPress server
+- Lists all published posts with ID, title, slug, and date fields
+- Outputs results in CSV format to `/tmp/all_posts.csv`
+- Counts the number of posts (lines in the CSV file)
+
+**Output:** CSV file with post data and line count to stdout
+
+**When to Use:**
+- Content audit and verification
+- Quick post count checks
+- Diagnostic investigation of post-related issues
 
 ### Common Issues Diagnosed
 

--- a/wp-cli/diagnostics/list-posts-count.sh
+++ b/wp-cli/diagnostics/list-posts-count.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # List all published posts and count lines
 
-ssh web@imagewize.com "cd /srv/www/imagewize.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
+ssh web@example.com "cd /srv/www/example.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
 wc -l /tmp/all_posts.csv

--- a/wp-cli/diagnostics/list-posts-count.sh
+++ b/wp-cli/diagnostics/list-posts-count.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# List all published posts and count lines
+
+ssh web@imagewize.com "cd /srv/www/imagewize.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
+wc -l /tmp/all_posts.csv


### PR DESCRIPTION
This release adds a new WP-CLI diagnostic snippet for counting posts by status, alongside documentation updates and a caveat fix in the PR creation script. Version 2.16.0 introduces `list-posts-count.sh`, a diagnostics utility that helps developers quickly audit post counts across a WordPress site. The accompanying README and CHANGELOG were updated to reflect the new tool, and the snippet itself was revised to use a generic `example.com` placeholder for broader applicability. Additionally, `create-pr.sh` received documentation clarifying a PATH detection limitation in its AI tool availability check.

**Diagnostics Tooling:**
- Added `wp-cli/diagnostics/list-posts-count.sh`, a new snippet for retrieving post counts, expanding the diagnostics toolkit for WordPress site auditing.
- Replaced site-specific values in the snippet with a generic `example.com` placeholder to make the example portable across projects.

**Documentation and Developer Guidance:**
- Updated `wp-cli/diagnostics/README.md` to document usage of the new `list-posts-count.sh` script.
- Updated `CHANGELOG.md` to record the version 2.16.0 release, including the new diagnostics snippet.
- Documented a PATH detection caveat in `scripts/create-pr.sh` related to how the script checks for AI tool availability, clarifying a known limitation for users running it in non-standard shell environments.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/add-list-posts-snippet/CHANGELOG.md) (Modified)
- [`scripts/create-pr.sh`](https://github.com/imagewize/wp-ops/blob/add-list-posts-snippet/scripts/create-pr.sh) (Modified)
- [`wp-cli/diagnostics/README.md`](https://github.com/imagewize/wp-ops/blob/add-list-posts-snippet/wp-cli/diagnostics/README.md) (Modified)
- [`wp-cli/diagnostics/list-posts-count.sh`](https://github.com/imagewize/wp-ops/blob/add-list-posts-snippet/wp-cli/diagnostics/list-posts-count.sh) (Added)