### PR TITLE
Feat/version Detection For Pr Description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2026-07-10
+
+### Changed
+
+- **scripts/create-pr.sh** - Reworked version detection so PR descriptions report the correct version reliably (previously AI backends, notably Mistral Vibe, frequently got the version wrong):
+  - `detect_version` is now **diff-based** - it inspects added lines in the branch diff rather than the current file contents, so it only reports a version that was genuinely introduced and always returns the new value. Editing `package.json`/`composer.json` for unrelated reasons no longer produces a false "bump" signal. A shared `added_version_line` helper replaces four near-duplicate extraction blocks.
+  - The detected version is now **injected into the PR body deterministically** (prepended as `**Version:** \`x.y.z\``) after the AI step, guaranteeing the correct version appears regardless of which AI backend generated the prose. The version is still passed to the prompt as narrative context.
+  - Generalized the WordPress plugin/theme header check from a hardcoded `min.php` filename to any changed `.php` file or a theme's `style.css`, matching an added `Version: x.y.z` header line - filename-agnostic and usable in any repo.
+  - Detection order is CHANGELOG → package.json → plugin/theme header → composer.json, all diff-based.
+
 ## [3.2.0] - 2026-07-09
 
 ### Added

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -326,7 +326,77 @@ detect_categories() {
     echo "$categories"
 }
 
+# Function to detect a version *bump* from the diff.
+#
+# Keying off the diff (added lines) rather than the current file content means
+# we only report a version when one was genuinely introduced in this branch.
+# Touching package.json/composer.json for an unrelated reason no longer produces
+# a false "bump" signal, and we always return the NEW value, not a stale one.
+detect_version() {
+    local version=""
+
+    # Grep the added lines for a given file, matching lines against $2.
+    added_version_line() {
+        local file="$1"
+        local line_pattern="$2"
+        git diff "$BASE_BRANCH".."$CURRENT_BRANCH" -- "$file" 2>/dev/null \
+            | grep -E '^\+' \
+            | grep -iE "$line_pattern" \
+            | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -1 || true
+    }
+
+    # Try CHANGELOG first (human-authoritative). Match added heading lines
+    # (## [1.3.1] or ## 1.3.1) so changelog body text can't be mistaken for the bump.
+    local changelog_files
+    changelog_files=$(echo "$CHANGED_FILES" | awk '{print $2}' | grep -i "CHANGELOG" || true)
+    for file in $changelog_files; do
+        version=$(added_version_line "$file" '^\+##[[:space:]]*\[?[0-9]+\.[0-9]+\.[0-9]+')
+        if [ -n "$version" ]; then
+            echo "$version"
+            return
+        fi
+    done
+
+    # Try package.json (added "version": "x.y.z" line)
+    local pkg_files
+    pkg_files=$(echo "$CHANGED_FILES" | awk '{print $2}' | grep -E "package\.json$" || true)
+    for file in $pkg_files; do
+        version=$(added_version_line "$file" '"version"[[:space:]]*:')
+        if [ -n "$version" ]; then
+            echo "$version"
+            return
+        fi
+    done
+
+    # Try WordPress plugin/theme headers: an added "Version: x.y.z" line in any
+    # changed .php file (plugin main file) or a theme's style.css. Diff-based and
+    # filename-agnostic, so it works in any repo rather than a specific plugin file.
+    local header_files
+    header_files=$(echo "$CHANGED_FILES" | awk '{print $2}' | grep -E '\.php$|(^|/)style\.css$' || true)
+    for file in $header_files; do
+        version=$(added_version_line "$file" 'Version:[[:space:]]*[0-9]')
+        if [ -n "$version" ]; then
+            echo "$version"
+            return
+        fi
+    done
+
+    # Try composer.json (added "version": "x.y.z" line)
+    local composer_files
+    composer_files=$(echo "$CHANGED_FILES" | awk '{print $2}' | grep -E "composer\.json$" || true)
+    for file in $composer_files; do
+        version=$(added_version_line "$file" '"version"[[:space:]]*:')
+        if [ -n "$version" ]; then
+            echo "$version"
+            return
+        fi
+    done
+
+    echo ""
+}
+
 CHANGE_CATEGORIES=$(detect_categories)
+VERSION_BUMP=$(detect_version)
 
 # Generate files changed section with clickable links grouped by status
 generate_file_list() {
@@ -497,6 +567,8 @@ CATEGORIES DETECTED: $CHANGE_CATEGORIES
 
 LOCK FILES UPDATED: $(echo "$LOCK_FILES" | awk '{print $2}' | xargs basename -a 2>/dev/null | tr '\n' ', ' | sed 's/, $//' || echo "none")
 
+${VERSION_BUMP:+VERSION BUMP: $VERSION_BUMP}
+
 Now provide ONLY the description content (no meta-commentary). Start directly with the summary paragraph."
 
     local ai_command ai_args=()
@@ -606,6 +678,14 @@ $COMMITS
 **Files Changed:**
 
 $FILES_SECTION"
+fi
+
+# Prepend the detected version deterministically so it is always correct,
+# regardless of whether (or how well) the AI backend surfaced it in the prose.
+if [ -n "$VERSION_BUMP" ]; then
+    PR_BODY="**Version:** \`$VERSION_BUMP\`
+
+$PR_BODY"
 fi
 
 # Create or update PR


### PR DESCRIPTION
**Version:** `3.2.1`

This pull request improves the reliability of automatic version detection in `scripts/create-pr.sh`, addressing a recurring problem where generated PR descriptions reported an incorrect version number (particularly with the Mistral Vibe AI backend). The core change reworks `detect_version` to be diff-based, inspecting the added lines of the branch diff rather than current file contents, so it only reports a version genuinely introduced by the branch and always returns the new value rather than a stale one. The detected version is now injected deterministically into the PR body after the AI step, guaranteeing correctness regardless of which backend generated the prose, while still being passed to the prompt as narrative context. The header-detection logic was also generalized from a hardcoded filename to any changed `.php` file or a theme's `style.css`, making the script usable across arbitrary WordPress repositories. This release is tagged as version 3.2.1.

**Version Detection Logic:**
- Reworked `detect_version` to key off added diff lines instead of file contents, so unrelated edits to `package.json` or `composer.json` no longer produce false "bump" signals and the newly introduced value is always returned.
- Introduced a shared `added_version_line` helper that consolidates four near-duplicate extraction blocks, matching added lines against a supplied pattern.
- Established a clear detection order — CHANGELOG, then `package.json`, then plugin/theme header, then `composer.json` — with CHANGELOG treated as human-authoritative and matched only on added heading lines to avoid mistaking body text for a version bump.

**Cross-Repository Compatibility:**
- Generalized the WordPress plugin/theme header check from the hardcoded `min.php` filename to any changed `.php` file or a theme's `style.css`, matching an added `Version: x.y.z` header line so the script works in any repository.

**PR Body Injection:**
- Prepended the detected version to the PR body as `**Version:** \`x.y.z\`` after AI generation, ensuring the correct version always appears independent of AI backend behavior.
- Retained passing the detected version to the AI prompt as a `VERSION BUMP` context hint for narrative use.

**Documentation:**
- Added a `[3.2.1] - 2026-07-10` entry to `CHANGELOG.md` documenting the diff-based detection rework, the deterministic body injection, and the generalized header matching.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/feat/version-detection-for-pr-description/CHANGELOG.md) (Modified)
- [`scripts/create-pr.sh`](https://github.com/imagewize/wp-ops/blob/feat/version-detection-for-pr-description/scripts/create-pr.sh) (Modified)