### PR TITLE
Add post-count.sh script and reorganize README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-07-08
+
+### Added
+
+- **scripts/post-count.sh** - New script to count published WordPress blog posts by year or month via `wp db query`:
+  - Defaults to `post_type=post` / `post_status=publish` only — pages, CPTs, and drafts excluded unless overridden with `--type` / `--status`
+  - Three modes: all-years breakdown (default), single-year total (`--year YYYY`), or monthly breakdown (`--months YYYY`)
+  - Runs locally (Trellis VM / server) or remotely via `--ssh HOST`, with `--site DIR` to target other web roots on a shared server
+  - Documented in [`scripts/README.md`](scripts/README.md#post-countsh)
+
+### Changed
+
+- **README.md** - Reorganized the Scripts section into four categorized tables (Releases & GitHub, Monitoring & Security, Content & Backups, Images/WooCommerce & Files) covering previously-undocumented scripts, and moved Troubleshooting out of the Trellis table into its own top-level section
+- **scripts/README.md** - Updated script count (21 → 22) and added a Content Reporting functional area for `post-count.sh`
+
 ## [2.17.0] - 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 - [Nginx](#nginx)
 - [Scripts](#scripts)
 - [WordPress Utilities](#wordpress-utilities)
+- [Troubleshooting](#troubleshooting)
 
 ## Trellis
 
@@ -28,7 +29,6 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 | **Project Setup** | Clone and configure an existing Trellis/Bedrock project | [→](trellis/provision/PROJECT-SETUP.md) |
 | **Monitoring** | Nginx log monitoring for traffic analysis and security threat detection | [→](trellis/monitoring/README.md) |
 | **Security** | fail2ban IP blocking and manual deny rules | [→](trellis/security/README.md) |
-| **Troubleshooting** | Diagnose PHP-FPM, MariaDB, and server issues | [→](troubleshooting/README.md) |
 
 ## Bedrock
 
@@ -57,13 +57,49 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 
 ## Scripts
 
+Standalone Bash/PHP utilities — see [scripts/README.md](scripts/README.md) for full docs, flags, and examples.
+
+### Releases & GitHub
+
 | Tool | Description | Docs |
 |------|-------------|------|
-| **404 Checker** | Internal broken-link checker — homepage scan or recursive spider | [→](scripts/README.md#404-checkersh) |
 | **PR Creation** | AI-powered GitHub PR descriptions (Claude/Codex) | [→](CREATE-PR.md) |
 | **Plugin Release** | AI-powered version bumping and changelog generation for plugins | [→](scripts/release-plugin.sh) |
 | **Theme Release** | AI-powered version bumping and changelog generation for themes | [→](scripts/release-theme.sh) |
-| **Theme Sync** | Rsync script for theme synchronization | [→](scripts/rsync-theme.sh) |
+| **WordPress.org Deploy** | Publish a plugin to the WordPress.org SVN directory | [→](scripts/README.md#deploy-plugin-wporgsh) |
+| **Release Asset Upload** | Manually attach a zip to an existing GitHub release | [→](scripts/upload-release-asset.sh) |
+
+### Monitoring & Security
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| **Run Monitoring** | Orchestrator: runs all monitors and generates a markdown summary | [→](scripts/monitoring/run-monitoring.sh) |
+| **Traffic Monitor** | Nginx traffic analysis with bot filtering and reporting | [→](scripts/monitoring/traffic-monitor.sh) |
+| **Security Monitor** | Nginx threat detection with IP block recommendations | [→](scripts/monitoring/security-monitor.sh) |
+| **AI Bot Monitor** | AI crawler traffic analysis (GPTBot, ClaudeBot, etc.) | [→](scripts/monitoring/ai-bot-monitor.sh) |
+| **404 Checker** | Internal broken-link checker — homepage scan or recursive spider | [→](scripts/README.md#404-checkersh) |
+| **Redirect Check** | Mass URL redirect checker using curl | [→](scripts/README.md#redirect-checksh) |
+| **CF7 Smoke Test** | Playwright post-deploy contact-form submission check | [→](scripts/monitoring/cf7-smoke-test.js) |
+| **Updown Webhook** | updown.io downtime alert handler + PHP receiver | [→](scripts/monitoring/updown-webhook-handler.sh) |
+
+### Content & Backups
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| **Post Count** | Count published blog posts by year/month (blog posts only, CPTs excluded) | [→](scripts/README.md#post-countsh) |
+| **DB Backup** | Trellis-aware database backup with optional URL replacement | [→](scripts/backup/db-backup.sh) |
+| **Site Backup** | Full site backup (database + uploads + config + content) | [→](scripts/backup/site-backup.sh) |
+
+### Images, WooCommerce & Files
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| **Batch Resize** | Batch resize + center-crop images for featured images | [→](scripts/README.md#batch-resizesh) |
+| **WebP Convert** | JPG→WebP at the Facebook OG ratio with center crop | [→](scripts/README.md#convert-to-webpsh) |
+| **Product Variations** | Bulk-create WooCommerce product variations via WP-CLI | [→](scripts/woocommerce/create-product-variations.sh) |
+| **Theme Sync** | Rsync a theme between Trellis and a standalone repo | [→](scripts/rsync-theme.sh) |
+| **Find & Replace** | Batch find and replace files across directory trees | [→](scripts/find-and-replace-files.sh) |
+| **Git Log Oneline** | Show recent git commits as compact one-liners | [→](scripts/README.md#git-log-onelinesh) |
 
 ## WordPress Utilities
 
@@ -73,6 +109,12 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 | **Age Verification** | Cookie-based age verification with modal interface and ACF integration | [→](wordpress-utilities/age-verification/README.md) |
 | **Analytics** | Google Analytics, Matomo implementation and detection | [→](wordpress-utilities/analytics/README.md) |
 | **Speed Optimization** | Performance testing and TTFB analysis with curl/wget | [→](wordpress-utilities/speed-optimization/README.md) |
+
+## Troubleshooting
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| **Server Diagnostics** | Diagnose PHP-FPM, MariaDB, and server issues | [→](troubleshooting/README.md) |
 
 ## Requirements
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,13 +4,14 @@ Production-ready Bash and PHP scripts for WordPress operations, GitHub integrati
 
 ## Overview
 
-This directory contains 21 utility scripts organized into six functional areas:
+This directory contains 22 utility scripts organized into seven functional areas:
 
 - **GitHub Integration** - AI-powered pull request creation and manual GitHub release asset uploads
 - **WordPress Management** - Plugin and theme release automation, WordPress.org SVN deployment, file synchronization
 - **WooCommerce** - Product variation bulk creation
 - **Image Utilities** - WebP conversion optimized for WordPress and Facebook OG images
 - **Git Utilities** - Quick access to recent commit history
+- **Content Reporting** - Published-post counts by year and month (blog posts only)
 - **Operations** - Server monitoring and backup infrastructure
 - **Webhook Integration** - Updown.io downtime alert handling
 
@@ -40,6 +41,7 @@ scripts/
 ├── upload-release-asset.sh    # Manual GitHub release zip upload (fallback for failed Actions)
 ├── find-and-replace-files.sh  # Batch find and replace files across directory trees
 ├── git-log-oneline.sh          # Show recent git commits as one-liners
+├── post-count.sh               # Count published blog posts by year/month (blog posts only)
 ├── release-plugin.sh           # WordPress plugin version release automation
 ├── release-theme.sh            # WordPress theme version release automation
 └── rsync-theme.sh             # Theme file synchronization utility
@@ -73,6 +75,13 @@ scripts/
 # Show recent git commits as one-liners
 ./scripts/git-log-oneline.sh
 ./scripts/git-log-oneline.sh 25
+
+# Count published blog posts by year (production, over SSH)
+./scripts/post-count.sh --ssh web@imagewize.com
+
+# Count just this year's blog posts, or a month-by-month breakdown
+./scripts/post-count.sh --ssh web@imagewize.com --year 2026
+./scripts/post-count.sh --ssh web@imagewize.com --months 2026
 
 # Release WordPress theme version
 ./scripts/release-theme.sh theme-name 1.2.5
@@ -304,6 +313,75 @@ Shows recent git commits as compact one-liners with short hash and commit messag
 - Review recent commits before creating a PR
 - Verify the last deployment included the right changes
 - Check if a specific fix has been committed
+
+---
+
+## Content Reporting
+
+### post-count.sh
+
+Counts published WordPress **blog posts** grouped by the year of `post_date`. Answers "how many posts have we published this year?" without pulling in pages, nav menu items, attachments, revisions, custom post types, or drafts.
+
+By default it counts `post_type=post` and `post_status=publish` only — so custom post types (e.g. an `iw_audit` CPT) and pages are **not** included. Override `--type` / `--status` if you need a different slice.
+
+Runs `wp db query`, so run it where WP-CLI works: inside the Trellis VM, on the production server, or from your host with `--ssh` (which wraps the query in an `ssh` call to the server).
+
+#### Features
+
+- **Blog posts only by default** — `post_type=post`, `post_status=publish`; CPTs, pages, menus, attachments, revisions, and drafts excluded
+- **Three modes**: all-years breakdown (default), single-year total (`--year`), or monthly breakdown (`--months`)
+- **Remote or local**: `--ssh HOST` runs against production over SSH; without it, runs against the current WP install
+- **Multi-site**: point `--site` at any web root on the server (e.g. aseonomics.com)
+- **Overridable slice**: `--type` / `--status` for pages, drafts, or a custom post type
+
+#### Usage
+
+```bash
+# All years, blog posts only (over SSH to production)
+./post-count.sh --ssh web@imagewize.com
+
+# Just 2026's blog-post total
+./post-count.sh --ssh web@imagewize.com --year 2026
+
+# Month-by-month for 2026
+./post-count.sh --ssh web@imagewize.com --months 2026
+
+# Run locally inside the Trellis VM / on the server (no --ssh needed)
+./post-count.sh --year 2026
+
+# aseonomics.com on the same server
+./post-count.sh --ssh web@imagewize.com --site /srv/www/aseonomics.com/current
+
+# Count published pages instead of posts
+./post-count.sh --ssh web@imagewize.com --type page
+
+# Syntax
+./post-count.sh [--year YYYY | --months YYYY] [--type TYPE] [--status STATUS] \
+                [--path WP_PATH] [--ssh HOST] [--site DIR]
+```
+
+#### Example Output
+
+```
+=== Monthly post count (publish) for 2026 ===
+Site: /srv/www/imagewize.com/current (web@imagewize.com)
+
+month	posts
+2026-01	2
+2026-02	13
+2026-03	3
+2026-04	12
+2026-05	16
+2026-06	12
+2026-07	4
+
+Done.
+```
+
+#### Requirements
+
+- WP-CLI available where the query runs (Trellis VM, production, or reachable via `--ssh`)
+- SSH access to the server when using `--ssh` (e.g. `web@imagewize.com`)
 
 ---
 

--- a/scripts/post-count.sh
+++ b/scripts/post-count.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# post-count.sh — Count published WordPress posts by year (blog posts only)
+#
+# Counts real blog posts (post_type=post, post_status=publish by default) grouped
+# by the year of post_date. Custom post types, pages, nav menu items, attachments,
+# revisions, and drafts are excluded unless you override --type / --status.
+#
+# Runs `wp db query` against a WordPress install. Run it where WP-CLI works — inside
+# the Trellis VM, on the production server, or from your host via --ssh (which wraps
+# the query in an ssh call to the server).
+#
+# Usage: ./post-count.sh [OPTIONS]
+#
+# Options:
+#   --year YYYY       Only this year — prints a single total
+#   --months YYYY     Monthly breakdown (YYYY-MM) for the given year
+#   --type TYPE       post_type to count (default: post)
+#   --status STATUS   post_status to count (default: publish)
+#   --path PATH       WordPress path passed to WP-CLI (default: web/wp)
+#   --ssh HOST        Run remotely over ssh, e.g. web@imagewize.com
+#   --site DIR        Remote site dir to cd into with --ssh
+#                     (default: /srv/www/imagewize.com/current)
+#   -h, --help        Show this help
+#
+# Examples:
+#   # All years, blog posts only (run inside VM or on server)
+#   ./post-count.sh
+#
+#   # From your host, hit production over SSH
+#   ./post-count.sh --ssh web@imagewize.com
+#
+#   # Just 2026's blog-post total
+#   ./post-count.sh --ssh web@imagewize.com --year 2026
+#
+#   # Month-by-month for 2026
+#   ./post-count.sh --ssh web@imagewize.com --months 2026
+#
+#   # aseonomics.com on the same server
+#   ./post-count.sh --ssh web@imagewize.com --site /srv/www/aseonomics.com/current
+
+set -euo pipefail
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+YEAR=""
+MONTHS=""
+PTYPE="post"
+PSTATUS="publish"
+WP_PATH="web/wp"
+SSH_HOST=""
+SITE_DIR="/srv/www/imagewize.com/current"
+
+usage() {
+  # Print the leading comment block (from line 2 until the first non-comment line)
+  awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+  exit "${1:-0}"
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --year)    YEAR="$2";    shift 2 ;;
+    --months)  MONTHS="$2";  shift 2 ;;
+    --type)    PTYPE="$2";   shift 2 ;;
+    --status)  PSTATUS="$2"; shift 2 ;;
+    --path)    WP_PATH="$2"; shift 2 ;;
+    --ssh)     SSH_HOST="$2"; shift 2 ;;
+    --site)    SITE_DIR="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) printf "${RED}Unknown option: %s${NC}\n" "$1" >&2; usage 2 ;;
+  esac
+done
+
+# Validate year-like arguments
+for y in "$YEAR" "$MONTHS"; do
+  if [[ -n "$y" && ! "$y" =~ ^[0-9]{4}$ ]]; then
+    printf "${RED}Year must be a 4-digit number (got: %s)${NC}\n" "$y" >&2
+    exit 2
+  fi
+done
+
+# ── Build the SQL ─────────────────────────────────────────────────────────────
+WHERE="post_type='${PTYPE}' AND post_status='${PSTATUS}'"
+
+if [[ -n "$MONTHS" ]]; then
+  SQL="SELECT DATE_FORMAT(post_date,'%Y-%m') AS month, COUNT(*) AS posts
+       FROM wp_posts WHERE ${WHERE} AND YEAR(post_date)=${MONTHS}
+       GROUP BY month ORDER BY month;"
+  HEADER="Monthly ${PTYPE} count (${PSTATUS}) for ${MONTHS}"
+elif [[ -n "$YEAR" ]]; then
+  SQL="SELECT COUNT(*) AS posts FROM wp_posts
+       WHERE ${WHERE} AND YEAR(post_date)=${YEAR};"
+  HEADER="${PTYPE} count (${PSTATUS}) for ${YEAR}"
+else
+  SQL="SELECT YEAR(post_date) AS year, COUNT(*) AS posts FROM wp_posts
+       WHERE ${WHERE} GROUP BY year ORDER BY year DESC;"
+  HEADER="${PTYPE} count (${PSTATUS}) by year"
+fi
+
+# Collapse whitespace so it travels cleanly over ssh
+SQL="$(printf '%s' "$SQL" | tr '\n' ' ' | tr -s ' ')"
+
+# ── Run the query ─────────────────────────────────────────────────────────────
+printf "${CYAN}=== %s ===${NC}\n" "$HEADER"
+[[ -n "$SSH_HOST" ]] && printf "${CYAN}Site: %s (%s)${NC}\n" "$SITE_DIR" "$SSH_HOST"
+printf "\n"
+
+if [[ -n "$SSH_HOST" ]]; then
+  ssh "$SSH_HOST" "cd '${SITE_DIR}' && wp db query \"${SQL}\" --path='${WP_PATH}'"
+else
+  if ! command -v wp >/dev/null 2>&1; then
+    printf "${RED}wp (WP-CLI) not found. Run this inside the Trellis VM / on the server, or use --ssh.${NC}\n" >&2
+    exit 2
+  fi
+  wp db query "${SQL}" --path="${WP_PATH}"
+fi
+
+printf "\n${GREEN}Done.${NC}\n"


### PR DESCRIPTION
Adds a `post-count.sh` script for counting published posts by year/month, alongside a README reorganization and the corresponding CHANGELOG entry for version 2.18.0. The new script provides site administrators with a quick way to audit content publishing volume over time without writing custom WP-CLI queries. Documentation updates restructure the README's scripts and troubleshooting sections to improve navigability as the script collection grows. Together these changes add 263 lines across four files, with the script itself being the primary functional addition.

**New Script:**
- Added `scripts/post-count.sh`, a standalone utility that counts published posts grouped by year and month, giving a quick content-volume audit for WordPress sites managed through this repository.

**Documentation and Organization:**
- Reorganized the scripts and troubleshooting sections in `README.md` to better group related utilities and improve discoverability as the `scripts/` directory expands.
- Updated `scripts/README.md` to document the new `post-count.sh` script alongside existing utilities, keeping usage instructions centralized.
- Added a CHANGELOG entry for version 2.18.0 documenting the new script and README reorganization.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/add/post-count-script/CHANGELOG.md) (Modified)
- [`README.md`](https://github.com/imagewize/wp-ops/blob/add/post-count-script/README.md) (Modified)
- [`scripts/README.md`](https://github.com/imagewize/wp-ops/blob/add/post-count-script/scripts/README.md) (Modified)
- [`scripts/post-count.sh`](https://github.com/imagewize/wp-ops/blob/add/post-count-script/scripts/post-count.sh) (Added)