### PR TITLE
Add rsync-package-to-site.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-07-23
+
+### Added
+
+- **scripts/rsync-package-to-site.sh** - Pushes a plugin or theme working copy *into* a Bedrock site, so unreleased changes can be tested on a real site without cutting a release. The reverse direction of `rsync-theme.sh`, which pulls a theme out of a Trellis site back into its standalone repo.
+  - Reads the package's own `.distignore` when present, so what reaches the site is what ships. `--delete-excluded` means a file that used to ship and is now excluded is removed at the destination too, rather than lingering and being tested after it is gone. Falls back to a sensible exclude list (`node_modules/`, `vendor/`, `.git/`, `.github/`, `docs/`, `tests/`, `bin/`, `*.sh`, editor cruft) for packages without one.
+  - Takes `<plugin|theme> <slug> [source-dir]` and reads the destination from `SITE_ROOT` (the Bedrock content directory holding `plugins/` and `themes/`), defaulting to the `example.com` layout used throughout this repo. Echoes the version that landed, so a no-op sync is obvious.
+  - Consolidates per-repo copies that had accumulated in the Aludra plugin and Aviendha theme as `bin/sync-demo.sh`. Those are being removed in favour of this one: their paths were personal configuration rather than package code, and WordPress Theme Check's `File_Check` rejects a theme that ships a `.sh` file at all — which is how the duplication surfaced.
+  - Complements rather than replaces the Composer `path` repository approach in `bedrock/local-package-development/`: that one suits a package you want Composer to resolve, this one a *pinned* dependency whose site `composer.json` you would rather leave alone.
+
 ## [3.2.2] - 2026-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Standalone Bash/PHP utilities — see [scripts/README.md](scripts/README.md) for
 | **WebP Convert** | JPG→WebP at the Facebook OG ratio with center crop | [→](scripts/README.md#convert-to-webpsh) |
 | **Product Variations** | Bulk-create WooCommerce product variations via WP-CLI | [→](scripts/woocommerce/create-product-variations.sh) |
 | **Theme Sync** | Rsync a theme between Trellis and a standalone repo | [→](scripts/rsync-theme.sh) |
+| **Package → Site Sync** | Push a plugin/theme working copy into a Bedrock site to test unreleased changes | [→](scripts/README.md#rsync-package-to-sitesh) |
 | **Find & Replace** | Batch find and replace files across directory trees | [→](scripts/find-and-replace-files.sh) |
 | **Git Log Oneline** | Show recent git commits as compact one-liners | [→](scripts/README.md#git-log-onelinesh) |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,6 +45,7 @@ scripts/
 ├── post-count.sh               # Count published blog posts by year/month (blog posts only)
 ├── release-plugin.sh           # WordPress plugin version release automation
 ├── release-theme.sh            # WordPress theme version release automation
+├── rsync-package-to-site.sh   # Push a plugin/theme working copy into a Bedrock site
 └── rsync-theme.sh             # Theme file synchronization utility
 ```
 
@@ -954,6 +955,69 @@ DESTINATION="$HOME/code/elayne/"
 - Prepare theme for WordPress.org submission
 - Backup theme to separate repository
 - Development workflow: edit in Trellis, sync to standalone for distribution
+
+---
+
+### rsync-package-to-site.sh
+
+The **reverse direction** of `rsync-theme.sh`: pushes a plugin or theme working
+copy *into* a Bedrock site, so unreleased changes can be tested on a real site
+without cutting a release. Use it when the package repo is the source of truth
+and the site is disposable.
+
+Keep this script here rather than committing a copy into each package repo — the
+paths are personal configuration, and WordPress Theme Check's `File_Check`
+rejects a theme that ships a `.sh` file at all.
+
+#### Features
+
+- **Dist-faithful**: reads the package's own `.distignore` when present, so a file
+  excluded from the release zip never reaches the site — what you test is what ships
+- **`--delete-excluded`**: a file that used to ship and is now excluded is removed
+  at the destination too, rather than lingering and being tested after it is gone
+- **Version echo**: prints the version that landed (theme `style.css` header, or the
+  plugin's main-file header), making a no-op sync obvious
+- **Fallback excludes** for packages without a `.distignore` (`node_modules/`,
+  `vendor/`, `.git/`, `.github/`, `docs/`, `tests/`, `bin/`, `*.sh`, editor cruft)
+
+#### Configuration
+
+`SITE_ROOT` is the Bedrock content directory — the one holding `plugins/` and
+`themes/` (`web/app` in a stock Bedrock install). Set it per invocation or in your
+shell profile:
+
+```bash
+export SITE_ROOT="$HOME/code/example.com/demo/web/app"
+```
+
+#### Usage
+
+```bash
+# From inside the package repo
+./rsync-package-to-site.sh plugin my-plugin
+
+# Or point at it explicitly
+./rsync-package-to-site.sh theme my-theme ~/code/my-theme
+
+# One-off destination
+SITE_ROOT=~/code/example.com/staging/web/app \
+  ./rsync-package-to-site.sh theme my-theme
+```
+
+#### Use Cases
+
+- Test a plugin/theme branch on a real site before tagging a release
+- Verify a release zip's contents in situ, since the sync honours `.distignore`
+- Refresh a demo site after every local change, without touching its `composer.json`
+
+#### Alternative
+
+A Composer `path` repository (see
+[bedrock/local-package-development](../bedrock/local-package-development/README.md))
+is the better fit when you want Composer itself to resolve the package and you are
+happy editing the site's `composer.json`. This script suits a *pinned* dependency
+you would rather leave alone. Either way, `composer update vendor/package` on the
+site restores the released code.
 
 ---
 

--- a/scripts/rsync-package-to-site.sh
+++ b/scripts/rsync-package-to-site.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Sync a plugin/theme working copy INTO a Bedrock site, so unreleased changes can
+# be tested on a real site without cutting a release.
+#
+# This is the reverse direction of scripts/rsync-theme.sh, which pulls a theme
+# out of a Trellis site back into its standalone repo. Use this one when the
+# package repo is the source of truth and the site is disposable.
+#
+# Why not a Composer `path` repository? That approach (see
+# bedrock/local-package-development/README.md) is better when you want Composer
+# itself to resolve the package and you are happy editing the site's
+# composer.json. This script is better when the package is a *pinned* dependency
+# you would rather not touch, and you want a dist-faithful copy on disk in one
+# command. A `composer update <vendor/package>` on the site restores the released
+# code either way.
+#
+# The rsync mirrors .distignore when the package has one, so what you test is
+# what ships — a file excluded from the release zip never reaches the site.
+#
+# Usage:
+#   rsync-package-to-site.sh <plugin|theme> <package-slug> [source-dir]
+#
+# Examples:
+#   rsync-package-to-site.sh plugin my-plugin              # cwd is the package repo
+#   rsync-package-to-site.sh theme  my-theme ~/code/my-theme
+#
+# Configure the destination once, in your shell profile or per invocation:
+#   SITE_ROOT=~/code/example.com/demo/web/app rsync-package-to-site.sh theme my-theme
+#
+# SITE_ROOT is the Bedrock content directory — the one holding plugins/ and
+# themes/ (web/app in a stock Bedrock install, wp-content elsewhere).
+
+set -euo pipefail
+
+usage() {
+	sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
+	exit "${1:-1}"
+}
+
+[ $# -ge 2 ] || usage 1
+case "$1" in -h|--help) usage 0 ;; esac
+
+kind="$1"
+slug="$2"
+src="${3:-$PWD}"
+
+case "$kind" in
+	plugin) dir="plugins" ;;
+	theme)  dir="themes" ;;
+	*) echo "✗ first argument must be 'plugin' or 'theme', got '$kind'" >&2; exit 1 ;;
+esac
+
+# Default to the conventional local Trellis/Bedrock layout. Override for your own.
+SITE_ROOT="${SITE_ROOT:-$HOME/code/example.com/demo/web/app}"
+
+src="$(cd "$src" && pwd)"
+dest="$SITE_ROOT/$dir/$slug"
+
+[ -d "$src" ] || { echo "✗ source $src not found" >&2; exit 1; }
+[ -d "$dest" ] || {
+	echo "✗ $dest not found — is the package installed on that site?" >&2
+	echo "  Set SITE_ROOT to the Bedrock content directory (the one holding plugins/ and themes/)." >&2
+	exit 1
+}
+
+# Never push development-only files onto a site. A package's own .distignore is
+# the authoritative list when it has one; the fallback covers the usual suspects
+# so this still does the right thing for a package without one.
+excludes=(
+	--exclude '.git/'
+	--exclude '.github/'
+	--exclude '.claude/'
+	--exclude '.vscode/'
+	--exclude '.idea/'
+	--exclude 'node_modules/'
+	--exclude 'vendor/'
+	--exclude 'docs/'
+	--exclude 'tests/'
+	--exclude 'bin/'
+	--exclude '*.sh'
+	--exclude '.gitignore'
+	--exclude '.gitattributes'
+	--exclude '.distignore'
+	--exclude '.editorconfig'
+	--exclude '.DS_Store'
+)
+if [ -f "$src/.distignore" ]; then
+	excludes+=( --exclude-from "$src/.distignore" )
+fi
+
+# --delete-excluded matters: without it, a file that used to ship and is now
+# excluded lingers at the destination and you test something that no longer
+# exists in the release.
+rsync -a --delete --delete-excluded "${excludes[@]}" "$src/" "$dest/"
+
+# Report the version that landed, so it is obvious when a sync silently no-ops.
+if [ "$kind" = "theme" ] && [ -f "$dest/style.css" ]; then
+	version=$(grep -m1 -i '^[[:space:]]*\*\{0,1\}[[:space:]]*Version:' "$dest/style.css" | tr -d ' *')
+else
+	version=$(grep -rm1 -i '^[[:space:]]*\*[[:space:]]*Version:' "$dest"/*.php 2>/dev/null | sed 's/.*://' | tr -d ' ')
+	version="${version:+Version:$version}"
+fi
+
+echo "✓ $slug → $dest ${version:+($version)}"


### PR DESCRIPTION
Pushes a plugin/theme working copy into a Bedrock site so unreleased changes can be tested without cutting a release — the reverse direction of rsync-theme.sh.

Consolidates copies that had accumulated in the Aludra plugin and Aviendha theme as bin/sync-demo.sh. Their paths were personal config rather than package code, and Theme Check's File_Check rejects a theme shipping a .sh file at all, which is how the duplication surfaced.

Honours the package's own .distignore, so what reaches the site is what ships.