### PR TITLE
Migrate five generic scripts from a client project into wp-ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 backup/.DS_Store
 create-pr.sh
+trellis/security/.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2026-07-31
+
+### Added
+
+- **wp-ops** - `scripts/*.py` files are now discovered and runnable through the CLI, alongside the existing `.sh`/`.js`/`.yml`/`.php` support. Descriptions are scraped from a single-line module docstring (`"""text"""`) rather than a shell `#` comment, matching how the JS/PHP/CSS branch already reads its own doc style.
+- **trellis/security** - New `check-ips.sh`: looks up one or more IPs against AbuseIPDB threat intelligence, so a manual Nginx deny rule is backed by an actual reputation score instead of a guess. Documented as a companion step in the "When to Add Manual IP Blocks" workflow, with its own setup/usage section and a `trellis/security/.env` (gitignored) for the API key.
+- **scripts/images** - New `make-square-webp.sh` (pads an image onto a square canvas and exports it as WebP, with an optional left-margin offset for off-center artwork) and `openverse_search.py`/`openverse_download.py` (search and download CC-licensed images from Openverse, with optional WebP conversion in the same pass). The Openverse pair is stdlib-only Python — no `pip install` required.
+- **scripts/misc** - New `convert-screenshot-for-claude.sh`: converts a PNG screenshot to JPEG, working around a Claude Code VSCode extension bug that mislabels PNG screenshots as `image/jpeg` and causes API errors when they're shared with Claude.
+
+These five scripts were migrated out of a client project's local `scripts/` directory, where they'd accumulated with no project-specific paths or config — pure duplication risk with no benefit to living outside wp-ops. First pass of a broader audit to pull generic, reusable tooling into wp-ops and keep client repos thin; a few thin site-specific wrappers (database backup/pull, Trellis updater) and a larger Playwright-based pattern-screenshot pipeline are candidates for a follow-up pass.
+
 ## [3.5.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wp-ops wordpress-utilities footer > footer.php   # redirect into your theme
 | **New Machine Setup** | Set up macOS for Trellis development | [→](trellis/provision/NEW-MACHINE.md) |
 | **Project Setup** | Clone and configure an existing Trellis/Bedrock project | [→](trellis/provision/PROJECT-SETUP.md) |
 | **Monitoring** | Nginx log monitoring for traffic analysis and security threat detection | [→](trellis/monitoring/README.md) |
-| **Security** | fail2ban IP blocking and manual deny rules | [→](trellis/security/README.md) |
+| **Security** | fail2ban IP blocking, manual deny rules, and AbuseIPDB reputation lookup | [→](trellis/security/README.md) |
 
 ## Bedrock
 
@@ -91,14 +91,14 @@ wp-ops wordpress-utilities footer > footer.php   # redirect into your theme
 
 ## Scripts
 
-23 standalone Bash/PHP utilities — full docs, flags, and examples in [scripts/README.md](scripts/README.md).
+27 standalone Bash/PHP/Python utilities — full docs, flags, and examples in [scripts/README.md](scripts/README.md).
 
 | Category | Includes | Docs |
 |------|-------------|------|
 | **Releases & GitHub** | PR creation, plugin/theme release automation, WordPress.org SVN deploy, release asset upload, GitHub traffic stats | [→](scripts/README.md#github-integration) |
 | **Monitoring & Security** | Traffic/security/AI-bot monitoring, 404 & redirect checking, CF7 smoke test, updown.io webhooks | [→](scripts/README.md#monitoring-scripts) |
 | **Backups** | Trellis-aware database and full-site backups | [→](scripts/README.md#backup-scripts) |
-| **Images, WooCommerce & Files** | Batch resize, WebP conversion, WooCommerce product variations, theme/package sync, find & replace | [→](scripts/README.md#image-utilities) |
+| **Images, WooCommerce & Files** | Batch resize, WebP conversion, square-canvas padding, Openverse image search/download, WooCommerce product variations, theme/package sync, find & replace | [→](scripts/README.md#image-utilities) |
 | **Content Reporting** | Published-post counts by year/month | [→](scripts/README.md#content-reporting) |
 
 ## MCP Server

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,15 +1,15 @@
 # Automation Scripts
 
-Production-ready Bash and PHP scripts for WordPress operations, GitHub integration, server monitoring, and backup automation.
+Production-ready Bash, PHP, and Python scripts for WordPress operations, GitHub integration, server monitoring, and backup automation.
 
 ## Overview
 
-This directory contains 23 utility scripts organized into seven functional areas:
+This directory contains 27 utility scripts organized into seven functional areas:
 
 - **GitHub Integration** - AI-powered pull request creation, manual GitHub release asset uploads, and repository traffic analytics
 - **WordPress Management** - Plugin and theme release automation, WordPress.org SVN deployment, file synchronization
 - **WooCommerce** - Product variation bulk creation
-- **Image Utilities** - WebP conversion optimized for WordPress and Facebook OG images
+- **Image Utilities** - WebP conversion optimized for WordPress and Facebook OG images, square-canvas padding, and Openverse (CC-licensed) image search/download
 - **Git Utilities** - Quick access to recent commit history
 - **Content Reporting** - Published-post counts by year and month (blog posts only)
 - **Operations** - Server monitoring and backup infrastructure
@@ -28,8 +28,12 @@ scripts/
 │   └── git-log-oneline.sh      # Show recent git commits as one-liners
 ├── images/                      # Image resizing and conversion
 │   ├── batch-resize.sh         # Batch resize and center-crop images for featured images
-│   └── convert-to-webp.sh      # JPG to WebP conversion with center-crop (Facebook OG)
+│   ├── convert-to-webp.sh      # JPG to WebP conversion with center-crop (Facebook OG)
+│   ├── make-square-webp.sh     # Pad an image onto a square canvas and export as WebP
+│   ├── openverse_search.py     # Search Openverse for CC-licensed images
+│   └── openverse_download.py   # Download Openverse image URLs, optionally converting to WebP
 ├── misc/                        # Miscellaneous utilities
+│   ├── convert-screenshot-for-claude.sh  # Convert PNG screenshots to JPEG for Claude Code compatibility
 │   ├── find-and-replace-files.sh     # Batch find and replace files across directory trees
 │   ├── post-count.sh                 # Count published blog posts by year/month (blog posts only)
 │   └── README-FIND-AND-REPLACE.md    # Docs for find-and-replace-files.sh
@@ -64,6 +68,7 @@ scripts/
 - WP-CLI (for WordPress backup/release scripts)
 - Claude CLI, Codex, or Mistral Vibe (optional, for AI features)
 - PHP (for webhook receiver)
+- Python 3 (for `openverse_search.py`/`openverse_download.py` — stdlib only, no pip installs needed)
 
 ### Common Operations
 
@@ -76,6 +81,15 @@ scripts/
 
 # Convert JPG to WebP for Facebook OG / featured image (800x419, center crop)
 ./scripts/images/convert-to-webp.sh image.jpg
+
+# Pad an image onto a square canvas and export as WebP
+./scripts/images/make-square-webp.sh logo.png logo-square.webp
+
+# Search Openverse for CC0-licensed images
+./scripts/images/openverse_search.py "wordpress hosting" --limit 3
+
+# Download Openverse image URLs and convert to WebP
+./scripts/images/openverse_download.py --url https://example.com/photo.jpg --convert-webp
 
 # Create GitHub PR with AI description
 ./scripts/git/create-pr.sh main "Add feature name"
@@ -276,6 +290,114 @@ Saved: featured.webp (800x419, q82)
 ```
 
 See also: `wordpress-utilities/snippets/webp-featured-image.md` for batch conversion commands.
+
+### make-square-webp.sh
+
+Pads an image onto a square canvas (letterboxing rather than cropping) and exports it as WebP — useful for logos, icons, or artwork that shouldn't be cropped to fit a square slot. Supports an optional left-margin offset for off-center source art.
+
+#### Requirements
+
+```bash
+brew install imagemagick webp   # macOS
+sudo apt-get install imagemagick webp  # Ubuntu/Debian
+```
+
+#### Usage
+
+```bash
+# Square canvas sized to the image's longest side, white background
+./scripts/images/make-square-webp.sh logo.png logo-square.webp
+
+# Fixed 2000px canvas, custom quality and background
+./scripts/images/make-square-webp.sh logo.png logo-square.webp --size 2000 --quality 90 --background transparent
+
+# Right-align the source art with a 200px left margin (asymmetric artwork)
+./scripts/images/make-square-webp.sh logo.png logo-square.webp --left-pad 200 --size 2000
+```
+
+#### Output
+
+```
+Saved: logo-square.webp
+```
+
+### openverse_search.py / openverse_download.py
+
+A pair of scripts for sourcing openly-licensed (CC0/CC-BY, etc.) images from [Openverse](https://openverse.org/) — useful for placeholder or production imagery on client sites without a licensed stock photo budget. `openverse_search.py` queries the API and prints candidates; `openverse_download.py` downloads chosen URLs (individually or from a manifest file) and can convert them to WebP in the same pass. Both are stdlib-only Python — no `pip install` required.
+
+#### Requirements
+
+```bash
+brew install webp   # macOS, only needed for --convert-webp
+```
+
+#### Usage
+
+```bash
+# Search for CC0 images (default), print top 5
+./scripts/images/openverse_search.py "wordpress hosting"
+
+# Narrow by license, provider, and result count
+./scripts/images/openverse_search.py "coffee shop" --license by --provider flickr --limit 10
+
+# Raw JSON output (for piping into another tool)
+./scripts/images/openverse_search.py "coffee shop" --json
+
+# Download a single URL, converting to WebP and discarding the original
+./scripts/images/openverse_download.py --url https://example.com/photo.jpg \
+  --out-dir ./downloads --convert-webp
+
+# Download a batch from a manifest file ("<url> <optional-filename>" per line, # for comments)
+./scripts/images/openverse_download.py --manifest images.txt --out-dir ./downloads --convert-webp --resize 1200
+```
+
+#### Example Output
+
+```
+$ ./scripts/images/openverse_search.py "wordpress hosting" --limit 2
+1. title='Server room'
+   creator='Jane Doe'
+   creator_url='https://openverse.org/user/janedoe'
+   source='flickr'
+   license='cc0' '1.0'
+   url='https://live.staticflickr.com/.../server-room.jpg'
+   landing='https://openverse.org/image/.../server-room'
+```
+
+#### Notes
+
+- Always double-check the license and attribution requirements on the `landing` page before using an image commercially — Openverse aggregates metadata from multiple sources and it isn't always perfectly accurate.
+- `openverse_download.py` skips (and warns on, not aborts) any URL that fails to download or convert, so a bad link in a large manifest doesn't kill the whole batch.
+
+---
+
+## Misc Utilities
+
+### convert-screenshot-for-claude.sh
+
+Converts a PNG screenshot to JPEG, working around a Claude Code VSCode extension bug that mislabels PNG screenshots as `image/jpeg`, causing API errors when the screenshot is shared with Claude. Handy after a Playwright screenshot run.
+
+#### Requirements
+
+```bash
+brew install imagemagick   # macOS
+sudo apt-get install imagemagick  # Ubuntu/Debian
+```
+
+#### Usage
+
+```bash
+./scripts/misc/convert-screenshot-for-claude.sh .playwright/screenshots/test.png
+
+# Custom JPEG quality (default: 90)
+./scripts/misc/convert-screenshot-for-claude.sh .playwright/screenshots/test.png --quality=95
+```
+
+#### Output
+
+```
+JPEG file created: .playwright/screenshots/test-for-claude.jpg
+```
 
 ---
 

--- a/scripts/images/make-square-webp.sh
+++ b/scripts/images/make-square-webp.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Pad an image onto a square canvas and export it as WebP
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./make-square-webp.sh <input> <output> [options]
+
+Options:
+  --size <px>       Square canvas size in pixels (defaults to max dimension)
+  --quality <0-100> WebP quality (default: 85)
+  --background <c>  Background color (default: white)
+  --left-pad <px>   Add left padding by right-aligning after resize
+
+Examples:
+  ./make-square-webp.sh input.webp output.webp
+  ./make-square-webp.sh input.webp output.webp --left-pad 200 --size 2000
+USAGE
+}
+
+if [ $# -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+input=$1
+output=$2
+shift 2
+
+size=""
+quality=85
+background="white"
+left_pad=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --size)
+      size=$2
+      shift 2
+      ;;
+    --quality|-q)
+      quality=$2
+      shift 2
+      ;;
+    --background)
+      background=$2
+      shift 2
+      ;;
+    --left-pad)
+      left_pad=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -f "$input" ]; then
+  echo "Input not found: $input" >&2
+  exit 1
+fi
+
+if ! command -v magick >/dev/null 2>&1; then
+  echo "Missing ImageMagick (magick)." >&2
+  exit 1
+fi
+
+if ! command -v cwebp >/dev/null 2>&1; then
+  echo "Missing cwebp." >&2
+  exit 1
+fi
+
+if [ -z "$size" ]; then
+  size=$(magick identify -format "%w %h" "$input" | awk '{print ($1>$2)?$1:$2}')
+fi
+
+temp_output=$(mktemp -t square-webp-XXXXXX.webp)
+
+if [ -n "$left_pad" ]; then
+  if ! [[ "$left_pad" =~ ^[0-9]+$ ]]; then
+    echo "--left-pad must be a number of pixels." >&2
+    exit 1
+  fi
+
+  resize_width=$((size - left_pad))
+  if [ "$resize_width" -le 0 ]; then
+    echo "--left-pad is too large for the chosen size." >&2
+    exit 1
+  fi
+
+  # Resize to create a left margin, then right-align on the square canvas.
+  magick "$input" \
+    -resize "${resize_width}x${size}" \
+    -background "$background" \
+    -gravity east \
+    -extent "${size}x${size}" \
+    "$temp_output"
+else
+  magick "$input" \
+    -background "$background" \
+    -gravity center \
+    -extent "${size}x${size}" \
+    "$temp_output"
+fi
+
+cwebp -q "$quality" "$temp_output" -o "$output" >/dev/null
+rm -f "$temp_output"
+
+echo "Saved: $output"

--- a/scripts/images/openverse_download.py
+++ b/scripts/images/openverse_download.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Download Openverse image URLs and optionally convert to WebP."""
+
+import argparse
+import os
+import sys
+import urllib.parse
+import urllib.request
+import subprocess
+
+DEFAULT_USER_AGENT = "wp-ops-openverse-download/1.0"
+
+
+def iter_manifest(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            url = parts[0]
+            name = parts[1] if len(parts) > 1 else None
+            yield url, name
+
+
+def download(url, dest_path, user_agent, referer):
+    headers = {"User-Agent": user_agent}
+    if referer:
+        headers["Referer"] = referer
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        data = resp.read()
+    with open(dest_path, "wb") as handle:
+        handle.write(data)
+
+
+def convert_to_webp(src_path, out_path, quality, resize_width):
+    cmd = ["cwebp", "-q", str(quality)]
+    if resize_width:
+        cmd += ["-resize", str(resize_width), "0"]
+    cmd += [src_path, "-o", out_path]
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download Openverse image URLs.")
+    parser.add_argument("--url", action="append", help="Image URL (repeatable)")
+    parser.add_argument("--manifest", help="Text file: '<url> <optional-filename>' per line")
+    parser.add_argument("--out-dir", default=".", help="Output directory")
+    parser.add_argument("--user-agent", default=DEFAULT_USER_AGENT, help="User-Agent header")
+    parser.add_argument("--referer", help="Referer header")
+    parser.add_argument("--convert-webp", action="store_true", help="Convert to .webp")
+    parser.add_argument("--quality", type=int, default=75, help="WebP quality (default: 75)")
+    parser.add_argument("--resize", type=int, default=0, help="Resize width (0 to skip)")
+    parser.add_argument("--keep-original", action="store_true", help="Keep original after conversion")
+    args = parser.parse_args()
+
+    items = []
+    if args.url:
+        for u in args.url:
+            items.append((u, None))
+    if args.manifest:
+        items.extend(iter_manifest(args.manifest))
+
+    if not items:
+        print("No URLs provided. Use --url or --manifest.", file=sys.stderr)
+        return 1
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    for url, name in items:
+        if not name:
+            parsed = urllib.parse.urlparse(url)
+            name = os.path.basename(parsed.path) or "download"
+        dest_path = os.path.join(args.out_dir, name)
+
+        try:
+            download(url, dest_path, args.user_agent, args.referer)
+        except Exception as exc:
+            print(f"Download failed for {url}: {exc}", file=sys.stderr)
+            continue
+
+        if args.convert_webp:
+            base, _ext = os.path.splitext(dest_path)
+            out_path = base + ".webp"
+            try:
+                convert_to_webp(dest_path, out_path, args.quality, args.resize)
+                if not args.keep_original:
+                    os.remove(dest_path)
+            except Exception as exc:
+                print(f"WebP conversion failed for {dest_path}: {exc}", file=sys.stderr)
+                continue
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/images/openverse_search.py
+++ b/scripts/images/openverse_search.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Query Openverse image API and print results."""
+
+import argparse
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+BASE_URL = "https://api.openverse.org/v1/images/"
+DEFAULT_USER_AGENT = "wp-ops-openverse-search/1.0"
+
+
+def build_url(query, license_value, license_type, page_size, mature, provider):
+    params = {
+        "q": query,
+        "license": license_value,
+        "license_type": license_type,
+        "page_size": page_size,
+        "mature": str(mature).lower(),
+    }
+    if provider:
+        params["source"] = provider
+    return BASE_URL + "?" + urllib.parse.urlencode(params)
+
+
+def fetch_results(url, user_agent):
+    req = urllib.request.Request(url, headers={"User-Agent": user_agent})
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def print_results(data, limit, output_json):
+    results = data.get("results", [])[:limit]
+    if output_json:
+        print(json.dumps(results, indent=2))
+        return
+
+    for idx, item in enumerate(results, 1):
+        print(f"{idx}. title={item.get('title')!r}")
+        print(f"   creator={item.get('creator')!r}")
+        print(f"   creator_url={item.get('creator_url')!r}")
+        print(f"   source={item.get('source')!r}")
+        print(f"   license={item.get('license')!r} {item.get('license_version')!r}")
+        print(f"   url={item.get('url')!r}")
+        print(f"   landing={item.get('foreign_landing_url')!r}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search Openverse images.")
+    parser.add_argument("query", help="Search query")
+    parser.add_argument("--license", default="cc0", help="License filter (default: cc0)")
+    parser.add_argument("--license-type", default="all", help="License type (default: all)")
+    parser.add_argument("--page-size", type=int, default=5, help="Results per page (default: 5)")
+    parser.add_argument("--limit", type=int, default=5, help="Max results to print (default: 5)")
+    parser.add_argument("--mature", action="store_true", help="Include mature results")
+    parser.add_argument("--provider", help="Source provider filter (e.g. flickr, stocksnap)")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON results")
+    parser.add_argument("--user-agent", default=DEFAULT_USER_AGENT, help="User-Agent header")
+    args = parser.parse_args()
+
+    url = build_url(
+        args.query,
+        args.license,
+        args.license_type,
+        args.page_size,
+        args.mature,
+        args.provider,
+    )
+
+    try:
+        data = fetch_results(url, args.user_agent)
+    except Exception as exc:
+        print(f"Error fetching Openverse results: {exc}", file=sys.stderr)
+        return 1
+
+    print_results(data, args.limit, args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/misc/convert-screenshot-for-claude.sh
+++ b/scripts/misc/convert-screenshot-for-claude.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+#
+# Convert Screenshot for Claude Code
+#
+# Converts PNG screenshots to JPEG format for compatibility with Claude Code's
+# VSCode extension, which has a known issue incorrectly labeling PNGs as JPEG.
+#
+# Usage:
+#   ./convert-screenshot-for-claude.sh <png-file>
+#   ./convert-screenshot-for-claude.sh --help
+#
+# Examples:
+#   ./convert-screenshot-for-claude.sh .playwright/screenshots/test-screenshot.png
+#   ./convert-screenshot-for-claude.sh ~/code/example.com/.playwright/screenshots/theme-unit-test-comments-desktop-2025-11-20-01-09-34.png
+#
+# Output:
+#   Creates a JPEG file with the same name + '-for-claude.jpg' suffix
+#   Example: test-screenshot.png -> test-screenshot-for-claude.jpg
+#
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+MAGENTA='\033[0;35m'
+NC='\033[0m' # No Color
+
+# Functions
+log_info() {
+    echo -e "${CYAN}ℹ ${NC}$1"
+}
+
+log_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+log_header() {
+    echo -e "${MAGENTA}$1${NC}"
+}
+
+show_help() {
+    cat << EOF
+${MAGENTA}Convert Screenshot for Claude Code${NC}
+
+Converts PNG screenshots to JPEG format for compatibility with Claude Code's
+VSCode extension.
+
+${CYAN}Background:${NC}
+Claude Code has a known issue where it incorrectly labels PNG screenshots
+with 'image/jpeg' media type, causing API errors. This script converts PNGs
+to actual JPEG files as a workaround.
+
+${CYAN}Usage:${NC}
+  ./convert-screenshot-for-claude.sh <png-file>
+  ./convert-screenshot-for-claude.sh --help
+
+${CYAN}Examples:${NC}
+  ${GREEN}# Convert a screenshot${NC}
+  ./convert-screenshot-for-claude.sh .playwright/screenshots/test.png
+
+  ${GREEN}# Convert with full path${NC}
+  ./convert-screenshot-for-claude.sh ~/code/example.com/.playwright/screenshots/screenshot.png
+
+${CYAN}Output:${NC}
+  Creates JPEG file with '-for-claude.jpg' suffix:
+    test-screenshot.png → test-screenshot-for-claude.jpg
+
+${CYAN}Options:${NC}
+  --help, -h          Show this help message
+  --quality=N         JPEG quality (1-100, default: 90)
+
+${CYAN}Requirements:${NC}
+  - ImageMagick (convert command)
+
+EOF
+    exit 0
+}
+
+# Check for help flag
+if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    show_help
+fi
+
+# Parse arguments
+QUALITY=90
+PNG_FILE=""
+
+for arg in "$@"; do
+    if [[ "$arg" == --quality=* ]]; then
+        QUALITY="${arg#*=}"
+    elif [[ ! "$arg" == --* ]]; then
+        PNG_FILE="$arg"
+    fi
+done
+
+# Check if file provided
+if [ -z "$PNG_FILE" ]; then
+    log_error "No PNG file provided"
+    echo ""
+    echo "Usage: ./convert-screenshot-for-claude.sh <png-file>"
+    echo "Run with --help for more information"
+    exit 1
+fi
+
+# Check if file exists
+if [ ! -f "$PNG_FILE" ]; then
+    log_error "File not found: $PNG_FILE"
+    exit 1
+fi
+
+# Check if ImageMagick is installed
+if ! command -v convert &> /dev/null; then
+    log_error "ImageMagick not found"
+    echo ""
+    echo "Please install ImageMagick:"
+    echo "  macOS: brew install imagemagick"
+    echo "  Ubuntu: sudo apt-get install imagemagick"
+    exit 1
+fi
+
+# Verify it's a PNG file
+if [[ ! "$PNG_FILE" =~ \.png$ ]]; then
+    log_warning "File doesn't have .png extension: $PNG_FILE"
+    log_warning "Attempting conversion anyway..."
+fi
+
+# Generate output filename
+BASENAME=$(basename "$PNG_FILE" .png)
+DIRNAME=$(dirname "$PNG_FILE")
+OUTPUT_FILE="$DIRNAME/${BASENAME}-for-claude.jpg"
+
+# Header
+log_header "════════════════════════════════════════════════════"
+log_header "  Convert Screenshot for Claude Code"
+log_header "════════════════════════════════════════════════════"
+echo ""
+
+log_info "Input:   $PNG_FILE"
+log_info "Output:  $OUTPUT_FILE"
+log_info "Quality: $QUALITY%"
+echo ""
+
+# Convert PNG to JPEG
+log_info "Converting PNG to JPEG..."
+
+if convert "$PNG_FILE" -quality "$QUALITY" "$OUTPUT_FILE" 2>/dev/null; then
+    log_success "Conversion complete"
+    echo ""
+
+    # Get file sizes
+    if command -v du &> /dev/null; then
+        ORIGINAL_SIZE=$(du -h "$PNG_FILE" | cut -f1)
+        NEW_SIZE=$(du -h "$OUTPUT_FILE" | cut -f1)
+        log_info "Original: $ORIGINAL_SIZE (PNG)"
+        log_info "Converted: $NEW_SIZE (JPEG)"
+        echo ""
+    fi
+
+    log_success "JPEG file created: $OUTPUT_FILE"
+    echo ""
+    log_info "You can now view this file in Claude Code without media type errors"
+    echo ""
+else
+    log_error "Conversion failed"
+    echo ""
+    echo "Common issues:"
+    echo "  - File may be corrupted"
+    echo "  - Not a valid PNG file"
+    echo "  - Insufficient permissions"
+    exit 1
+fi
+
+exit 0

--- a/trellis/security/README.md
+++ b/trellis/security/README.md
@@ -44,6 +44,7 @@ This directory contains documentation and configurations for securing WordPress 
 |------|---------|-------------|------|
 | **fail2ban** | Automatic IP blocking for brute force attacks | Zero (once configured) | [FAIL2BAN.md](./FAIL2BAN.md) |
 | **Manual IP blocks** | Permanent Nginx-level IP blocking | Manual updates required | [MANUAL-IP-BLOCKING.md](./MANUAL-IP-BLOCKING.md) |
+| **IP reputation lookup** | Verify an IP is actually malicious before blocking it | Run as needed | [check-ips.sh](#ip-reputation-checking) |
 | **Security scanners** | Malware detection for WordPress | Run weekly/monthly | [wp-cli/security](../../wp-cli/security/) |
 
 ---
@@ -151,6 +152,64 @@ Use manual Nginx IP blocks **only** when:
 - ❌ Regular brute force attempts (fail2ban handles this)
 - ❌ One-time attackers (fail2ban temporary ban is sufficient)
 - ❌ IPs that might be shared (VPNs, corporate networks, etc.)
+
+Before adding a manual block, run [`check-ips.sh`](#ip-reputation-checking) on the IP —
+it's easy to mistake a search-engine crawler or a monitoring service's IP for an
+attacker, especially in a distributed attack pattern.
+
+---
+
+## IP Reputation Checking
+
+`check-ips.sh` looks up one or more IPs against [AbuseIPDB](https://www.abuseipdb.com/)'s
+threat intelligence database, so you can confirm an IP is actually malicious before
+adding it to a manual block list or investigating further.
+
+### Setup
+
+```bash
+# Get a free API key (1,000 checks/day): https://www.abuseipdb.com/register
+echo 'ABUSEIPDB_KEY=your_key_here' > trellis/security/.env
+```
+
+### Usage
+
+```bash
+# Look up one or more IPs
+./trellis/security/check-ips.sh 203.0.113.50 198.51.100.25
+
+# Via wp-ops
+wp-ops trellis/security/check-ips 203.0.113.50
+```
+
+### Requirements
+
+```bash
+brew install jq curl   # macOS
+```
+
+### Example Output
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  203.0.113.50
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{
+  "score": 92,
+  "reports": 187,
+  "lastSeen": "2026-07-30T14:22:11+00:00",
+  "country": "CN",
+  "isp": "Example ISP",
+  "usageType": "Data Center/Web Hosting/Transit",
+  "domain": "example.net",
+  "tor": false
+}
+```
+
+A high `score` (AbuseIPDB's 0-100 confidence rating) with recent, numerous
+`reports` supports a manual block. A `score` of 0 with no reports is a strong
+signal the IP is not actually malicious (a shared NAT gateway, a legitimate
+crawler, etc.) — don't block it.
 
 ---
 
@@ -507,6 +566,12 @@ nano trellis/nginx-includes/all/deny-ips.conf.j2
 
 # 3. Deploy
 cd trellis && trellis provision --tags nginx production
+```
+
+### Check IP Reputation
+
+```bash
+./trellis/security/check-ips.sh 203.0.113.50 198.51.100.25
 ```
 
 ### Run Security Scan

--- a/trellis/security/check-ips.sh
+++ b/trellis/security/check-ips.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# check-ips.sh — Look up IP addresses against AbuseIPDB threat intelligence
+#
+# Usage:
+#   ./check-ips.sh <ip1> [ip2 ip3 ...]
+#
+# API key loaded from trellis/security/.env (ABUSEIPDB_KEY=xxx)
+# Get a free key at https://www.abuseipdb.com/register (1,000 checks/day)
+#
+# Requirements:
+#   brew install jq curl
+
+set -euo pipefail
+
+# Load API key from a .env file next to this script if it exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+if [[ -z "${ABUSEIPDB_KEY:-}" ]]; then
+  echo "Error: ABUSEIPDB_KEY not set."
+  echo "Add it to trellis/security/.env:"
+  echo "  echo 'ABUSEIPDB_KEY=your_key_here' > trellis/security/.env"
+  exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: ./check-ips.sh <ip1> [ip2 ip3 ...]"
+  exit 1
+fi
+
+for IP in "$@"; do
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  $IP"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  RESPONSE=$(curl -s --max-time 10 --connect-timeout 5 \
+    -G https://api.abuseipdb.com/api/v2/check \
+    --data-urlencode "ipAddress=$IP" \
+    -d maxAgeInDays=90 \
+    -H "Key: $ABUSEIPDB_KEY" \
+    -H "Accept: application/json")
+
+  # Check for API errors (throttle, invalid key, etc.)
+  if echo "$RESPONSE" | jq -e '.errors' &>/dev/null; then
+    echo "$RESPONSE" | jq '.errors[]'
+  elif [[ -z "$RESPONSE" ]]; then
+    echo "  [ERROR] No response (timeout or network issue)"
+  else
+    echo "$RESPONSE" | jq '{
+        score:     .data.abuseConfidenceScore,
+        reports:   .data.totalReports,
+        lastSeen:  .data.lastReportedAt,
+        country:   .data.countryCode,
+        isp:       .data.isp,
+        usageType: .data.usageType,
+        domain:    .data.domain,
+        tor:       .data.isTor
+      }'
+  fi
+  echo ""
+  # Respect AbuseIPDB rate limit (1 req/sec on free tier)
+  sleep 1
+done

--- a/wp-ops
+++ b/wp-ops
@@ -128,6 +128,12 @@ discover_commands() {
         if [[ "$category" == "trellis" ]]; then
             name_matchers+=(-o -name "*.yml")
         fi
+        # scripts/ is the only category with standalone Python utilities
+        # (e.g. scripts/images/openverse_search.py) — elsewhere *.py would
+        # collide with WordPress/Bedrock reference code that isn't runnable.
+        if [[ "$category" == "scripts" ]]; then
+            name_matchers+=(-o -name "*.py")
+        fi
         # wp-cli and bedrock are the only categories whose *.php files are
         # standalone WP-CLI scripts (wp eval-file / a registered wp command).
         # Elsewhere (e.g. wordpress-utilities snippets) *.php is reference
@@ -154,6 +160,7 @@ discover_commands() {
             command_key="${command_key%.yml}"
             command_key="${command_key%.php}"
             command_key="${command_key%.css}"
+            command_key="${command_key%.py}"
 
             description=""
             if [[ -f "$script_path" ]]; then
@@ -166,6 +173,11 @@ discover_commands() {
                         if [[ -z "$description" ]]; then
                             description=$(head -20 "$script_path" | grep -m1 -E '^\s*//\s*\S' | sed -E 's#^[[:space:]]*//[[:space:]]*##')
                         fi
+                        ;;
+                    *.py)
+                        # Python files document themselves with a single-line
+                        # module docstring ("""text"""), not shell "#" comments.
+                        description=$(head -5 "$script_path" | grep -m1 -E '^"""[^"]+"""$' | sed -E 's/^"""(.*)"""$/\1/')
                         ;;
                     *)
                         description=$(head -20 "$script_path" | grep -m1 -E '^#\s' | sed 's/^#\s*//')
@@ -387,6 +399,11 @@ get_script_path() {
 
     if [[ -f "${REPO_ROOT}/${command_key}.css" ]]; then
         echo "${REPO_ROOT}/${command_key}.css"
+        return 0
+    fi
+
+    if [[ -f "${REPO_ROOT}/${command_key}.py" ]]; then
+        echo "${REPO_ROOT}/${command_key}.py"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

First pass of an audit comparing `~/code/imagewize.com/scripts` against wp-ops's coverage. These five scripts had no project-specific paths or config — they were pure duplication risk, not intentionally site-specific — so they move here instead of staying copy-pasted in a client repo.

- **wp-ops CLI**: `scripts/*.py` files are now discovered and runnable, alongside the existing `.sh`/`.js`/`.yml`/`.php` support (descriptions scraped from a single-line module docstring).
- **`trellis/security/check-ips.sh`**: AbuseIPDB IP reputation lookup, wired into the manual-IP-block workflow docs as a "check before you block" step.
- **`scripts/images/`**: `make-square-webp.sh` (pad-to-square + WebP export) and `openverse_search.py`/`openverse_download.py` (CC-licensed image search/download, stdlib-only Python).
- **`scripts/misc/convert-screenshot-for-claude.sh`**: PNG→JPEG workaround for a Claude Code VSCode extension bug.

Root `README.md`, `scripts/README.md`, `trellis/security/README.md`, and `CHANGELOG.md` (v3.6.0) are all updated to match.

A larger follow-up pass is likely: a Playwright-based pattern-screenshot pipeline (7 scripts) and a few thin site-specific wrappers around existing Ansible playbooks (database backup/pull, Trellis updater) were also identified as migration candidates but are out of scope here.

## Test plan

- [x] `bash -n` on all new/modified `.sh` files
- [x] `python3 -m py_compile` on both new `.py` files
- [x] `./wp-ops --json` confirms all 5 new commands are discovered with correct category/description
- [x] `./wp-ops <category>/<command> --help` and direct invocation verified for all 5
- [x] `./wp-ops scripts --help` / `./wp-ops trellis --help` show them grouped under the right subdirectory