### PR TITLE
Enhance/mcp Server Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-07-08
+
+### Added
+
+- **mcp-server/** - Enhanced site registry schema with support for custom `wpBin` and `phpBin` paths (enables cPanel/Plesk shared hosting sites with non-standard WP-CLI/PHP locations) and optional `url` field per environment (enables static sites and simplifies audit tool usage). Updated `redirect_audit` and `schema_audit` tools to accept either raw URLs or `site`+`env` parameters to look up URLs from the registry.
+
 ## [3.0.0] - 2026-07-08
 
 ### Added

--- a/mcp-server/config/sites.example.json
+++ b/mcp-server/config/sites.example.json
@@ -5,11 +5,27 @@
     },
     "staging": {
       "sshHost": "staging.example.com",
-      "remotePath": "/srv/www/example.com/current/web/wp"
+      "remotePath": "/srv/www/example.com/current/web/wp",
+      "url": "https://staging.example.com"
     },
     "production": {
       "sshHost": "production.example.com",
-      "remotePath": "/srv/www/example.com/current/web/wp"
+      "remotePath": "/srv/www/example.com/current/web/wp",
+      "url": "https://example.com"
+    }
+  },
+  "client.nl": {
+    "production": {
+      "sshHost": "client@client.nl",
+      "remotePath": "/home/client/public_html",
+      "wpBin": "~/wp-cli.phar",
+      "phpBin": "/opt/plesk/php/8.2/bin/php",
+      "url": "https://client.nl"
+    }
+  },
+  "static-site": {
+    "production": {
+      "url": "https://static-site.com"
     }
   }
 }

--- a/mcp-server/src/registry.ts
+++ b/mcp-server/src/registry.ts
@@ -7,23 +7,36 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CONFIG_PATH = path.resolve(__dirname, "../config/sites.json");
 
 // Every entry must resolve to exactly one way of reaching the site: a Trellis dev VM
-// (trellisDir+vmWorkdir), a remote host (sshHost+remotePath), or a local path. Mirrors
-// the fallback order in tools/wpCli.ts's runWpCli.
+// (trellisDir+vmWorkdir), a remote host (sshHost+remotePath), a local path, or a URL.
+// Mirrors the fallback order in tools/wpCli.ts's runWpCli.
 const envEntrySchema = z
   .object({
     localPath: z.string().min(1).optional(),
     sshHost: z.string().min(1).optional(),
     remotePath: z.string().min(1).optional(),
+    url: z.string().url().optional(),
     // Trellis VM (local development): run commands inside the dev VM via
     // `trellis vm shell`, since a Trellis dev box keeps the database in the VM,
     // not on the host — so plain `wp` against localPath can't reach the DB.
     trellisDir: z.string().min(1).optional(), // dir to run `trellis` from (the Trellis project root, holds trellis.cli.yml)
     vmWorkdir: z.string().min(1).optional(), // --workdir inside the VM, e.g. /srv/www/example.com/current
     vmPath: z.string().min(1).optional(), // wp --path relative to vmWorkdir; defaults to "web/wp"
+    // Custom binary paths for shared hosting (cPanel/Plesk) or non-standard setups
+    wpBin: z.string().min(1).optional(), // path to wp-cli binary/phar, e.g. "~/wp-cli.phar" or "/usr/local/bin/wp"
+    phpBin: z.string().min(1).optional(), // path to PHP binary, e.g. "/opt/plesk/php/8.2/bin/php"
   })
-  .refine((entry) => Boolean((entry.trellisDir && entry.vmWorkdir) || (entry.sshHost && entry.remotePath) || entry.localPath), {
-    message: "must set one of: trellisDir+vmWorkdir, sshHost+remotePath, or localPath",
-  })
+  .refine(
+    (entry) =>
+      Boolean(
+        (entry.trellisDir && entry.vmWorkdir) ||
+        (entry.sshHost && entry.remotePath) ||
+        entry.localPath ||
+        entry.url
+      ),
+    {
+      message: "must set one of: trellisDir+vmWorkdir, sshHost+remotePath, localPath, or url",
+    }
+  )
   .refine((entry) => !entry.sshHost === !entry.remotePath, {
     message: "sshHost and remotePath must be set together",
   })
@@ -37,6 +50,18 @@ export type EnvEntry = z.infer<typeof envEntrySchema>;
 
 export function hasTrellisVm(entry: EnvEntry): entry is EnvEntry & { trellisDir: string; vmWorkdir: string } {
   return Boolean(entry.trellisDir && entry.vmWorkdir);
+}
+
+export function resolveWpBin(entry: EnvEntry): string {
+  return entry.wpBin || "wp";
+}
+
+export function resolvePhpBin(entry: EnvEntry): string | undefined {
+  return entry.phpBin;
+}
+
+export function hasUrl(entry: EnvEntry): entry is EnvEntry & { url: string } {
+  return Boolean(entry.url);
 }
 
 export type SiteRegistry = z.infer<typeof siteRegistrySchema>;

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -112,12 +112,15 @@ export function createServer(): McpServer {
     "Run a comprehensive redirect chain audit for one or more URLs. Tests HTTPS pages for 200 status " +
       "with 0 redirects (optimal), verifies HTTP→HTTPS 301 redirects, checks www→non-www canonicalization, " +
       "and validates security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options). Returns color-coded " +
-      "status for each test with detailed recommendations.",
+      "status for each test with detailed recommendations. Pass either `urls` or `site`+`env` (to use the site's registered URL).",
     {
       urls: z
         .array(z.string().url())
         .min(1)
+        .optional()
         .describe('URL(s) to audit, e.g. ["https://example.com", "https://example.com/about/"]'),
+      site: z.string().optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: z.string().optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
       checkWww: z
         .boolean()
         .default(true)
@@ -127,9 +130,25 @@ export function createServer(): McpServer {
         .default(true)
         .describe('Whether to check for security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options)'),
     },
-    async ({ urls, checkWww, checkSecurityHeaders }) => {
+    async ({ urls, site, env, checkWww, checkSecurityHeaders }) => {
       try {
-        const result = await runRedirectAudit(urls, checkWww, checkSecurityHeaders);
+        // Resolve URLs from site/env if provided
+        let targetUrls = urls;
+        if (site && env) {
+          const registry = loadRegistry();
+          const entry = resolveSiteEnv(registry, site, env);
+          if (entry.url) {
+            targetUrls = [entry.url];
+          } else {
+            throw new Error(`Site entry for "${site}"/"${env}" has no URL field. Use the "urls" parameter instead.`);
+          }
+        }
+        
+        if (!targetUrls || targetUrls.length === 0) {
+          throw new Error("Either provide 'urls' or 'site' + 'env' parameters.");
+        }
+        
+        const result = await runRedirectAudit(targetUrls, checkWww, checkSecurityHeaders);
         const lines: string[] = [
           `Redirect Audit: ${result.overallStatus === "PASS" ? "✅ PASS" : "❌ FAIL"}`,
           `Total Tests: ${result.totalTests} | Passed: ${result.passedTests} | Failed: ${result.failedTests}`,
@@ -172,9 +191,11 @@ export function createServer(): McpServer {
     "schema_audit",
     "Audit schema markup (JSON-LD) across key pages of a site. Checks for Organization, LocalBusiness, " +
       "Service, Product, WebSite, BreadcrumbList, Article, FAQPage, HowTo, and Person schema types. " +
-      "Returns count of pages with/without schema and which schema types are present.",
+      "Returns count of pages with/without schema and which schema types are present. Pass either `siteUrl` or `site`+`env`.",
     {
-      siteUrl: z.string().describe('Site URL to audit, e.g. "https://example.com"'),
+      siteUrl: z.string().optional().describe('Site URL to audit, e.g. "https://example.com"'),
+      site: z.string().optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: z.string().optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
       pages: z
         .array(z.string())
         .optional()
@@ -183,9 +204,25 @@ export function createServer(): McpServer {
             'Defaults to common pages (homepage, services, about, contact, portfolio, shop, blog, etc.)'
         ),
     },
-    async ({ siteUrl, pages }) => {
+    async ({ siteUrl, site, env, pages }) => {
       try {
-        const result = await runSchemaAudit(siteUrl, pages);
+        // Resolve siteUrl from site/env if provided
+        let targetUrl = siteUrl;
+        if (site && env) {
+          const registry = loadRegistry();
+          const entry = resolveSiteEnv(registry, site, env);
+          if (entry.url) {
+            targetUrl = entry.url;
+          } else {
+            throw new Error(`Site entry for "${site}"/"${env}" has no URL field. Use the "siteUrl" parameter instead.`);
+          }
+        }
+        
+        if (!targetUrl) {
+          throw new Error("Either provide 'siteUrl' or 'site' + 'env' parameters.");
+        }
+        
+        const result = await runSchemaAudit(targetUrl, pages);
         const lines: string[] = [
           `Schema Audit: ${result.pagesWithSchema}/${result.totalPages} pages have schema markup`,
           "",

--- a/mcp-server/src/tools/dbBackup.ts
+++ b/mcp-server/src/tools/dbBackup.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { gzip as gzipCallback } from "node:zlib";
 import type { EnvEntry } from "../registry.js";
-import { hasTrellisVm } from "../registry.js";
+import { hasTrellisVm, resolveWpBin, resolvePhpBin } from "../registry.js";
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
 
 const gzip = promisify(gzipCallback);
 
@@ -48,6 +52,10 @@ function exportSql(command: string, args: string[], cwd?: string): Promise<Buffe
 }
 
 export async function runDbBackup(entry: EnvEntry, site: string, env: string): Promise<BackupResult> {
+  const wpBin = resolveWpBin(entry);
+  const phpBin = resolvePhpBin(entry);
+  const wpCommand = phpBin ? [phpBin, wpBin] : [wpBin];
+  
   let sql: Buffer;
   // VM-first: a Trellis dev box keeps the DB in the VM, so `wp db export` must run there.
   if (hasTrellisVm(entry)) {
@@ -55,17 +63,18 @@ export async function runDbBackup(entry: EnvEntry, site: string, env: string): P
     // Export streams over the VM shell's stdout; nothing is written to disk in the VM.
     sql = await exportSql(
       "trellis",
-      ["vm", "shell", "--workdir", entry.vmWorkdir, "--", "wp", "db", "export", "-", `--path=${wpPath}`],
+      ["vm", "shell", "--workdir", entry.vmWorkdir, "--", ...wpCommand, "db", "export", "-", `--path=${wpPath}`],
       entry.trellisDir
     );
   } else if (entry.sshHost && entry.remotePath) {
     // Streams the export over SSH stdout so nothing is ever written to disk on the
     // remote host (same rationale as securityScan's remote path).
-    sql = await exportSql("ssh", [entry.sshHost, "wp", "db", "export", "-", `--path=${entry.remotePath}`]);
+    const remoteCommand = [...wpCommand, "db", "export", "-", `--path=${entry.remotePath}`].map(shellQuote).join(" ");
+    sql = await exportSql("ssh", [entry.sshHost, remoteCommand]);
   } else if (entry.localPath) {
-    sql = await exportSql("wp", ["db", "export", "-", `--path=${entry.localPath}`]);
+    sql = await exportSql(wpCommand[0], [...wpCommand.slice(1), "db", "export", "-", `--path=${entry.localPath}`]);
   } else {
-    throw new Error("Site/env entry has none of: trellisDir+vmWorkdir, sshHost+remotePath, or localPath.");
+    throw new Error("Site/env entry has none of: trellisDir+vmWorkdir, sshHost+remotePath, localPath, or url.");
   }
 
   const compressed = await gzip(sql);

--- a/mcp-server/src/tools/securityScan.ts
+++ b/mcp-server/src/tools/securityScan.ts
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { EnvEntry } from "../registry.js";
-import { hasTrellisVm } from "../registry.js";
+import { hasTrellisVm, resolvePhpBin } from "../registry.js";
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCANNER_DIR = path.resolve(__dirname, "../../../wp-cli/security");
@@ -21,9 +25,9 @@ interface ExecResult {
   code: number;
 }
 
-function runLocal(scannerFile: string, scanPath: string): Promise<ExecResult> {
+function runLocal(scannerFile: string, scanPath: string, phpBin: string): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("php", [scannerFile, scanPath]);
+    const child = spawn(phpBin, [scannerFile, scanPath]);
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => (stdout += d));
@@ -35,9 +39,9 @@ function runLocal(scannerFile: string, scanPath: string): Promise<ExecResult> {
 
 // Streams the scanner source over SSH stdin so nothing is ever written to disk
 // on the remote host (avoids the scp-to-/tmp-then-remember-to-delete step).
-function runRemote(sshHost: string, scannerSource: string, remotePath: string): Promise<ExecResult> {
+function runRemote(sshHost: string, scannerSource: string, remotePath: string, phpBin: string): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("ssh", [sshHost, "php", "-", remotePath]);
+    const child = spawn("ssh", [sshHost, `${shellQuote(phpBin)} - ${shellQuote(remotePath)}`]);
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => (stdout += d));
@@ -55,10 +59,11 @@ function runVm(
   trellisDir: string,
   scannerSource: string,
   workdir: string,
-  scanPath: string
+  scanPath: string,
+  phpBin: string
 ): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("trellis", ["vm", "shell", "--workdir", workdir, "--", "php", "-", scanPath], {
+    const child = spawn("trellis", ["vm", "shell", "--workdir", workdir, "--", phpBin, "-", scanPath], {
       cwd: trellisDir,
     });
     let stdout = "";
@@ -73,6 +78,7 @@ function runVm(
 }
 
 export async function runSecurityScan(entry: EnvEntry, mode: ScanMode): Promise<string> {
+  const phpBin = resolvePhpBin(entry) || "php";
   const modesToRun: Array<keyof typeof SCANNERS> = mode === "both" ? ["targeted", "general"] : [mode];
   const sections: string[] = [];
 
@@ -83,15 +89,15 @@ export async function runSecurityScan(entry: EnvEntry, mode: ScanMode): Promise<
     // Scanners read files (no DB), so prefer host localPath when present — it's the
     // fastest path and needs no VM/SSH round trip. Fall back to SSH, then the dev VM.
     if (entry.localPath) {
-      result = await runLocal(scannerFile, entry.localPath);
+      result = await runLocal(scannerFile, entry.localPath, phpBin);
     } else if (entry.sshHost && entry.remotePath) {
       const scannerSource = readFileSync(scannerFile, "utf-8");
-      result = await runRemote(entry.sshHost, scannerSource, entry.remotePath);
+      result = await runRemote(entry.sshHost, scannerSource, entry.remotePath, phpBin);
     } else if (hasTrellisVm(entry)) {
       const scannerSource = readFileSync(scannerFile, "utf-8");
-      result = await runVm(entry.trellisDir, scannerSource, entry.vmWorkdir, entry.vmPath ?? "web/wp");
+      result = await runVm(entry.trellisDir, scannerSource, entry.vmWorkdir, entry.vmPath ?? "web/wp", phpBin);
     } else {
-      throw new Error("Site/env entry has none of: localPath, sshHost+remotePath, or trellisDir+vmWorkdir.");
+      throw new Error("Site/env entry has none of: localPath, sshHost+remotePath, trellisDir+vmWorkdir, or url.");
     }
 
     sections.push(

--- a/mcp-server/src/tools/wpCli.ts
+++ b/mcp-server/src/tools/wpCli.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import type { EnvEntry } from "../registry.js";
-import { hasTrellisVm } from "../registry.js";
+import { hasTrellisVm, resolveWpBin, resolvePhpBin } from "../registry.js";
 
 interface ExecResult {
   stdout: string;
@@ -28,9 +28,10 @@ export function isReadOnlyWpCommand(args: string[]): boolean {
   return verb !== undefined && SAFE_READ_VERBS.has(verb);
 }
 
-function runLocal(args: string[], localPath: string): Promise<ExecResult> {
+function runLocal(args: string[], localPath: string, wpBin: string, phpBin?: string): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("wp", [...args, `--path=${localPath}`]);
+    const command = phpBin ? [phpBin, wpBin] : [wpBin];
+    const child = spawn(command[0], [...command.slice(1), ...args, `--path=${localPath}`]);
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", (d) => (stdout += d));
@@ -48,9 +49,10 @@ function shellQuote(arg: string): string {
   return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
-function runRemote(sshHost: string, args: string[], remotePath: string): Promise<ExecResult> {
+function runRemote(sshHost: string, args: string[], remotePath: string, wpBin: string, phpBin?: string): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const remoteCommand = ["wp", ...args, `--path=${remotePath}`].map(shellQuote).join(" ");
+    const wpCommand = phpBin ? [phpBin, wpBin] : [wpBin];
+    const remoteCommand = [...wpCommand, ...args, `--path=${remotePath}`].map(shellQuote).join(" ");
     const child = spawn("ssh", [sshHost, remoteCommand]);
     let stdout = "";
     let stderr = "";
@@ -65,11 +67,12 @@ function runRemote(sshHost: string, args: string[], remotePath: string): Promise
 // `trellis` must run from the Trellis project dir (it locates the project from cwd), so
 // we set cwd rather than relying on the caller's working directory. Tokens are passed as
 // separate argv after `--` (matching `trellis vm shell -- wp post list --path=web/wp`).
-function runVm(trellisDir: string, workdir: string, wpPath: string, args: string[]): Promise<ExecResult> {
+function runVm(trellisDir: string, workdir: string, wpPath: string, args: string[], wpBin: string, phpBin?: string): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
+    const wpCommand = phpBin ? [phpBin, wpBin] : [wpBin];
     const child = spawn(
       "trellis",
-      ["vm", "shell", "--workdir", workdir, "--", "wp", ...args, `--path=${wpPath}`],
+      ["vm", "shell", "--workdir", workdir, "--", ...wpCommand, ...args, `--path=${wpPath}`],
       { cwd: trellisDir }
     );
     let stdout = "";
@@ -82,17 +85,19 @@ function runVm(trellisDir: string, workdir: string, wpPath: string, args: string
 }
 
 export async function runWpCli(entry: EnvEntry, args: string[]): Promise<string> {
+  const wpBin = resolveWpBin(entry);
+  const phpBin = resolvePhpBin(entry);
   let result: ExecResult;
   // Order matters: a Trellis dev VM keeps the DB in the VM, so prefer the VM over
   // localPath when both are set — plain `wp` against the host can't reach the database.
   if (hasTrellisVm(entry)) {
-    result = await runVm(entry.trellisDir, entry.vmWorkdir, entry.vmPath ?? "web/wp", args);
+    result = await runVm(entry.trellisDir, entry.vmWorkdir, entry.vmPath ?? "web/wp", args, wpBin, phpBin);
   } else if (entry.sshHost && entry.remotePath) {
-    result = await runRemote(entry.sshHost, args, entry.remotePath);
+    result = await runRemote(entry.sshHost, args, entry.remotePath, wpBin, phpBin);
   } else if (entry.localPath) {
-    result = await runLocal(args, entry.localPath);
+    result = await runLocal(args, entry.localPath, wpBin, phpBin);
   } else {
-    throw new Error("Site/env entry has none of: trellisDir+vmWorkdir, sshHost+remotePath, or localPath.");
+    throw new Error("Site/env entry has none of: trellisDir+vmWorkdir, sshHost+remotePath, localPath, or url.");
   }
 
   // Nonzero exit isn't necessarily failure (e.g. `plugin is-active` returns 1 for


### PR DESCRIPTION
The MCP server registry gained explicit binary path configuration, allowing sites to specify custom WP-CLI and PHP executable locations instead of relying on system defaults, alongside expanded site/environment parameterization for the redirect and schema audit tools. This release (v3.1.0) extends the registry schema with `wpBin`, `phpBin`, and `url` fields, updates the core WP-CLI, database backup, and security scan tool implementations to consume these new paths, and documents the changes in the changelog. The updates improve compatibility with hosting environments that use non-standard PHP or WP-CLI installations, and bring audit tooling in line with the multi-site/multi-environment pattern already used elsewhere in the registry.

**Registry Schema and Configuration:**
- Added `wpBin`, `phpBin`, and `url` fields to the site registry schema in `registry.ts`, allowing per-site overrides of the WP-CLI binary, PHP binary, and canonical site URL.
- Updated `sites.example.json` to demonstrate the new configuration fields for reference when onboarding new sites.

**Tool Updates for Custom Binary Paths:**
- Modified `wpCli.ts`, `dbBackup.ts`, and `securityScan.ts` to resolve and use the configured `wpBin`/`phpBin` paths instead of assuming binaries are available on the default system `PATH`.
- Ensures WP-CLI and PHP-dependent operations (backups, security scans, general WP-CLI calls) work correctly on hosts with non-standard or version-specific binary locations.

**Audit Tool Parameterization:**
- Added `site` and `env` parameters to the `redirect_audit` and `schema_audit` tools in `server.ts`, aligning them with the site/environment targeting convention used by other registry-driven tools.
- Enables these audits to be run against specific registered sites and environments rather than requiring a single implicit context.

**Documentation:**
- Updated `CHANGELOG.md` to record the 3.1.0 release, summarizing the registry enhancements and tool updates.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/CHANGELOG.md) (Modified)
- [`mcp-server/config/sites.example.json`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/config/sites.example.json) (Modified)
- [`mcp-server/src/registry.ts`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/src/registry.ts) (Modified)
- [`mcp-server/src/server.ts`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/src/server.ts) (Modified)
- [`mcp-server/src/tools/dbBackup.ts`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/src/tools/dbBackup.ts) (Modified)
- [`mcp-server/src/tools/securityScan.ts`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/src/tools/securityScan.ts) (Modified)
- [`mcp-server/src/tools/wpCli.ts`](https://github.com/imagewize/wp-ops/blob/enhance/mcp-server-registry/mcp-server/src/tools/wpCli.ts) (Modified)