### PR TITLE
Fix release script changelog JSON parsing (v3.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - 2026-07-25
+
+### Fixed
+
+- **scripts/release-theme.sh**, **scripts/release-plugin.sh** - Fixed changelog extraction leaving a trailing `",` (or `"`) artifact appended to every generated entry. The awk parser assumed both JSON keys sat on a single line; when the AI pretty-prints its response (one key per line), each value's closing quote lands at the end of its own line and the greedy `","readme_txt".*` / `"}$` patterns never matched. Both scripts now parse the response with `jq` (already required by `create-pr.sh`) and fall back to a hardened awk extractor that strips a closing quote optionally followed by `,` or `}` at end of line.
+
 ## [3.3.2] - 2026-07-23
 
 ### Added

--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -263,10 +263,40 @@ if [ -z "$CHANGELOG_JSON" ]; then
     exit 1
 fi
 
-# Extract changelog entries using simple text processing (no jq needed)
-# Use awk to properly handle escaped quotes and backslashes in JSON values
-CHANGELOG_MD=$(echo "$CHANGELOG_JSON" | awk -F'"changelog_md"[[:space:]]*:[[:space:]]*"' '{if (NF>1) {gsub(/","readme_txt".*/, "", $2); gsub(/\\n/, "\n", $2); gsub(/\\"/, "\"", $2); print $2}}')
-README_TXT=$(echo "$CHANGELOG_JSON" | awk -F'"readme_txt"[[:space:]]*:[[:space:]]*"' '{if (NF>1) {gsub(/"}$/, "", $2); gsub(/\\n/, "\n", $2); gsub(/\\"/, "\"", $2); print $2}}')
+# Extract changelog entries from the AI's JSON response.
+#
+# Prefer jq: it's already part of this toolchain (create-pr.sh depends on it) and
+# parses the object correctly no matter how the model formats it. The previous
+# awk-only approach assumed both keys sat on a single line; when the model
+# pretty-prints the JSON (one key per line), each value's closing quote lands at
+# the end of its own line and the greedy `","readme_txt".*` / `"}$` patterns
+# never matched — leaving a trailing `",` or `"` artifact in the changelog.
+CHANGELOG_MD=""
+README_TXT=""
+if command -v jq > /dev/null 2>&1; then
+    CHANGELOG_MD=$(printf '%s' "$CHANGELOG_JSON" | jq -r '.changelog_md // empty' 2>/dev/null)
+    README_TXT=$(printf '%s' "$CHANGELOG_JSON" | jq -r '.readme_txt // empty' 2>/dev/null)
+fi
+
+# Fallback for when jq is unavailable (or the response wasn't strictly valid
+# JSON). Locate the key on its line, then strip a closing quote that may be
+# followed by `,` or `}` and trailing whitespace at end of line — covering both
+# compact and pretty-printed shapes.
+extract_json_string() {
+    awk -v key="$1" '
+        BEGIN { sep = "\"" key "\"[[:space:]]*:[[:space:]]*\"" }
+        match($0, sep) {
+            val = substr($0, RSTART + RLENGTH)
+            sub(/","(changelog_md|readme_txt)".*/, "", val)   # another key on the same line
+            sub(/"[[:space:]]*[},]?[[:space:]]*$/, "", val)   # closing quote at end of line
+            gsub(/\\n/, "\n", val)
+            gsub(/\\"/, "\"", val)
+            print val
+        }
+    ' <<< "$CHANGELOG_JSON"
+}
+[ -z "$CHANGELOG_MD" ] && CHANGELOG_MD=$(extract_json_string "changelog_md")
+[ -z "$README_TXT" ] && README_TXT=$(extract_json_string "readme_txt")
 
 if [ -z "$CHANGELOG_MD" ] || [ -z "$README_TXT" ]; then
     echo -e "${RED}  ✗ Failed to extract changelog entries${NC}"

--- a/scripts/release-theme.sh
+++ b/scripts/release-theme.sh
@@ -302,10 +302,40 @@ if [ -z "$CHANGELOG_JSON" ]; then
     exit 1
 fi
 
-# Extract changelog entries using simple text processing (no jq needed)
-# Use awk to properly handle escaped quotes and backslashes in JSON values
-CHANGELOG_MD=$(echo "$CHANGELOG_JSON" | awk -F'"changelog_md"[[:space:]]*:[[:space:]]*"' '{if (NF>1) {gsub(/","readme_txt".*/, "", $2); gsub(/\\n/, "\n", $2); gsub(/\\"/, "\"", $2); print $2}}')
-README_TXT=$(echo "$CHANGELOG_JSON" | awk -F'"readme_txt"[[:space:]]*:[[:space:]]*"' '{if (NF>1) {gsub(/"}$/, "", $2); gsub(/\\n/, "\n", $2); gsub(/\\"/, "\"", $2); print $2}}')
+# Extract changelog entries from the AI's JSON response.
+#
+# Prefer jq: it's already part of this toolchain (create-pr.sh depends on it) and
+# parses the object correctly no matter how the model formats it. The previous
+# awk-only approach assumed both keys sat on a single line; when the model
+# pretty-prints the JSON (one key per line), each value's closing quote lands at
+# the end of its own line and the greedy `","readme_txt".*` / `"}$` patterns
+# never matched — leaving a trailing `",` or `"` artifact in the changelog.
+CHANGELOG_MD=""
+README_TXT=""
+if command -v jq > /dev/null 2>&1; then
+    CHANGELOG_MD=$(printf '%s' "$CHANGELOG_JSON" | jq -r '.changelog_md // empty' 2>/dev/null)
+    README_TXT=$(printf '%s' "$CHANGELOG_JSON" | jq -r '.readme_txt // empty' 2>/dev/null)
+fi
+
+# Fallback for when jq is unavailable (or the response wasn't strictly valid
+# JSON). Locate the key on its line, then strip a closing quote that may be
+# followed by `,` or `}` and trailing whitespace at end of line — covering both
+# compact and pretty-printed shapes.
+extract_json_string() {
+    awk -v key="$1" '
+        BEGIN { sep = "\"" key "\"[[:space:]]*:[[:space:]]*\"" }
+        match($0, sep) {
+            val = substr($0, RSTART + RLENGTH)
+            sub(/","(changelog_md|readme_txt)".*/, "", val)   # another key on the same line
+            sub(/"[[:space:]]*[},]?[[:space:]]*$/, "", val)   # closing quote at end of line
+            gsub(/\\n/, "\n", val)
+            gsub(/\\"/, "\"", val)
+            print val
+        }
+    ' <<< "$CHANGELOG_JSON"
+}
+[ -z "$CHANGELOG_MD" ] && CHANGELOG_MD=$(extract_json_string "changelog_md")
+[ -z "$README_TXT" ] && README_TXT=$(extract_json_string "readme_txt")
 
 if [ -z "$CHANGELOG_MD" ] || [ -z "$README_TXT" ]; then
     echo -e "${RED}  ✗ Failed to extract changelog entries${NC}"


### PR DESCRIPTION
**Version:** `3.3.3`

Fixes a changelog corruption bug in the plugin and theme release automation scripts, where every AI-generated changelog entry had a stray `",` or `"` artifact appended to its final line. The previous extraction logic used a single-pass `awk` field split that implicitly assumed both `changelog_md` and `readme_txt` keys appeared on the same line of the JSON response; when the model pretty-printed its output (one key per line), the greedy `","readme_txt".*` and `"}$` cleanup patterns never matched and the value's closing quote survived into the written file. Both `scripts/release-plugin.sh` and `scripts/release-theme.sh` now parse the response with `jq` — already a hard dependency elsewhere in this toolchain via `create-pr.sh` — and retain a hardened `awk` extractor as a fallback for environments without `jq` or for responses that are not strictly valid JSON. The fix is applied identically to both scripts to keep the plugin and theme release paths behaviorally consistent, and is released as patch version 3.3.3.

**Changelog Extraction Rewrite:**

- Replaced the brittle `awk -F` field-splitting approach with `jq -r '.changelog_md // empty'` and `jq -r '.readme_txt // empty'`, which correctly decodes JSON string escapes and is insensitive to the model's chosen formatting (compact or pretty-printed).
- Switched from `echo` to `printf '%s'` when piping the JSON payload, avoiding shell-dependent interpretation of backslash sequences in the response before it reaches the parser.
- Values are guarded with `// empty` so a missing key yields an empty string, allowing the existing post-extraction validation to fail loudly rather than writing a partial changelog.

**Fallback Parser Hardening:**

- Extracted the awk logic into a reusable `extract_json_string()` function invoked per key, replacing two near-duplicate inline one-liners in each script.
- The fallback now handles both JSON shapes: `sub(/","(changelog_md|readme_txt)".*/, ...)` truncates at a sibling key on the same line, while `sub(/"[[:space:]]*[},]?[[:space:]]*$/, ...)` strips a closing quote optionally followed by `,` or `}` and trailing whitespace at end of line — the case that produced the original artifact.
- The fallback runs only when `jq` is absent or returned nothing, via `command -v jq` detection and empty-value guards, so the correct parser is preferred without removing support for minimal environments.

**Documentation:**

- Added a `[3.3.3]` entry to `CHANGELOG.md` under `Fixed`, documenting the affected scripts, the root cause of the parsing failure, and the two-tier `jq`/`awk` resolution.
- Inline comments in both scripts now explain why `jq` is preferred and record the specific failure mode of the prior implementation, preventing a regression back to single-line-only parsing.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/wp-ops/blob/fix/release-scripts-changelog-json-parsing/CHANGELOG.md) (Modified)
- [`scripts/release-plugin.sh`](https://github.com/imagewize/wp-ops/blob/fix/release-scripts-changelog-json-parsing/scripts/release-plugin.sh) (Modified)
- [`scripts/release-theme.sh`](https://github.com/imagewize/wp-ops/blob/fix/release-scripts-changelog-json-parsing/scripts/release-theme.sh) (Modified)