### PR TITLE
Add pattern screenshot toolkit and server resource monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] - 2026-07-31
+
+### Added
+
+- **scripts/patterns** - New Playwright/sharp toolkit for screenshotting WordPress block patterns and converting them to WebP: `screenshot-patterns.sh` orchestrates the full pipeline (create a temp WP page via a fully configurable `WP_CLI_CMD`, screenshot it, delete the page, batch-convert to WebP); `screenshot-url.js` is the underlying generic Playwright capture primitive (any URL, element selector or full page); `convert-to-webp.js` is a standalone sharp-based converter; `trim-screenshots.sh`/`center-screenshots.sh` post-process a directory of screenshots with ImageMagick (whitespace trim, or trim + center on a fixed canvas), backing up originals and safe to re-run. `WP_CLI_CMD` supports a local site, a Trellis VM, or a remote server over SSH, so no client-specific paths are baked in. Rebuilt from scratch rather than ported, since the source project's Playwright scripts were hardcoded to one theme's paths and one site's Trellis VM location.
+- **scripts/monitoring** - New `server-monitor.sh`: live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot over SSH, plus recent OOM killer events and swap usage. Complements the existing log-based monitors (`traffic-monitor.sh`, `security-monitor.sh`, `ai-bot-monitor.sh`) with a point-in-time view of what the server itself is doing. SSH target and PHP-FPM pool name are arguments, not hardcoded.
+
+Second pass of the client-project audit flagged in 3.6.0. `check-carousel.sh` and the ~50 one-off debug scripts in the source project's `.playwright/scripts/` were deliberately left out — too coupled to one theme's custom carousel block and that project's dev history to generalize usefully.
+
 ## [3.6.0] - 2026-07-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ This is a collection of tools, scripts, and documentation for WordPress operatio
   - `scripts/images/` - Image resizing and conversion
     - `scripts/images/batch-resize.sh` - Batch image resize with center-crop
     - `scripts/images/convert-to-webp.sh` - Convert JPG images to WebP format
+  - `scripts/patterns/` - WordPress block pattern screenshot toolkit (Playwright + sharp)
+    - `scripts/patterns/screenshot-patterns.sh` - Create temp WP page, screenshot pattern, delete page, convert to WebP
   - `scripts/misc/` - Miscellaneous utilities
     - `scripts/misc/find-and-replace-files.sh` - Batch find-and-replace files across projects
 - **wordpress-utilities/** - Reusable WordPress components and utilities

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,15 +4,16 @@ Production-ready Bash, PHP, and Python scripts for WordPress operations, GitHub 
 
 ## Overview
 
-This directory contains 27 utility scripts organized into seven functional areas:
+This directory contains utility scripts organized into functional areas:
 
 - **GitHub Integration** - AI-powered pull request creation, manual GitHub release asset uploads, and repository traffic analytics
 - **WordPress Management** - Plugin and theme release automation, WordPress.org SVN deployment, file synchronization
 - **WooCommerce** - Product variation bulk creation
 - **Image Utilities** - WebP conversion optimized for WordPress and Facebook OG images, square-canvas padding, and Openverse (CC-licensed) image search/download
+- **Pattern Screenshots** - Playwright/sharp toolkit for screenshotting WordPress block patterns and converting them to WebP
 - **Git Utilities** - Quick access to recent commit history
 - **Content Reporting** - Published-post counts by year and month (blog posts only)
-- **Operations** - Server monitoring and backup infrastructure
+- **Operations** - Server resource/traffic/security monitoring and backup infrastructure
 - **Webhook Integration** - Updown.io downtime alert handling
 
 ## Directory Structure
@@ -43,10 +44,18 @@ scripts/
 │   ├── redirect-check.sh       # Mass URL redirect checker using curl
 │   ├── run-monitoring.sh       # Orchestrator: runs all monitors and generates summary
 │   ├── security-monitor.sh     # Nginx security threat detection
+│   ├── server-monitor.sh       # Live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot over SSH
 │   ├── traffic-monitor.sh      # Nginx traffic analysis and reporting
 │   ├── cf7-smoke-test.js             # Playwright CF7 form submission smoke test
 │   ├── updown-webhook-handler.sh     # Webhook event handler
 │   └── updown-webhook-receiver.php   # Webhook HTTP receiver
+├── patterns/                    # WordPress block pattern screenshot toolkit
+│   ├── screenshot-patterns.sh  # End-to-end: create temp WP page, screenshot, delete, convert to WebP
+│   ├── screenshot-url.js       # Generic Playwright URL/element screenshot primitive
+│   ├── convert-to-webp.js      # Sharp-based PNG to WebP converter
+│   ├── trim-screenshots.sh     # Trim whitespace from a directory of pattern screenshots (ImageMagick)
+│   ├── center-screenshots.sh   # Center screenshots on a fixed canvas (ImageMagick)
+│   └── README.md               # Setup and usage docs
 ├── release/                     # Release automation
 │   ├── deploy-plugin-wporg.sh  # Publish a plugin to the WordPress.org directory via SVN
 │   ├── release-plugin.sh       # WordPress plugin version release automation
@@ -136,8 +145,16 @@ cd ~/code/my-plugin
 # Analyze AI crawler traffic
 ./scripts/monitoring/ai-bot-monitor.sh /srv/www/example.com/logs/access.log 24
 
+# Live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot
+./scripts/monitoring/server-monitor.sh web@example.com
+
 # Run all monitors and save timestamped reports
 ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+
+# Screenshot WordPress block patterns and convert to WebP
+cd scripts/patterns && npm install && npx playwright install chromium
+PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test WP_CLI_CMD="wp --path=web/wp" \
+  ./screenshot-patterns.sh hero-dark testimonials-and-logos
 ```
 
 ---
@@ -368,6 +385,68 @@ $ ./scripts/images/openverse_search.py "wordpress hosting" --limit 2
 
 - Always double-check the license and attribution requirements on the `landing` page before using an image commercially — Openverse aggregates metadata from multiple sources and it isn't always perfectly accurate.
 - `openverse_download.py` skips (and warns on, not aborts) any URL that fails to download or convert, so a bad link in a large manifest doesn't kill the whole batch.
+
+---
+
+## Pattern Screenshots
+
+### patterns/ toolkit
+
+Playwright/sharp toolkit for screenshotting WordPress block patterns (or any URL) and
+converting them to WebP — for pattern-library preview images, documentation
+screenshots, or visual diffs during theme development. Full docs in
+[`patterns/README.md`](patterns/README.md); summary here.
+
+#### Setup
+
+```bash
+cd scripts/patterns
+npm install
+npx playwright install chromium
+brew install imagemagick   # only needed for trim-screenshots.sh / center-screenshots.sh
+```
+
+#### Scripts
+
+- **`screenshot-patterns.sh`** — end-to-end pipeline: creates a temporary WordPress
+  page containing the pattern, screenshots it, deletes the page, converts every
+  capture to WebP. Configured entirely via environment variables (`WP_CLI_CMD`,
+  `SITE_URL`, `PATTERN_NAMESPACE`, `OUTPUT_DIR`) so it works against a local site, a
+  Trellis VM, or a remote server over SSH.
+- **`screenshot-url.js`** — the generic Playwright capture primitive underneath it;
+  screenshots any URL (element selector or full page), independent of WordPress.
+- **`convert-to-webp.js`** — standalone sharp-based PNG → WebP converter, single file
+  or `--all` batch mode.
+- **`trim-screenshots.sh`** / **`center-screenshots.sh`** — ImageMagick post-processing
+  for a directory of `pattern-*.webp` files (trim whitespace, or trim + center on a
+  fixed canvas). Both back up originals and are safe to re-run.
+
+#### Usage
+
+```bash
+PATTERN_NAMESPACE=mytheme \
+SITE_URL=http://example.test \
+WP_CLI_CMD="wp --path=web/wp" \
+./scripts/patterns/screenshot-patterns.sh hero-dark testimonials-and-logos
+
+# Then, optionally, center on a fixed canvas
+./scripts/patterns/center-screenshots.sh ./scripts/patterns/screenshots 900 600
+```
+
+`WP_CLI_CMD` is whatever actually invokes WP-CLI for the target site:
+
+```bash
+WP_CLI_CMD="wp --path=web/wp"                                                  # local Bedrock site
+WP_CLI_CMD="trellis vm shell --workdir /srv/www/example.com/current -- wp"     # Trellis VM
+WP_CLI_CMD="ssh web@example.com -- wp --path=/srv/www/example.com/current/web/wp"  # remote over SSH
+```
+
+#### Not included
+
+Site-specific QA checks (e.g. verifying a custom carousel block's JS state) are too
+coupled to a particular block/theme to generalize usefully — write those as one-off
+Playwright scripts in the project itself, using `screenshot-url.js` as a starting
+point.
 
 ---
 
@@ -1507,6 +1586,60 @@ Analyzes AI crawler traffic from Nginx logs, with per-bot breakdowns, bandwidth 
 # Syntax
 ./ai-bot-monitor.sh [LOG_FILE] [HOURS] [OUTPUT_FILE]
 ```
+
+---
+
+### server-monitor.sh
+
+Live resource-usage snapshot over SSH — complements the log-based monitors above
+(traffic/security/AI-bot) with a point-in-time view of what the server itself is
+doing right now.
+
+#### Features
+
+- System uptime and load average
+- Memory usage (absolute and percentage)
+- Disk usage (absolute and percentage)
+- Top 15 memory-consuming processes
+- PHP-FPM pool statistics (worker count, total and average RSS memory)
+- MySQL/MariaDB and Nginx memory/CPU usage
+- Process summary (total, running, sleeping)
+- Recent OOM killer events (last 7 days, via `journalctl`)
+- Swap usage warning
+
+#### Usage
+
+```bash
+./server-monitor.sh <ssh-target> [php-fpm-pool-pattern]
+
+# Examples
+./server-monitor.sh web@example.com
+./server-monitor.sh root@example.com "php-fpm: pool wordpress"
+```
+
+The optional second argument narrows the PHP-FPM `ps aux` grep to a specific pool
+name — useful on a multi-site server where several pools are running and you only
+want one site's numbers. Defaults to matching any `php-fpm: pool` process.
+
+#### Example Output
+
+```
+━━━ Memory Usage (Percentage) ━━━
+Memory: 5.1G/7.5G (68.42% used)
+
+━━━ PHP-FPM Pool Statistics ━━━
+PHP-FPM workers: 13
+Total RSS memory: 1950.23 MB
+Average per worker: 150.02 MB
+
+━━━ Recent OOM Killer Events (Last 7 Days) ━━━
+✓ No OOM killer events in last 7 days
+```
+
+#### Requirements
+
+- SSH access to the target server
+- `journalctl` on the remote host (systemd-based Linux; standard on Trellis/Ubuntu servers)
 
 ---
 

--- a/scripts/monitoring/server-monitor.sh
+++ b/scripts/monitoring/server-monitor.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Server Resource Monitor
+# Live CPU, memory, disk, and process usage snapshot over SSH.
+#
+# Usage:
+#   ./server-monitor.sh <ssh-target> [php-fpm-pool-pattern]
+#
+# Examples:
+#   ./server-monitor.sh web@example.com
+#   ./server-monitor.sh root@example.com "php-fpm: pool wordpress"
+#
+
+set -euo pipefail
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  echo "Usage: $(basename "$0") <ssh-target> [php-fpm-pool-pattern]"
+  echo "Example: $(basename "$0") web@example.com"
+  echo "         $(basename "$0") root@example.com \"php-fpm: pool wordpress\""
+  exit 0
+fi
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $(basename "$0") <ssh-target> [php-fpm-pool-pattern]"
+  echo "Example: $(basename "$0") web@example.com"
+  exit 1
+fi
+
+SERVER="$1"
+# Matches any pool by default; pass a specific pool name (e.g. "php-fpm: pool wordpress") to narrow it.
+PHP_FPM_PATTERN="${2:-php-fpm: pool}"
+
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}Server Resource Monitor - $SERVER${NC}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${BLUE}Generated:${NC} $(date)"
+echo ""
+
+# System uptime and load
+echo -e "${BOLD}━━━ System Uptime & Load ━━━${NC}"
+ssh "$SERVER" "uptime"
+echo ""
+
+# Memory usage
+echo -e "${BOLD}━━━ Memory Usage ━━━${NC}"
+ssh "$SERVER" "free -h"
+echo ""
+
+# Memory usage by percentage
+echo -e "${BOLD}━━━ Memory Usage (Percentage) ━━━${NC}"
+ssh "$SERVER" "free | awk 'NR==2{printf \"Memory: %s/%s (%.2f%% used)\n\", \$3,\$2,\$3*100/\$2 }'"
+echo ""
+
+# Disk usage
+echo -e "${BOLD}━━━ Disk Usage ━━━${NC}"
+ssh "$SERVER" "df -h /"
+echo ""
+
+# Disk usage by percentage
+echo -e "${BOLD}━━━ Disk Usage (Percentage) ━━━${NC}"
+ssh "$SERVER" "df -h / | awk 'NR==2{printf \"Disk: %s/%s (%s used)\n\", \$3,\$2,\$5}'"
+echo ""
+
+# Top 15 memory-consuming processes
+echo -e "${BOLD}━━━ Top 15 Memory Consumers ━━━${NC}"
+echo -e "${YELLOW}USER       PID  %CPU %MEM    VSZ    RSS  COMMAND${NC}"
+ssh "$SERVER" "ps aux --sort=-%mem | head -16 | tail -15"
+echo ""
+
+# PHP-FPM process count and memory
+echo -e "${BOLD}━━━ PHP-FPM Pool Statistics ━━━${NC}"
+ssh "$SERVER" "
+ps aux | grep '$PHP_FPM_PATTERN' | grep -v grep | wc -l | awk '{print \"PHP-FPM workers: \" \$1}'
+ps aux | grep '$PHP_FPM_PATTERN' | grep -v grep | awk '{sum+=\$6} END {printf \"Total RSS memory: %.2f MB\n\", sum/1024}'
+ps aux | grep '$PHP_FPM_PATTERN' | grep -v grep | awk '{sum+=\$6; count++} END {if(count>0) printf \"Average per worker: %.2f MB\n\", sum/1024/count}'
+"
+echo ""
+
+# MySQL/MariaDB memory usage
+echo -e "${BOLD}━━━ MySQL/MariaDB Statistics ━━━${NC}"
+ssh "$SERVER" "
+ps aux | grep -E 'mysql|mariadb' | grep -v grep | awk '{
+    printf \"Process: %s\n\", \$11
+    printf \"Memory (RSS): %.2f MB\n\", \$6/1024
+    printf \"CPU: %.1f%%\n\", \$3
+}'
+"
+echo ""
+
+# Nginx memory usage
+echo -e "${BOLD}━━━ Nginx Statistics ━━━${NC}"
+ssh "$SERVER" "
+ps aux | grep nginx | grep -v grep | awk '{sum+=\$6; count++} END {
+    printf \"Nginx workers: %d\n\", count
+    printf \"Total memory: %.2f MB\n\", sum/1024
+}'
+"
+echo ""
+
+# System processes summary
+echo -e "${BOLD}━━━ Process Summary ━━━${NC}"
+ssh "$SERVER" "
+echo \"Total processes: \$(ps aux | wc -l)\"
+echo \"Running processes: \$(ps aux | grep -c ' R ')\"
+echo \"Sleeping processes: \$(ps aux | grep -c ' S ')\"
+"
+echo ""
+
+# Check for memory pressure / OOM killer events
+echo -e "${BOLD}━━━ Recent OOM Killer Events (Last 7 Days) ━━━${NC}"
+if ssh "$SERVER" "journalctl -k --since '7 days ago' | grep -i 'out of memory\|oom' | wc -l" | grep -q '^0$'; then
+    echo -e "${GREEN}✓ No OOM killer events in last 7 days${NC}"
+else
+    echo -e "${RED}⚠ OOM killer events detected:${NC}"
+    ssh "$SERVER" "journalctl -k --since '7 days ago' | grep -i 'out of memory\|oom' | tail -10"
+fi
+echo ""
+
+# Swap usage
+echo -e "${BOLD}━━━ Swap Usage ━━━${NC}"
+ssh "$SERVER" "free -h | grep Swap"
+swap_used=$(ssh "$SERVER" "free | awk 'NR==3{print \$3}'")
+if [ "$swap_used" -gt 0 ]; then
+    echo -e "${YELLOW}⚠ Warning: Swap is being used ($swap_used bytes)${NC}"
+else
+    echo -e "${GREEN}✓ No swap usage detected${NC}"
+fi
+echo ""
+
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${BOLD}Monitor Complete${NC}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/scripts/patterns/README.md
+++ b/scripts/patterns/README.md
@@ -1,0 +1,117 @@
+# Pattern Screenshot Toolkit
+
+Playwright/sharp toolkit for screenshotting WordPress block patterns (or any URL) and
+converting them to WebP. Useful for generating pattern-library preview images,
+documentation screenshots, or visual diffs during theme development.
+
+## Setup
+
+```bash
+cd scripts/patterns
+npm install
+npx playwright install chromium
+```
+
+Also requires ImageMagick for `trim-screenshots.sh` / `center-screenshots.sh`:
+
+```bash
+brew install imagemagick   # macOS
+sudo apt-get install imagemagick  # Ubuntu/Debian
+```
+
+## Scripts
+
+### screenshot-patterns.sh
+
+End-to-end pattern screenshot pipeline: creates a temporary WordPress page containing
+the pattern, screenshots it, deletes the page, and converts every capture to WebP.
+
+Configure via environment variables (see the script header for the full list):
+
+```bash
+PATTERN_NAMESPACE=mytheme \
+SITE_URL=http://example.test \
+WP_CLI_CMD="wp --path=web/wp" \
+./screenshot-patterns.sh hero-dark testimonials-and-logos
+```
+
+`WP_CLI_CMD` is whatever actually invokes WP-CLI for the target site — adjust it to
+match your setup:
+
+```bash
+# Local Bedrock site
+WP_CLI_CMD="wp --path=web/wp"
+
+# Trellis VM
+WP_CLI_CMD="trellis vm shell --workdir /srv/www/example.com/current -- wp"
+
+# Remote over SSH
+WP_CLI_CMD="ssh web@example.com -- wp --path=/srv/www/example.com/current/web/wp"
+```
+
+Output PNGs and WebPs land in `OUTPUT_DIR` (default: `./screenshots` next to this
+script).
+
+### screenshot-url.js
+
+Generic capture primitive behind `screenshot-patterns.sh` — screenshots any URL, not
+just a WordPress pattern page. Useful standalone for one-off captures or other
+automation.
+
+```bash
+node screenshot-url.js http://example.test/some-page/ --out=page.png
+node screenshot-url.js http://example.test/ --out=full.png --full-page --width=1920 --height=1080
+
+# Custom selector priority list (first match wins, falls back to full page)
+node screenshot-url.js http://example.test/pattern/ --out=pattern.png \
+  --selector=".my-pattern-wrapper,.entry-content > *:first-child"
+```
+
+### convert-to-webp.js
+
+Standalone PNG → WebP converter (sharp-based), used by `screenshot-patterns.sh` but
+usable on its own for any directory of screenshots.
+
+```bash
+node convert-to-webp.js pattern-hero-dark.png
+node convert-to-webp.js --all --dir=./screenshots
+node convert-to-webp.js --all --dir=./screenshots --output-dir=./webp --quality=90
+```
+
+### trim-screenshots.sh / center-screenshots.sh
+
+Post-processing for a directory of `pattern-*.webp` files (ImageMagick). Both back up
+originals to `<dir>/originals/` before modifying in place, and skip files that already
+have a backup (safe to re-run).
+
+```bash
+# Trim whitespace, resize to 900px wide
+./trim-screenshots.sh ./screenshots 900
+
+# Trim + center on a fixed 900x600 canvas (white background)
+./center-screenshots.sh ./screenshots 900 600
+```
+
+## Typical workflow
+
+```bash
+PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test WP_CLI_CMD="wp --path=web/wp" \
+  ./screenshot-patterns.sh hero-dark testimonials-and-logos
+
+./center-screenshots.sh ./screenshots 900 600
+```
+
+## Requirements
+
+- Node.js >= 18, `npm install` in this directory
+- Playwright Chromium (`npx playwright install chromium`)
+- A reachable WordPress site with the target pattern registered under `PATTERN_NAMESPACE`
+- WP-CLI access via whatever `WP_CLI_CMD` you configure
+- ImageMagick, for `trim-screenshots.sh` / `center-screenshots.sh` only
+
+## Not included
+
+Site-specific QA checks (e.g. verifying a custom carousel block's JS state) are too
+coupled to a particular block/theme to generalize usefully — write those as one-off
+Playwright scripts in the project itself, using `screenshot-url.js` or Playwright
+directly as a starting point.

--- a/scripts/patterns/center-screenshots.sh
+++ b/scripts/patterns/center-screenshots.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Center pattern screenshots on a fixed canvas (in place). Trims whitespace,
+# resizes to a fixed width, then extends the canvas to WIDTHxHEIGHT with the
+# pattern vertically centered (white background). Originals are backed up.
+#
+# Usage:
+#   ./center-screenshots.sh <screenshots-dir> [width] [height]
+#
+# Example:
+#   ./center-screenshots.sh ./screenshots 900 600
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $(basename "$0") <screenshots-dir> [width] [height]"
+    exit 1
+fi
+
+if ! command -v magick &> /dev/null && ! command -v identify &> /dev/null; then
+    echo "Error: ImageMagick not found. Install with: brew install imagemagick"
+    exit 1
+fi
+
+SCREENSHOTS_DIR="$(cd "$1" && pwd)"
+WIDTH="${2:-900}"
+TARGET_HEIGHT="${3:-600}"
+BACKUP_DIR="$SCREENSHOTS_DIR/originals"
+
+echo -e "${BLUE}Center Pattern Screenshots${NC}"
+echo -e "${BLUE}==========================${NC}"
+echo -e "${BLUE}Target canvas: ${WIDTH}x${TARGET_HEIGHT}px${NC}\n"
+
+mkdir -p "$BACKUP_DIR"
+echo -e "${YELLOW}Backups in: $BACKUP_DIR${NC}\n"
+
+PROCESSED=0
+SKIPPED=0
+
+for file in "$SCREENSHOTS_DIR"/pattern-*.webp; do
+    [ -f "$file" ] || continue
+
+    filename=$(basename "$file")
+    backup_file="$BACKUP_DIR/$filename"
+
+    if [ -f "$backup_file" ]; then
+        echo -e "${YELLOW}skip${NC} $filename (already processed)"
+        ((SKIPPED++))
+        continue
+    fi
+
+    echo -e "${BLUE}center${NC} $filename"
+    cp "$file" "$backup_file"
+
+    current_dims=$(identify -format "%wx%h" "$file")
+
+    magick "$file" \
+        -trim \
+        +repage \
+        -resize "${WIDTH}x" \
+        -gravity center \
+        -background white \
+        -extent "${WIDTH}x${TARGET_HEIGHT}" \
+        -quality 85 \
+        "$file"
+
+    new_dims=$(identify -format "%wx%h" "$file")
+    file_size=$(du -h "$file" | cut -f1)
+
+    echo -e "   ${current_dims} -> ${new_dims} (${file_size})"
+    ((PROCESSED++))
+done
+
+echo ""
+echo -e "${GREEN}Done.${NC} Processed: $PROCESSED  Skipped: $SKIPPED  Canvas: ${WIDTH}x${TARGET_HEIGHT}px"
+echo -e "\nTo restore originals: cp $BACKUP_DIR/*.webp $SCREENSHOTS_DIR/"

--- a/scripts/patterns/convert-to-webp.js
+++ b/scripts/patterns/convert-to-webp.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * Convert PNG screenshots to WebP
+ *
+ * Converts a single PNG or a whole directory of pattern-*.png files to
+ * optimized WebP using sharp.
+ *
+ * Usage:
+ *   node convert-to-webp.js <input-file> [options]
+ *   node convert-to-webp.js --all --dir=<screenshots-dir> [options]
+ *
+ * Options:
+ *   --all                  Convert every pattern-*.png file in --dir
+ *   --dir=<path>           Source directory for --all (default: ./screenshots)
+ *   --output-dir=<path>    Output directory (default: same as source file/dir)
+ *   --quality=85           WebP quality 1-100 (default: 85)
+ *   --dry-run              Show what would be done without writing files
+ *
+ * Examples:
+ *   node convert-to-webp.js pattern-hero-dark.png
+ *   node convert-to-webp.js --all --dir=./screenshots --output-dir=./webp
+ *   node convert-to-webp.js --all --dir=./screenshots --quality=90
+ */
+
+const sharp = require('sharp');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_QUALITY = 85;
+const INPUT_PATTERN = /^pattern-.*\.png$/;
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m'
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function parseArgs(argv) {
+  const flag = (name) => argv.find((a) => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+  const inputFile = argv.find((a) => !a.startsWith('--'));
+  const convertAll = argv.includes('--all');
+  const dryRun = argv.includes('--dry-run');
+  const dir = path.resolve(flag('dir') || './screenshots');
+  const quality = parseInt(flag('quality') || String(DEFAULT_QUALITY), 10);
+  const outputDirArg = flag('output-dir');
+
+  if (!inputFile && !convertAll) {
+    log('Error: specify an input file or use --all --dir=<path>', 'red');
+    process.exit(1);
+  }
+
+  if (quality < 1 || quality > 100) {
+    log('Error: quality must be between 1-100', 'red');
+    process.exit(1);
+  }
+
+  return { inputFile, convertAll, dir, quality, outputDirArg, dryRun };
+}
+
+function getInputFiles(opts) {
+  if (opts.convertAll) {
+    if (!fs.existsSync(opts.dir)) {
+      log(`Error: directory not found: ${opts.dir}`, 'red');
+      process.exit(1);
+    }
+    const files = fs
+      .readdirSync(opts.dir)
+      .filter((f) => INPUT_PATTERN.test(f))
+      .map((f) => path.join(opts.dir, f));
+
+    if (files.length === 0) {
+      log(`No pattern-*.png files found in ${opts.dir}`, 'yellow');
+    }
+    return files;
+  }
+
+  const inputPath = path.resolve(opts.inputFile);
+  if (!fs.existsSync(inputPath)) {
+    log(`Error: input file not found: ${inputPath}`, 'red');
+    process.exit(1);
+  }
+  return [inputPath];
+}
+
+async function convertToWebP(inputPath, outputPath, quality, dryRun) {
+  if (dryRun) {
+    log(`[DRY RUN] Would convert: ${path.basename(inputPath)} -> ${path.basename(outputPath)}`, 'yellow');
+    return null;
+  }
+
+  const inputSize = fs.statSync(inputPath).size;
+  log(`Converting: ${path.basename(inputPath)} (${Math.round(inputSize / 1024)}KB)`, 'cyan');
+
+  await sharp(inputPath).webp({ quality }).toFile(outputPath);
+
+  const outputSize = fs.statSync(outputPath).size;
+  const reduction = Math.round(((inputSize - outputSize) / inputSize) * 100);
+  log(`Created: ${path.basename(outputPath)} (${Math.round(outputSize / 1024)}KB, ${reduction}% smaller)`, 'green');
+
+  return { inputSize, outputSize };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  log('\nWebP Conversion', 'magenta');
+  log(`Quality: ${opts.quality}%  |  dry-run: ${opts.dryRun}`, 'blue');
+
+  const inputFiles = getInputFiles(opts);
+  if (inputFiles.length === 0) {
+    process.exit(0);
+  }
+
+  log(`Found ${inputFiles.length} file(s) to convert\n`, 'blue');
+
+  const results = [];
+  for (const inputPath of inputFiles) {
+    const outputDir = opts.outputDirArg ? path.resolve(opts.outputDirArg) : path.dirname(inputPath);
+    if (!opts.dryRun && !fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+    const outputPath = path.join(outputDir, `${path.basename(inputPath, '.png')}.webp`);
+
+    try {
+      const result = await convertToWebP(inputPath, outputPath, opts.quality, opts.dryRun);
+      if (result) results.push(result);
+    } catch (error) {
+      log(`Skipping ${path.basename(inputPath)}: ${error.message}`, 'red');
+    }
+  }
+
+  if (!opts.dryRun && results.length > 0) {
+    const totalIn = results.reduce((sum, r) => sum + r.inputSize, 0);
+    const totalOut = results.reduce((sum, r) => sum + r.outputSize, 0);
+    log(`\nConverted ${results.length} file(s), ${Math.round(((totalIn - totalOut) / totalIn) * 100)}% smaller overall`, 'green');
+  }
+}
+
+main().catch((error) => {
+  log(`\nFatal error: ${error.message}`, 'red');
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/patterns/package.json
+++ b/scripts/patterns/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wp-ops-pattern-screenshots",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright/sharp toolkit for screenshotting WordPress block patterns and converting them to WebP",
+  "devDependencies": {
+    "playwright": "^1.48.0",
+    "sharp": "^0.35.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/scripts/patterns/screenshot-patterns.sh
+++ b/scripts/patterns/screenshot-patterns.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Pattern Screenshot Tool
+#
+# Automates screenshotting WordPress block patterns and converting them to WebP:
+#   1. Creates a temporary WordPress page containing the pattern
+#   2. Screenshots the pattern element with Playwright
+#   3. Deletes the temporary page
+#   4. Converts all captured PNGs to WebP
+#
+# Configuration (environment variables):
+#   WP_CLI_CMD         WP-CLI invocation prefix (default: "wp"). Point this at
+#                       whatever actually runs WP-CLI for the target site:
+#                         WP_CLI_CMD="wp --path=web/wp"
+#                         WP_CLI_CMD="trellis vm shell --workdir /srv/www/example.com/current -- wp"
+#                         WP_CLI_CMD="ssh web@example.com -- wp --path=/srv/www/example.com/current/web/wp"
+#   SITE_URL            Base URL the temp page is reachable at (default: http://example.test)
+#   PATTERN_NAMESPACE   Theme namespace used in the pattern slug, e.g. "moiraine" for
+#                        <!-- wp:pattern {"slug":"moiraine/hero-dark"} /--> (required)
+#   OUTPUT_DIR          Where PNG/WebP screenshots are saved (default: ./screenshots)
+#   VIEWPORT_WIDTH      Screenshot viewport width (default: 1400)
+#   VIEWPORT_HEIGHT     Screenshot viewport height (default: 900)
+#
+# Usage:
+#   PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test WP_CLI_CMD="wp --path=web/wp" \
+#     ./screenshot-patterns.sh <pattern-slug> [pattern-slug2 ...]
+#
+# Requirements:
+#   npm install   (from this directory, installs playwright + sharp)
+#   npx playwright install chromium
+
+set -euo pipefail
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+CYAN=$'\033[0;36m'
+MAGENTA=$'\033[0;35m'
+NC=$'\033[0m'
+
+log_info()    { echo -e "${CYAN}i ${NC}$1"; }
+log_success() { echo -e "${GREEN}+${NC} $1"; }
+log_error()   { echo -e "${RED}x${NC} $1"; }
+log_warning() { echo -e "${YELLOW}!${NC} $1"; }
+log_header()  { echo -e "${MAGENTA}$1${NC}"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+WP_CLI_CMD="${WP_CLI_CMD:-wp}"
+SITE_URL="${SITE_URL:-http://example.test}"
+PATTERN_NAMESPACE="${PATTERN_NAMESPACE:-}"
+OUTPUT_DIR="${OUTPUT_DIR:-$SCRIPT_DIR/screenshots}"
+VIEWPORT_WIDTH="${VIEWPORT_WIDTH:-1400}"
+VIEWPORT_HEIGHT="${VIEWPORT_HEIGHT:-900}"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    cat << EOF
+${MAGENTA}Pattern Screenshot Tool${NC}
+
+Usage:
+  PATTERN_NAMESPACE=<theme> [SITE_URL=...] [WP_CLI_CMD=...] $(basename "$0") <pattern-slug> [pattern-slug2 ...]
+
+See the header comment in this script for full configuration docs.
+EOF
+    exit 0
+fi
+
+if [ -z "$PATTERN_NAMESPACE" ]; then
+    log_error "PATTERN_NAMESPACE is required, e.g. PATTERN_NAMESPACE=moiraine $(basename "$0") hero-dark"
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    log_error "No pattern slugs provided"
+    echo "Usage: PATTERN_NAMESPACE=<theme> $(basename "$0") <pattern-slug> [pattern-slug2 ...]"
+    exit 1
+fi
+
+if [ ! -f "$SCRIPT_DIR/screenshot-url.js" ]; then
+    log_error "screenshot-url.js not found next to this script"
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+PATTERN_SLUGS=("$@")
+log_header "════════════════════════════════════════════════════"
+log_header "  Pattern Screenshot Tool"
+log_header "════════════════════════════════════════════════════"
+log_info "Namespace: $PATTERN_NAMESPACE  |  Site: $SITE_URL"
+log_info "Patterns to screenshot: ${#PATTERN_SLUGS[@]}"
+echo ""
+
+SCREENSHOT_COUNT=0
+FAILED_PATTERNS=()
+
+for slug in "${PATTERN_SLUGS[@]}"; do
+    log_info "Screenshotting pattern: $slug"
+
+    temp_slug="pattern-screenshot-$slug"
+    pattern_content="<!-- wp:pattern {\"slug\":\"$PATTERN_NAMESPACE/$slug\"} /-->"
+
+    page_id=$($WP_CLI_CMD post create \
+        --post_type=page \
+        --post_title="Pattern Screenshot: $slug" \
+        --post_name="$temp_slug" \
+        --post_status=publish \
+        --post_content="$pattern_content" \
+        --porcelain | tail -n 1 | tr -d '[:space:]')
+
+    if [[ ! "$page_id" =~ ^[0-9]+$ ]]; then
+        log_error "Failed to create temp page for: $slug"
+        FAILED_PATTERNS+=("$slug")
+        echo ""
+        continue
+    fi
+
+    page_url="$SITE_URL/$temp_slug/"
+
+    if node "$SCRIPT_DIR/screenshot-url.js" "$page_url" \
+        --out="$OUTPUT_DIR/pattern-$slug.png" \
+        --width="$VIEWPORT_WIDTH" --height="$VIEWPORT_HEIGHT"; then
+        log_success "Screenshot created: pattern-$slug.png"
+        ((SCREENSHOT_COUNT++))
+    else
+        log_error "Failed to screenshot: $slug"
+        FAILED_PATTERNS+=("$slug")
+    fi
+
+    $WP_CLI_CMD post delete "$page_id" --force > /dev/null
+    echo ""
+done
+
+if [ $SCREENSHOT_COUNT -eq 0 ]; then
+    log_error "No screenshots were created successfully"
+    exit 1
+fi
+
+log_header "Converting to WebP"
+log_header "────────────────────────────────────────────────────"
+node "$SCRIPT_DIR/convert-to-webp.js" --all --dir="$OUTPUT_DIR"
+
+echo ""
+log_success "Successfully processed: $SCREENSHOT_COUNT pattern(s)"
+if [ ${#FAILED_PATTERNS[@]} -gt 0 ]; then
+    log_warning "Failed patterns: ${FAILED_PATTERNS[*]}"
+fi
+log_info "Output directory: $OUTPUT_DIR"

--- a/scripts/patterns/screenshot-url.js
+++ b/scripts/patterns/screenshot-url.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * Screenshot a URL with Playwright
+ *
+ * Navigates to a URL and screenshots either the first element matching a
+ * selector (tries each --selector in order, falls back to full page) or the
+ * whole page. Generic capture primitive — no WordPress/site-specific paths.
+ *
+ * Usage:
+ *   node screenshot-url.js <url> --out=<path> [options]
+ *
+ * Options:
+ *   --out=<path>        Output PNG path (required)
+ *   --width=1400         Viewport width (default: 1400)
+ *   --height=900          Viewport height (default: 900)
+ *   --wait=3000           Milliseconds to wait after load, for JS-rendered content (default: 3000)
+ *   --selector=<a,b,c>   Comma-separated CSS selectors, tried in order; first match is screenshotted
+ *   --full-page          Skip selector matching and screenshot the entire page
+ *
+ * Examples:
+ *   node screenshot-url.js http://example.test/my-page/ --out=pattern.png
+ *   node screenshot-url.js http://example.test/my-page/ --out=pattern.png --selector=".entry-content > *:first-child"
+ *   node screenshot-url.js http://example.test/ --out=full.png --full-page --width=1920 --height=1080
+ */
+
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_SELECTORS = [
+  '.entry-content > *:first-child',
+  'article .entry-content > div',
+  'main > *:first-child',
+  '.wp-site-blocks > *:first-child'
+];
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m'
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function parseArgs(argv) {
+  const url = argv[0];
+  if (!url || url.startsWith('--')) {
+    log('Error: URL is required', 'red');
+    log('Usage: node screenshot-url.js <url> --out=<path> [options]', 'yellow');
+    process.exit(1);
+  }
+
+  const flag = (name) => argv.find((a) => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
+
+  const out = flag('out');
+  if (!out) {
+    log('Error: --out=<path> is required', 'red');
+    process.exit(1);
+  }
+
+  return {
+    url,
+    out,
+    width: parseInt(flag('width') || '1400', 10),
+    height: parseInt(flag('height') || '900', 10),
+    wait: parseInt(flag('wait') || '3000', 10),
+    selectors: flag('selector') ? flag('selector').split(',') : DEFAULT_SELECTORS,
+    fullPage: argv.includes('--full-page')
+  };
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  log(`\nScreenshot: ${opts.url}`, 'blue');
+  log(`Viewport: ${opts.width}x${opts.height}  |  wait: ${opts.wait}ms  |  full-page: ${opts.fullPage}`, 'cyan');
+
+  const outDir = path.dirname(opts.out);
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: opts.width, height: opts.height } });
+  const page = await context.newPage();
+
+  try {
+    await page.goto(opts.url, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(opts.wait);
+
+    let captured = false;
+
+    if (!opts.fullPage) {
+      for (const selector of opts.selectors) {
+        const element = await page.$(selector);
+        if (element) {
+          await element.screenshot({ path: opts.out, type: 'png' });
+          log(`Matched selector: ${selector}`, 'cyan');
+          captured = true;
+          break;
+        }
+      }
+      if (!captured) {
+        log('No selector matched, falling back to full page', 'yellow');
+      }
+    }
+
+    if (!captured) {
+      await page.screenshot({ path: opts.out, fullPage: true });
+    }
+
+    const { size } = fs.statSync(opts.out);
+    log(`Saved: ${opts.out} (${Math.round(size / 1024)}KB)`, 'green');
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  log(`\nFatal error: ${error.message}`, 'red');
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/patterns/trim-screenshots.sh
+++ b/scripts/patterns/trim-screenshots.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Trim whitespace from pattern screenshots (in place), keeping aspect ratio.
+# Originals are backed up before modification.
+#
+# Usage:
+#   ./trim-screenshots.sh <screenshots-dir> [width]
+#
+# Example:
+#   ./trim-screenshots.sh ./screenshots 900
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $(basename "$0") <screenshots-dir> [width]"
+    exit 1
+fi
+
+if ! command -v magick &> /dev/null && ! command -v identify &> /dev/null; then
+    echo "Error: ImageMagick not found. Install with: brew install imagemagick"
+    exit 1
+fi
+
+SCREENSHOTS_DIR="$(cd "$1" && pwd)"
+WIDTH="${2:-900}"
+BACKUP_DIR="$SCREENSHOTS_DIR/originals"
+
+echo -e "${BLUE}Trim Pattern Screenshots${NC}"
+echo -e "${BLUE}========================${NC}\n"
+
+mkdir -p "$BACKUP_DIR"
+echo -e "${YELLOW}Backups in: $BACKUP_DIR${NC}\n"
+
+PROCESSED=0
+SKIPPED=0
+
+for file in "$SCREENSHOTS_DIR"/pattern-*.webp; do
+    [ -f "$file" ] || continue
+
+    filename=$(basename "$file")
+    backup_file="$BACKUP_DIR/$filename"
+
+    if [ -f "$backup_file" ]; then
+        echo -e "${YELLOW}skip${NC} $filename (already processed)"
+        ((SKIPPED++))
+        continue
+    fi
+
+    echo -e "${BLUE}trim${NC} $filename"
+    cp "$file" "$backup_file"
+
+    current_dims=$(identify -format "%wx%h" "$file")
+
+    magick "$file" \
+        -trim \
+        +repage \
+        -resize "${WIDTH}x" \
+        -quality 85 \
+        "$file"
+
+    new_dims=$(identify -format "%wx%h" "$file")
+    file_size=$(du -h "$file" | cut -f1)
+
+    echo -e "   ${current_dims} -> ${new_dims} (${file_size})"
+    ((PROCESSED++))
+done
+
+echo ""
+echo -e "${GREEN}Done.${NC} Processed: $PROCESSED  Skipped: $SKIPPED"
+echo -e "\nTo restore originals: cp $BACKUP_DIR/*.webp $SCREENSHOTS_DIR/"


### PR DESCRIPTION
## Summary
- Adds `scripts/patterns/`, a generalized Playwright/sharp toolkit for screenshotting WordPress block patterns and converting them to WebP (temp-page creation via a fully configurable `WP_CLI_CMD`, generic URL/element screenshot primitive, WebP conversion, ImageMagick trim/center post-processing)
- Adds `scripts/monitoring/server-monitor.sh`, a live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot over SSH, complementing the existing log-based traffic/security/AI-bot monitors
- Wires both into `scripts/README.md` and `CLAUDE.md`, and adds a `[3.7.0]` CHANGELOG entry
- Second pass of the client-project script audit flagged in 3.6.0; deliberately excludes `check-carousel.sh` and ~50 one-off debug scripts from the source project that are too coupled to a specific theme/carousel block to generalize

## Test plan
- [x] `bash -n` on all new/modified shell scripts
- [x] `node --check` on all new JS files
- [x] Verified `wp-ops` auto-discovers all 6 new scripts with correct descriptions (`wp-ops --json`)
- [x] Verified `--help` output on `server-monitor.sh` and `screenshot-patterns.sh` renders correctly (found and fixed an ANSI color heredoc bug and a missing `--help` guard in the process)
- [ ] Manual end-to-end run of `screenshot-patterns.sh` against a real WordPress site (not run in this session — no live site available)