### PR TITLE
Document SSH connection multiplexing for production access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-07-04
+
+### Added
+
+- **SSH Connection Multiplexing** - Documented `ControlMaster`/`ControlPersist` setup in [trellis/provision/PROJECT-SETUP.md](trellis/provision/PROJECT-SETUP.md) under "Speed Up SSH with Connection Multiplexing": reuses an authenticated SSH socket across repeat connections to production (log checks, WP-CLI, fail2ban lookups) instead of renegotiating each time. Keyed per remote user via `%r`, so `web@` and `admin_user@` get independent sockets.
+
 ## [2.16.0] - 2026-07-04
 
 ### Added

--- a/trellis/provision/PROJECT-SETUP.md
+++ b/trellis/provision/PROJECT-SETUP.md
@@ -610,6 +610,27 @@ ssh admin_user@yourproject.com
 
 **Note:** Root SSH access is disabled for security. Use your configured admin user for sudo access.
 
+#### Speed Up SSH with Connection Multiplexing (Recommended)
+
+If you SSH into production frequently (log checks, WP-CLI, fail2ban lookups, deploys), add connection multiplexing to `~/.ssh/config` so repeat connections reuse an already-authenticated socket instead of renegotiating SSH each time:
+
+```
+Host yourproject.com
+  KexAlgorithms curve25519-sha256@libssh.org
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/%r@%h-%p
+  ControlPersist 600
+```
+
+```bash
+mkdir -p ~/.ssh/sockets && chmod 700 ~/.ssh/sockets
+```
+
+**Notes:**
+- Multiplexing is keyed per remote user (`%r`), so `web@yourproject.com` and `admin_user@yourproject.com` get separate sockets — both benefit independently.
+- `ControlPersist 600` keeps the master connection open for 10 minutes after your last session closes, so a burst of commands (e.g. diagnostics during an incident) only pays the handshake cost once.
+- Verify it's working: run the same SSH command twice in a row — the second should return in well under a second, and `~/.ssh/sockets/` will contain a socket file per user.
+
 #### Troubleshooting
 
 **Problem:** `Permission denied (publickey)` after provisioning


### PR DESCRIPTION
This documentation update introduces SSH connection multiplexing guidance to speed up repeated SSH and Ansible operations against production servers within Trellis workflows. It adds a new section to `trellis/provision/PROJECT-SETUP.md` explaining how to configure `ControlMaster`/`ControlPersist` settings in `~/.ssh/config` so that subsequent connections reuse an existing authenticated session instead of renegotiating the SSH handshake each time. The `CHANGELOG.md` is updated to record this documentation addition. This change is purely additive documentation with no impact on existing scripts, playbooks, or automation behavior.

**Documentation and Developer Guidance:**
- Added a new SSH connection multiplexing section to `PROJECT-SETUP.md`, describing the `ControlMaster auto`, `ControlPath`, and `ControlPersist` SSH config directives and their effect on connection reuse.
- Explained the practical benefit for Trellis operators: faster repeated `trellis` commands and Ansible playbook runs against production hosts by avoiding redundant SSH handshakes.
- Updated `CHANGELOG.md` to reflect the new documentation entry, keeping the change log aligned with recent additions to the provisioning guide.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/add/ssh-connection-multiplexing/CHANGELOG.md) (Modified)
- [`trellis/provision/PROJECT-SETUP.md`](https://github.com/imagewize/wp-ops/blob/add/ssh-connection-multiplexing/trellis/provision/PROJECT-SETUP.md) (Modified)