### PR TITLE
Update/trellis Updater Nginx Exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.2] - 2026-07-23
+
+### Changed
+
+- **trellis/updater/** - Added `roles/nginx/templates/nginx.conf.j2` to Trellis updater exclusions to protect custom Nginx rate limiting configuration from being overwritten during updates. Updated both rsync `--exclude` and `EXCLUDED_FILES` array, and documented in README.
+
 ## [3.2.1] - 2026-07-10
 
 ### Changed

--- a/trellis/updater/README.md
+++ b/trellis/updater/README.md
@@ -59,6 +59,7 @@ The updater script specifically preserves the following files/directories:
 
 ### Custom Nginx Configurations
 - `nginx-includes/` - Custom Nginx configs (SEO redirects, asset expiry, security rules)
+- `roles/nginx/templates/nginx.conf.j2` - Custom Nginx main config (rate limiting, etc.)
 
 ### Custom Documentation
 - `docs/` - Project-specific documentation
@@ -72,6 +73,7 @@ After upgrading, you should manually review and potentially merge changes from t
 1. **Role template changes** - Check if upstream changed any templates you've customized:
    - `roles/mariadb/templates/` - If you added custom MariaDB settings
    - `roles/wordpress-setup/templates/` - If you modified PHP-FPM pool templates
+   - `roles/nginx/templates/nginx.conf.j2` - If you customized rate limiting or other Nginx settings
 
 2. **New variables** - Check upstream `main.yml` files for new useful variables you may want to adopt
 

--- a/trellis/updater/trellis-updater.sh
+++ b/trellis/updater/trellis-updater.sh
@@ -71,6 +71,7 @@ echo "=== Syncing Trellis updates while preserving custom configurations ==="
 #   - Custom Nginx configs (nginx-includes/)
 #   - Custom documentation (docs/, CHANGELOG.md)
 #   - Custom role templates (php-fpm-pool with request_terminate_timeout)
+#   - Custom Nginx config (nginx.conf.j2 with rate limiting zone)
 rsync -av --delete \
   --exclude=".vault_pass" \
   --exclude="ansible.cfg" \
@@ -106,6 +107,7 @@ rsync -av --delete \
   --exclude="CHANGELOG.md" \
   --exclude="CHANGELOG-TRELLIS-DATABASE-UPLOADS-MIGRATION.md" \
   --exclude="roles/wordpress-setup/templates/php-fpm-pool-wordpress.conf.j2" \
+  --exclude="roles/nginx/templates/nginx.conf.j2" \
   $TEMP_DIR/trellis/ $TRELLIS_DIR/
 
 echo "✓ Trellis files updated"
@@ -126,6 +128,7 @@ EXCLUDED_FILES=(
   "group_vars/production/wordpress_sites.yml"
   "group_vars/staging/wordpress_sites.yml"
   "roles/wordpress-setup/templates/php-fpm-pool-wordpress.conf.j2"
+  "roles/nginx/templates/nginx.conf.j2"
 )
 
 UPSTREAM_CHANGES_DIR=$DIFF_DIR/excluded-file-diffs


### PR DESCRIPTION
**Version:** `3.2.2`

This PR introduces version 3.2.2, which adds `nginx.conf.j2` to the Trellis updater's exclusion list. This change prevents the automated updater from overwriting custom Nginx Jinja2 template configurations during Trellis framework updates. The modification ensures that server-specific Nginx templates, which often contain essential custom configurations, remain intact. Both the updater script and its accompanying documentation have been updated to reflect this change. The CHANGELOG.md entry for v3.2.2 documents this specific enhancement.

**Trellis Updater Improvements:**
- Added `nginx.conf.j2` to the exclusion array in `trellis-updater.sh` to prevent overwriting of custom Nginx template files during update operations
- This preserves server-specific configurations that should not be replaced by upstream Trellis defaults

**Documentation:**
- Updated `trellis/updater/README.md` to document the new exclusion and its purpose
- Added v3.2.2 entry to `CHANGELOG.md` detailing the nginx.conf.j2 exclusion change

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/update/trellis-updater-nginx-exclude/CHANGELOG.md) (Modified)
- [`trellis/updater/README.md`](https://github.com/imagewize/wp-ops/blob/update/trellis-updater-nginx-exclude/trellis/updater/README.md) (Modified)
- [`trellis/updater/trellis-updater.sh`](https://github.com/imagewize/wp-ops/blob/update/trellis-updater-nginx-exclude/trellis/updater/trellis-updater.sh) (Modified)