### PR TITLE
Add --dry-run to rsync sync scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2026-07-23
+
+### Added
+
+- **scripts/rsync-theme.sh**, **scripts/rsync-package-to-site.sh** - Added `-n` / `--dry-run` to both sync scripts. Both run rsync with `--delete` (plus `--delete-excluded` in `rsync-package-to-site.sh`), so a mistaken invocation can remove files at the destination; `--dry-run` prints the full transfer, deletions included, and writes nothing.
+
+### Fixed
+
+- **scripts/rsync-theme.sh** - Unknown arguments are now rejected instead of silently ignored. The script previously hardcoded its rsync invocation and dropped anything passed to it, so `./rsync-theme.sh --dry-run` looked like a preview but performed a real sync — which is what prompted adding the flag.
+
+### Changed
+
+- **scripts/rsync-theme.sh** - Source and destination are now `SOURCE` / `DEST` variables overridable per invocation (`SOURCE=… DEST=… ./rsync-theme.sh -n`) rather than requiring an edit to the script. Added `-h` / `--help`, and switched to `#!/usr/bin/env bash` with `set -euo pipefail` to match `rsync-package-to-site.sh`. Corrected the README's stale `DESTINATION` variable name and its `(28 lines)` heading.
+
 ## [3.3.0] - 2026-07-23
 
 ### Added

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -915,7 +915,7 @@ export OPENAI_API_KEY="your-key-here"
 
 ---
 
-### rsync-theme.sh (28 lines)
+### rsync-theme.sh
 
 Simple rsync wrapper for theme synchronization between Trellis and standalone repositories.
 
@@ -923,6 +923,8 @@ Simple rsync wrapper for theme synchronization between Trellis and standalone re
 
 - **Archive Mode**: Preserves timestamps, permissions, ownership
 - **Selective Deletion**: Removes destination files not in source
+- **Dry Run**: `--dry-run` previews the transfer — including deletions — without
+  writing anything
 - **Exclude Filters**:
   - `node_modules/`, `vendor/` (dependencies)
   - `.git/`, `.github/` (version control)
@@ -930,24 +932,36 @@ Simple rsync wrapper for theme synchronization between Trellis and standalone re
 
 #### Configuration
 
-Edit script with your paths:
+Edit the defaults at the top of the script, or override them per invocation:
 
 ```bash
 SOURCE="$HOME/code/example.com/demo/web/app/themes/elayne/"
-DESTINATION="$HOME/code/elayne/"
+DEST="$HOME/code/elayne/"
 ```
 
 #### Usage
 
 ```bash
+# Preview first — --delete means anything at the destination that is not in the
+# source is removed
+./rsync-theme.sh --dry-run
+
 # Run synchronization
 ./rsync-theme.sh
+
+# One-off paths
+SOURCE=~/code/example.com/site/web/app/themes/my-theme/ \
+  DEST=~/code/my-theme/ ./rsync-theme.sh -n
 
 # Output shows:
 # - Files sent/received
 # - Total size transferred
 # - Speedup achieved
 ```
+
+Unknown options are rejected rather than ignored — the script previously passed
+over any argument it did not recognize, so a mistyped `--dry-run` ran the sync
+for real.
 
 #### Use Cases
 
@@ -973,6 +987,8 @@ rejects a theme that ships a `.sh` file at all.
 
 - **Dist-faithful**: reads the package's own `.distignore` when present, so a file
   excluded from the release zip never reaches the site — what you test is what ships
+- **Dry Run**: `--dry-run` previews the transfer — including deletions — without
+  writing anything
 - **`--delete-excluded`**: a file that used to ship and is now excluded is removed
   at the destination too, rather than lingering and being tested after it is gone
 - **Version echo**: prints the version that landed (theme `style.css` header, or the
@@ -993,6 +1009,9 @@ export SITE_ROOT="$HOME/code/example.com/demo/web/app"
 #### Usage
 
 ```bash
+# Preview first — the sync runs with --delete --delete-excluded
+./rsync-package-to-site.sh --dry-run plugin my-plugin
+
 # From inside the package repo
 ./rsync-package-to-site.sh plugin my-plugin
 

--- a/scripts/rsync-package-to-site.sh
+++ b/scripts/rsync-package-to-site.sh
@@ -18,12 +18,16 @@
 # The rsync mirrors .distignore when the package has one, so what you test is
 # what ships — a file excluded from the release zip never reaches the site.
 #
+# The sync runs with --delete --delete-excluded, so it can remove files at the
+# destination. Pass --dry-run to see exactly what would change without writing.
+#
 # Usage:
-#   rsync-package-to-site.sh <plugin|theme> <package-slug> [source-dir]
+#   rsync-package-to-site.sh [-n|--dry-run] <plugin|theme> <package-slug> [source-dir]
 #
 # Examples:
 #   rsync-package-to-site.sh plugin my-plugin              # cwd is the package repo
 #   rsync-package-to-site.sh theme  my-theme ~/code/my-theme
+#   rsync-package-to-site.sh -n theme my-theme             # preview only
 #
 # Configure the destination once, in your shell profile or per invocation:
 #   SITE_ROOT=~/code/example.com/demo/web/app rsync-package-to-site.sh theme my-theme
@@ -34,12 +38,23 @@
 set -euo pipefail
 
 usage() {
-	sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
+	sed -n '2,36p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
 	exit "${1:-1}"
 }
 
+# Flags first, so the positional arguments below keep their existing meaning.
+dry_run=false
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-n|--dry-run) dry_run=true; shift ;;
+		-h|--help) usage 0 ;;
+		--) shift; break ;;
+		-*) echo "✗ unknown option '$1'" >&2; echo >&2; usage 1 ;;
+		*) break ;;
+	esac
+done
+
 [ $# -ge 2 ] || usage 1
-case "$1" in -h|--help) usage 0 ;; esac
 
 kind="$1"
 slug="$2"
@@ -92,7 +107,19 @@ fi
 # --delete-excluded matters: without it, a file that used to ship and is now
 # excluded lingers at the destination and you test something that no longer
 # exists in the release.
-rsync -a --delete --delete-excluded "${excludes[@]}" "$src/" "$dest/"
+rsync_args=(-a --delete --delete-excluded)
+if [ "$dry_run" = true ]; then
+	# -v as well: a silent dry run would print nothing at all.
+	rsync_args+=(--dry-run -v)
+fi
+
+rsync "${rsync_args[@]}" "${excludes[@]}" "$src/" "$dest/"
+
+if [ "$dry_run" = true ]; then
+	echo
+	echo "Dry run — nothing was written. Re-run without --dry-run to apply."
+	exit 0
+fi
 
 # Report the version that landed, so it is obvious when a sync silently no-ops.
 if [ "$kind" = "theme" ] && [ -f "$dest/style.css" ]; then

--- a/scripts/rsync-theme.sh
+++ b/scripts/rsync-theme.sh
@@ -1,28 +1,68 @@
-#!/bin/bash
-
-# Sync theme files from Trellis project to standalone theme repository
+#!/usr/bin/env bash
 #
-# This script uses rsync to synchronize theme files from your Trellis site
-# to a separate theme repository, useful for theme development workflow.
+# Sync theme files from a Trellis project to a standalone theme repository.
+#
+# Useful for a theme development workflow where the theme is edited inside a
+# working site but released from its own repo.
 #
 # How it works:
 # - rsync -av: Archive mode (preserves permissions, timestamps) with verbose output
 # - --delete: Removes files in destination that don't exist in source
 # - --exclude: Skips syncing specific directories (dependencies, git files)
 #
-# Customize the paths below for your setup:
-# - Source: Your theme location within the Trellis project
-# - Destination: Your standalone theme repository
+# --delete makes this destructive: anything at the destination that is not in
+# the source is removed. Run --dry-run first when you are not certain the
+# destination is clean — it prints exactly what would change and writes nothing.
 #
-# Example theme name used: 'nynaeve' - replace with your actual theme name
+# Usage:
+#   rsync-theme.sh [-n|--dry-run] [-h|--help]
+#
+# Customize the paths below for your setup:
+# - SOURCE: Your theme location within the Trellis project
+# - DEST:   Your standalone theme repository
+#
+# Both can be overridden per invocation without editing the script:
+#   SOURCE=~/code/example.com/site/web/app/themes/my-theme DEST=~/code/my-theme rsync-theme.sh -n
+#
+# Example theme name used: 'elayne' - replace with your actual theme name
 
-rsync -av --delete \
-  --exclude create-pr.sh \
-  --exclude .distignore \
-  --exclude 'node_modules/' \
-  --exclude 'vendor/' \
-  --exclude '.git/' \
-  --exclude '.github/' \
-  ~/code/example.com/demo/web/app/themes/elayne/ \
-  ~/code/elayne/
-  
+set -euo pipefail
+
+# Trailing slashes matter to rsync: "src/" copies the *contents* of src.
+SOURCE="${SOURCE:-$HOME/code/example.com/demo/web/app/themes/elayne/}"
+DEST="${DEST:-$HOME/code/elayne/}"
+
+usage() {
+	sed -n '2,27p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
+	exit "${1:-1}"
+}
+
+dry_run=false
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-n|--dry-run) dry_run=true ;;
+		-h|--help) usage 0 ;;
+		*) echo "✗ unknown option '$1'" >&2; echo >&2; usage 1 ;;
+	esac
+	shift
+done
+
+# Built as an array so --dry-run can be added conditionally. Anything not passed
+# here is silently ignored, which is why unknown options are rejected above.
+args=(-av --delete)
+[ "$dry_run" = true ] && args+=(--dry-run)
+args+=(
+	--exclude create-pr.sh
+	--exclude .distignore
+	--exclude 'node_modules/'
+	--exclude 'vendor/'
+	--exclude '.git/'
+	--exclude '.github/'
+)
+
+rsync "${args[@]}" "$SOURCE" "$DEST"
+
+if [ "$dry_run" = true ]; then
+	echo
+	echo "Dry run — nothing was written. Re-run without --dry-run to apply."
+fi


### PR DESCRIPTION
**Version:** `3.3.1`

Adds a `-n` / `--dry-run` flag to both rsync sync scripts (`rsync-theme.sh` and `rsync-package-to-site.sh`), released as version 3.3.1. Both scripts run rsync with `--delete` — and `rsync-package-to-site.sh` additionally with `--delete-excluded` — meaning a mistaken invocation silently removes files at the destination that are not present in the source. The new flag prints the complete transfer, deletions included, and writes nothing, followed by an explicit "nothing was written" notice so a preview is never mistaken for a completed sync. The change also fixes a latent hazard in `rsync-theme.sh`, which hardcoded its rsync invocation and discarded any argument passed to it: `./rsync-theme.sh --dry-run` previously looked like a preview but performed a real, destructive sync. Alongside the flag, `rsync-theme.sh` is brought in line with the conventions already used by `rsync-package-to-site.sh`.

**Dry-Run Support:**

- Added `-n` / `--dry-run` to both scripts, with the rsync invocation built as an array so the flag can be appended conditionally rather than duplicating the command.
- In `rsync-package-to-site.sh`, the dry run also adds `-v`, since the script otherwise runs rsync in archive mode without verbose output and a preview would print nothing at all.
- Flag parsing in `rsync-package-to-site.sh` is handled in a leading loop, preserving the existing meaning of the `<plugin|theme> <package-slug> [source-dir]` positional arguments and honoring `--` as an end-of-options marker.

**rsync-theme.sh Hardening:**

- Unknown options are now rejected with a non-zero exit and usage output instead of being silently ignored, closing the failure mode where a mistyped or unsupported flag ran the sync for real.
- Source and destination are now `SOURCE` / `DEST` environment-overridable variables, so one-off paths no longer require editing the script.
- Switched to `#!/usr/bin/env bash` with `set -euo pipefail` and added `-h` / `--help`, matching the structure of `rsync-package-to-site.sh`.

**Documentation:**

- `scripts/README.md` documents the dry-run flag for both scripts, leads the usage examples with a preview invocation, and notes the argument-rejection behavior and its rationale.
- Corrected the stale `DESTINATION` variable name to `DEST` and removed the outdated `(28 lines)` heading suffix from the `rsync-theme.sh` section.
- `CHANGELOG.md` records 3.3.1 with the flag under Added, the silently-ignored-arguments bug under Fixed, and the variable and shell-convention updates under Changed.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/feat/rsync-dry-run/CHANGELOG.md) (Modified)
- [`scripts/README.md`](https://github.com/imagewize/wp-ops/blob/feat/rsync-dry-run/scripts/README.md) (Modified)
- [`scripts/rsync-package-to-site.sh`](https://github.com/imagewize/wp-ops/blob/feat/rsync-dry-run/scripts/rsync-package-to-site.sh) (Modified)
- [`scripts/rsync-theme.sh`](https://github.com/imagewize/wp-ops/blob/feat/rsync-dry-run/scripts/rsync-theme.sh) (Modified)