### PR TITLE
Add safety checks and a dry run to create-pr.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-07-23
+
+### Added
+
+- **scripts/create-pr.sh** - Added `--dry-run` flag that generates the PR description and prints it without pushing to GitHub or touching the remote repository.
+
+### Changed
+
+- **scripts/create-pr.sh** - Added safety checks before PR creation:
+  - Warns when there are uncommitted changes (local modifications or staged but uncommitted changes) that won't be included in the PR
+  - Interactive prompt to continue or cancel when uncommitted changes are detected
+  - Enhanced branch push logic: now checks if branch exists remotely AND if there are new commits to push, then pushes accordingly
+- **scripts/create-pr.sh** - Updated AI prompt requirements to explicitly prohibit mentioning AI assistants or adding generated-by/co-authored-by footers in PR descriptions.
+
 ## [3.3.1] - 2026-07-23
 
 ### Added

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -10,6 +10,7 @@
 #   --no-ai              Skip AI-powered description generation (faster but less detailed)
 #   --no-interactive     Skip all prompts, use defaults/arguments
 #   --update             Update existing PR description for current branch
+#   --dry-run            Print the generated body and exit without touching GitHub
 
 set -e
 
@@ -27,6 +28,7 @@ Options:
   --no-ai              Skip AI description generation
   --no-interactive     Skip all interactive prompts
   --update             Update existing PR for current branch
+  --dry-run            Print the generated body and exit without touching GitHub
 
 Arguments:
   [base-branch]        Target branch for PR (default: main)
@@ -36,6 +38,7 @@ Examples:
   ./create-pr.sh --ai=vibe
   ./create-pr.sh main "Add new feature" --no-ai
   ./create-pr.sh --update --ai=claude
+  ./create-pr.sh --dry-run
 EOF
     exit 0
 }
@@ -44,6 +47,7 @@ EOF
 USE_AI=""
 INTERACTIVE=true
 UPDATE_MODE=false
+DRY_RUN=false
 AI_TOOL="claude"
 AI_TOOL_SPECIFIED=false
 ARGS=()
@@ -60,6 +64,9 @@ while [ $# -gt 0 ]; do
         ;;
     --update)
         UPDATE_MODE=true
+        ;;
+    --dry-run)
+        DRY_RUN=true
         ;;
     --ai=*)
         AI_TOOL="${1#--ai=}"
@@ -226,11 +233,44 @@ if [ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]; then
     exit 1
 fi
 
-# Check if branch is pushed to remote
-if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" > /dev/null 2>&1; then
+# Warn about work that won't be in the PR. The description is generated from
+# commits, so uncommitted changes produce a PR that describes more than it ships.
+DIRTY=false
+git diff --quiet || DIRTY=true
+git diff --cached --quiet || DIRTY=true
+if [ "$DIRTY" = true ]; then
+    echo "⚠️  You have uncommitted changes. They will not be part of this PR:"
+    git status --short
+    echo ""
+    if [ "$INTERACTIVE" = true ]; then
+        read -p "Continue anyway? (y/N): " confirm_dirty
+        if [[ ! "$confirm_dirty" =~ ^[Yy]$ ]]; then
+            echo "Cancelled."
+            exit 0
+        fi
+        echo ""
+    fi
+fi
+
+# Push the branch. Checking only whether the remote branch *exists* isn't enough:
+# on a branch that was pushed earlier, later commits would stay local and the
+# generated description would cover work GitHub doesn't have. This matters most
+# in --update mode, which is exactly the "I added commits" case.
+#
+# A dry run touches nothing remote, so it skips this entirely.
+if [ "$DRY_RUN" = true ]; then
+    :
+elif ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" > /dev/null 2>&1; then
     echo "Branch '$CURRENT_BRANCH' is not pushed to remote."
     echo "Pushing to origin..."
     git push -u origin "$CURRENT_BRANCH"
+else
+    AHEAD=$(git rev-list --count "@{upstream}..HEAD" 2>/dev/null || echo "0")
+    if [ "$AHEAD" -gt 0 ]; then
+        echo "Branch '$CURRENT_BRANCH' is $AHEAD commit(s) ahead of its remote."
+        echo "Pushing to origin..."
+        git push origin "$CURRENT_BRANCH"
+    fi
 fi
 
 # Get the GitHub repository URL for file links
@@ -553,6 +593,8 @@ REQUIREMENTS:
 - Use professional technical writing - NO emoticons, NO casual language
 - Focus on the most important changes first
 - Keep each bullet point to 1-2 sentences maximum
+- Describe the change, never the tooling: do NOT mention Claude, Codex, AI or any
+  assistant, and do NOT append a generated-by / co-authored-by footer of any kind
 
 CHANGED FILES (excluding lock files):
 $CHANGED_FILES_NO_LOCKS
@@ -686,6 +728,21 @@ if [ -n "$VERSION_BUMP" ]; then
     PR_BODY="**Version:** \`$VERSION_BUMP\`
 
 $PR_BODY"
+fi
+
+# A dry run stops here: the body is the thing worth reviewing, and generating it
+# is the expensive part, so print it and leave GitHub alone.
+if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "🔍 Dry run — nothing was pushed or sent to GitHub."
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Title: ${PR_TITLE:-<unchanged>}"
+    echo "Base:  $BASE_BRANCH"
+    echo "Head:  $CURRENT_BRANCH"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "$PR_BODY"
+    exit 0
 fi
 
 # Create or update PR


### PR DESCRIPTION
Hardens `scripts/create-pr.sh` against three ways the script could produce a pull request that misrepresents the branch it describes. The push logic previously checked only whether the remote branch existed, so any commits added after the initial push stayed local while the generated description still covered them — a mismatch that surfaced most often in `--update` mode, which is precisely the "I added more commits" workflow. The script now compares the branch against its upstream with `git rev-list --count @{upstream}..HEAD` and pushes whenever it is ahead, warns about uncommitted work before the description is built, and adds a `--dry-run` flag that prints the generated body without contacting GitHub. The AI prompt template was also amended to forbid assistant attribution and generated-by footers in the output, aligning generated descriptions with the repository's commit and PR conventions.

**Push and Working-Tree Safety Checks:**

- Replaced the remote-branch-existence check with an upstream comparison so that a branch already on origin still gets its newer commits pushed before the PR is created or updated, keeping the GitHub diff consistent with the generated description.
- Added a dirty-working-tree check using `git diff` and `git diff --cached` that lists uncommitted files via `git status --short` and, in interactive mode, requires confirmation before continuing; non-interactive runs print the warning without blocking automation.

**Dry-Run Mode:**

- Added a `--dry-run` flag that generates the description and prints it along with the resolved title, base, and head branches, then exits before any `gh` invocation.
- Dry runs skip the push step entirely, making the flag safe for previewing a description on a branch the user is not ready to publish.

**Prompt and Documentation Updates:**

- Extended the AI prompt requirements to explicitly prohibit mentioning any assistant tooling and to prohibit generated-by or co-authored-by footers, so descriptions no longer need manual cleanup before submission.
- Documented `--dry-run` in the script header comment, the `--help` output, and the usage examples alongside the existing flags.

**Files Changed:**

- [`scripts/create-pr.sh`](https://github.com/imagewize/wp-ops/blob/feat/create-pr-safety-checks/scripts/create-pr.sh) (Modified)