### PR TITLE
Add error-monitor.sh and wp-ops docs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-07-31
+
+### Added
+
+- **scripts/monitoring** - New `error-monitor.sh`: error-log review across the whole stack — Nginx (global and per-site, with a severity breakdown), PHP-FPM, WordPress/Acorn exceptions, MySQL/MariaDB, and the systemd journal (priority-`err` messages, PHP segfaults, OOM kills). Completes the monitoring set: the existing three read the *access* log and answer "who is visiting?", this one reads the *error* logs and answers "is anything broken?". Migrated from a client project, where it hardcoded one server and one domain; it now takes `[domain] [hours] [output_file]` like its siblings and is wired into `run-monitoring.sh`, whose summary gains an error section that calls out segfaults and OOM kills separately — those drop requests mid-flight and leave no access-log trace. Where the journal isn't readable (the `web` user usually can't), those sections report as *skipped* rather than empty, since "no errors" and "no permission" otherwise look identical while you're chasing an outage.
+- **wp-ops CLI** - `wp-ops docs [term]`: full-text search across the repository's ~60 guides, grouped by document with line numbers. `wp-ops search` only ever looked at command names and descriptions, which left two entire categories (`nginx/`, `troubleshooting/`) and every README unreachable from the CLI — a large part of what this toolkit knows is written down rather than scripted. `-w` matches whole words only (so `oom` stops matching "server room"), `-l` prints paths only for piping to an editor, and a bare `wp-ops docs` lists every guide. When `wp-ops search` finds no command for a term, it now checks the documentation and points there.
+
+### Fixed
+
+- **scripts/monitoring/error-monitor** - Time filtering that only claimed to be time filtering. The original counted `tail -100 | wc -l`, which reports ~100 for any non-empty log regardless of the window, and its Nginx count combined `find`'s output with a line count into a value that made `[ "$x" -gt 0 ]` fail outright. Every source is now filtered to the requested window by its own timestamp format (Nginx `2026/07/31 11:07:01`, PHP-FPM `[31-Jul-2026 …]`, Acorn `[2026-07-31 …]`, MySQL ISO), all of which sort chronologically as text — so plain `awk` string comparison suffices and no `gawk` is required on the server. Counts and excerpts now come from a single read of each file, so the number can't disagree with the lines printed beneath it. Also: PHP-FPM logs are found by globbing `/var/log/php*-fpm.log` instead of asking `php -v` (the CLI version can differ from the version FPM runs), Acorn stack-trace continuation lines stay attached to their entry, and the summary no longer exits early on `set -e` when a breakdown line's count is zero.
+- **wp-ops CLI** - The server-side guidance printed for `run-monitoring` was written for the access-log monitors: it described reading `access.log`, suggested a log path as the first argument (`run-monitoring`'s is an hour count), and offered to run it locally against a log file it doesn't accept. Guidance, example arguments, and the local-log-file escape hatch are now scoped to the commands that genuinely take an access log path.
+
 ## [3.8.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ wp-ops trellis --help        # list commands in one category
 wp-ops <category> <command> [args...]
 
 wp-ops search webp           # find a command by name or description
+wp-ops docs oom              # search the guides, not just the commands
 wp-ops doctor                # check dependencies and environment
 wp-ops <command> --where     # print the path to a command's script
 ```
@@ -56,13 +57,25 @@ If either variable is unset, wp-ops looks for the project by walking up from you
 
 `nginx/` and `troubleshooting/` contain guides and Nginx config templates rather than runnable scripts; `wp-ops nginx` lists those documents instead of commands.
 
-Everything else runs on your own machine, including the commands that touch a server — Ansible playbooks, `server-monitor`, and `post-count --ssh` all reach out over SSH from here. The exception is the Nginx log monitors, which read `/srv/www/<site>/logs/` directly and execute on the host. Those are tagged `(server)` in listings and search, and running one locally prints the SSH invocation rather than failing on a missing log path:
+A good deal of what this repo knows is written down rather than scripted, so `wp-ops docs` searches the prose the way `wp-ops search` searches the catalog:
+
+```bash
+wp-ops docs                  # list every guide
+wp-ops docs "search-replace" # show matching lines, grouped by document
+wp-ops docs oom -w           # whole words only (so "oom" skips "server room")
+wp-ops docs oom -l           # paths only, for piping: wp-ops docs oom -l | xargs $EDITOR
+```
+
+When `wp-ops search` finds no command for a term, it checks the documentation and points you there.
+
+Everything else runs on your own machine, including the commands that touch a server — Ansible playbooks, `server-monitor`, and `post-count --ssh` all reach out over SSH from here. The exception is the log monitors, which read `/srv/www/<site>/logs/` and `/var/log/` directly and execute on the host. Those are tagged `(server)` in listings and search, and running one locally prints the SSH invocation rather than failing on a missing log path:
 
 ```bash
 ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 48
 ```
 
-Nothing needs to be installed on the server for that — the script is streamed to its stdin. It does want `gawk` there for accurate time filtering (Ubuntu ships mawk, so `apt install gawk`); without it the monitors fall back to a line-count estimate. `wp-ops --json` reports this as a `runs_on` field (`local` or `server`).
+Nothing needs to be installed on the server for that — the script is streamed to its stdin. The access-log monitors want `gawk` there for accurate time filtering (Ubuntu ships mawk, so `apt install gawk`); without it they fall back to a line-count estimate. `error-monitor` needs neither gawk nor a log path — it takes the domain, and connecting as `root` additionally gets you the systemd sections (critical errors, PHP segfaults, OOM kills) that the `web` user can't read. `wp-ops --json` reports the local/server split as a `runs_on` field.
 
 `wordpress-utilities/` is different: those are copy-paste-into-a-theme snippets, not runnable scripts, so `wp-ops wordpress-utilities <snippet>` prints or clipboard-copies them instead:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,6 +41,7 @@ scripts/
 ├── monitoring/                  # Server monitoring and alerting
 │   ├── 404-checker.sh          # Internal broken-link checker (homepage scan or recursive spider)
 │   ├── ai-bot-monitor.sh       # AI crawler traffic analysis (GPTBot, ClaudeBot, etc.)
+│   ├── error-monitor.sh        # Nginx/PHP-FPM/WordPress/MySQL/systemd error log review
 │   ├── redirect-check.sh       # Mass URL redirect checker using curl
 │   ├── run-monitoring.sh       # Orchestrator: runs all monitors and generates summary
 │   ├── security-monitor.sh     # Nginx security threat detection
@@ -147,6 +148,9 @@ cd ~/code/my-plugin
 
 # Live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot
 ./scripts/monitoring/server-monitor.sh web@example.com
+
+# Review error logs (nginx, PHP-FPM, WordPress, MySQL, systemd)
+ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 24
 
 # Run all monitors and save timestamped reports
 ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
@@ -1643,6 +1647,83 @@ Average per worker: 150.02 MB
 
 ---
 
+### error-monitor.sh
+
+Error-log review across every layer of the stack. The traffic/security/AI-bot
+monitors read the *access* log and answer "who is visiting?"; this one reads the
+*error* logs and answers "is anything broken?".
+
+Runs **on the server** — it reads `/var/log/` and `/srv/www/<domain>/logs/`
+directly and needs GNU `date` — so stream it over SSH like `run-monitoring.sh`.
+
+#### Features
+
+- Nginx error log, global and per-site, with a severity breakdown
+  (`[emerg]`/`[alert]`/`[crit]`/`[error]`/`[warn]`/`[notice]`) so a single
+  `[emerg]` isn't buried among hundreds of routine notices
+- PHP-FPM error log, discovered by globbing `/var/log/php*-fpm.log` rather than
+  asking `php -v` — the CLI version can differ from the version FPM runs, and a
+  server mid-upgrade has more than one log
+- WordPress/Acorn exceptions (`.../cache/acorn/logs/laravel.log`), with stack
+  trace continuation lines kept attached to their entry
+- MySQL/MariaDB error log
+- systemd journal: priority-`err` messages, PHP segfaults, OOM kills
+- Every source is **filtered to the requested time window**, each by its own
+  timestamp format — counts and excerpts come from one read of the file, so they
+  can never disagree
+- Summary with a per-source breakdown, and a callout when segfaults or OOM kills
+  occurred (those drop requests mid-flight and never appear in the access log)
+
+#### Usage
+
+```bash
+ssh <target> 'bash -s' < ./error-monitor.sh [domain] [hours] [output_file]
+
+# Examples
+ssh web@example.com 'bash -s' < scripts/monitoring/error-monitor.sh
+ssh web@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 48
+ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 24
+
+# On the server itself
+./error-monitor.sh example.com 24
+```
+
+Connect as **root** to include the systemd sections. The `web` user usually
+can't read the journal, in which case those checks are reported as *skipped*
+rather than silently empty — an empty result and no permission look identical
+otherwise, and the difference matters when you're chasing an outage.
+
+#### Example Output
+
+```
+━━━ Nginx Error Log (example.com) ━━━
+14 entries in the last 24h (/srv/www/example.com/logs/error.log)
+
+━━━ Nginx Severity Breakdown ━━━
+  11 [error]
+   2 [warn]
+   1 [crit]
+
+━━━ Out of Memory Events ━━━
+✓ No OOM killer events
+
+━━━ Summary ━━━
+23 log entries in the last 24 hours
+
+Breakdown:
+  - Nginx (example.com):   14
+  - PHP-FPM:               2
+  - WordPress/Acorn:       7
+```
+
+#### Requirements
+
+- Runs on the server (GNU `date`; no `gawk` needed — the time filtering is plain
+  `awk` string comparison, since these log formats all sort chronologically as text)
+- `journalctl` access for the systemd sections (root, or a user in `adm`/`systemd-journal`)
+
+---
+
 ### 404-checker.sh
 
 Internal broken-link checker for WordPress sites. Scans for pages and links that return 4xx or 5xx responses. Two modes: a fast homepage scan (~30 s) that catches global footer/nav issues, and a recursive wget spider (~5–10 min) that traverses the whole site.
@@ -1740,7 +1821,7 @@ https://example.com/old-page/ => 404 ->
 
 ### run-monitoring.sh (285 lines)
 
-Orchestrator that runs all three monitoring scripts in sequence and generates a consolidated markdown summary report.
+Orchestrator that runs all four monitoring scripts in sequence and generates a consolidated markdown summary report.
 
 #### Features
 
@@ -1748,11 +1829,13 @@ Orchestrator that runs all three monitoring scripts in sequence and generates a 
   - `traffic-monitor.sh` — traffic analysis
   - `security-monitor.sh` — security threat detection
   - `ai-bot-monitor.sh` — AI crawler analysis
+  - `error-monitor.sh` — error logs across nginx, PHP-FPM, WordPress, MySQL, systemd
 
 - **Timestamped Output Files** (for the default site):
   - `traffic-monitor-YYYY-MM-DD-HHmmss.txt`
   - `security-monitor-YYYY-MM-DD-HHmmss.txt`
   - `ai-bot-monitor-YYYY-MM-DD-HHmmss.txt`
+  - `error-monitor-YYYY-MM-DD-HHmmss.txt`
   - `monitoring-summary-YYYY-MM-DD.md` — consolidated markdown report
 
   When a non-default `domain` argument is passed, each filename gets a
@@ -1767,8 +1850,13 @@ Orchestrator that runs all three monitoring scripts in sequence and generates a 
   - Site name, total requests, real user traffic, unique visitors, bandwidth
   - Security alert and warning counts with top alerts listed
   - AI crawler share of traffic and bandwidth
+  - Error-log entry totals, plus PHP segfault and OOM-kill counts called out
+    separately (those take down requests without leaving an access-log trace)
   - Top 10 most requested pages (real users)
   - Recommendations and next steps
+
+  Run it as `root` to get the systemd portion of the error report; as `web` those
+  sections are marked skipped.
 
 #### Usage
 

--- a/scripts/monitoring/error-monitor.sh
+++ b/scripts/monitoring/error-monitor.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+#
+# Error Monitor - Surface errors from Nginx, PHP-FPM, WordPress, MySQL and systemd
+#
+# Complements the traffic/security/AI-bot monitors, which read the *access* log.
+# This one answers "is anything broken?" rather than "who is visiting?".
+#
+# Runs on the server (it reads /srv/www/<domain>/logs/ and /var/log/ directly
+# and needs GNU date), so invoke it the same way as the other monitors:
+#
+# Usage:
+#   ssh web@example.com 'bash -s' < ./error-monitor.sh [domain] [hours] [output_file]
+#   ./error-monitor.sh example.com 24        # on the server itself
+#
+# Examples:
+#   ssh web@example.com 'bash -s' < scripts/monitoring/error-monitor.sh
+#   ssh web@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 48
+#   ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 24
+#
+# The systemd sections (critical errors, PHP segfaults, OOM kills) need journal
+# read access. The web user usually lacks it, so those are reported as skipped
+# rather than empty — connect as root, or add the user to the adm/systemd-journal
+# group, to include them.
+#
+
+set -uo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DOMAIN="${1:-example.com}"
+HOURS="${2:-24}"
+OUTPUT_FILE="${3:-}"  # Optional: path to save report
+
+SITE_ERROR_LOG="/srv/www/${DOMAIN}/logs/error.log"
+NGINX_ERROR_LOG="/var/log/nginx/error.log"
+# Acorn (Sage 10+) writes WordPress-side exceptions here. Sites not using Acorn
+# simply won't have it, which is reported as "not found" rather than as a fault.
+ACORN_LOG="/srv/www/${DOMAIN}/current/web/app/cache/acorn/logs/laravel.log"
+MYSQL_ERROR_LOG="/var/log/mysql/error.log"
+
+# How many matching lines to print per section. The counts are always exact —
+# this only caps the excerpt.
+SAMPLE_LINES=30
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Usage: $(basename "$0") [domain] [hours] [output_file]"
+    echo ""
+    echo "Runs on the server. From your machine:"
+    echo "  ssh web@example.com 'bash -s' < $(basename "$0") example.com 24"
+    exit 0
+fi
+
+# ============================================================================
+# Time Filtering
+# ============================================================================
+#
+# Every log here stamps its lines differently, so each gets its own cutoff in
+# its own format and a plain string comparison does the rest — all four formats
+# are zero-padded and therefore sort chronologically as text. No gawk needed
+# (unlike the access-log monitors, which parse Nginx's combined-format date).
+
+if ! date -d "1 hour ago" +%s >/dev/null 2>&1; then
+    echo "Error: GNU date is required (this script is meant to run on the server)." >&2
+    echo "From your machine: ssh web@${DOMAIN} 'bash -s' < $(basename "$0")" >&2
+    exit 1
+fi
+
+CUTOFF_NGINX=$(date -d "${HOURS} hours ago" +'%Y/%m/%d %H:%M:%S')   # 2026/07/31 11:07:01
+CUTOFF_ISO=$(date -d "${HOURS} hours ago" +'%Y-%m-%d %H:%M:%S')     # 2026-07-31 11:07:01
+CUTOFF_COMPACT=$(date -d "${HOURS} hours ago" +'%Y%m%d%H%M%S')      # 20260731110701
+
+# Nginx error log: "2026/07/31 11:07:01 [error] 12345#0: ..."
+filter_nginx() {
+    awk -v cutoff="$CUTOFF_NGINX" '
+        substr($0, 5, 1) == "/" && substr($0, 8, 1) == "/" {
+            show = (($1 " " $2) >= cutoff)
+        }
+        show
+    ' "$1" 2>/dev/null
+}
+
+# PHP-FPM log: "[31-Jul-2026 11:07:01] WARNING: ..."
+# Continuation lines (stack traces) carry no stamp, so they inherit the
+# decision made for the entry that opened the block.
+filter_php_fpm() {
+    awk -v cutoff="$CUTOFF_COMPACT" '
+        BEGIN {
+            split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", names, " ")
+            for (i = 1; i <= 12; i++) month[names[i]] = sprintf("%02d", i)
+        }
+        substr($0, 1, 1) == "[" && substr($0, 4, 1) == "-" && substr($0, 8, 1) == "-" {
+            stamp = substr($0, 9, 4) month[substr($0, 5, 3)] substr($0, 2, 2)
+            time = substr($0, 14, 8)
+            gsub(/:/, "", time)
+            show = ((stamp time) >= cutoff)
+        }
+        show
+    ' "$1" 2>/dev/null
+}
+
+# Acorn/Laravel log: "[2026-07-31 11:07:01] production.ERROR: ..."
+filter_acorn() {
+    awk -v cutoff="$CUTOFF_ISO" '
+        substr($0, 1, 1) == "[" && substr($0, 6, 1) == "-" && substr($0, 9, 1) == "-" {
+            show = (substr($0, 2, 19) >= cutoff)
+        }
+        show
+    ' "$1" 2>/dev/null
+}
+
+# MySQL/MariaDB error log: "2026-07-31 11:07:01 0 [Note] ..."
+filter_mysql() {
+    awk -v cutoff="$CUTOFF_ISO" '
+        substr($0, 5, 1) == "-" && substr($0, 8, 1) == "-" {
+            show = (substr($0, 1, 19) >= cutoff)
+        }
+        show
+    ' "$1" 2>/dev/null
+}
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+print_header() {
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}$1${NC}"
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+print_section() {
+    echo -e "${BOLD}━━━ $1 ━━━${NC}"
+}
+
+# An empty $(...) still counts as one line under `wc -l <<<`, so count here
+# instead and keep every caller honest about "0".
+count_lines() {
+    if [[ -z "$1" ]]; then
+        echo 0
+    else
+        printf '%s\n' "$1" | wc -l | tr -d ' '
+    fi
+}
+
+# "1 entries in the last 1 hours" reads like a bug in the script rather than a
+# quiet hour, and these reports get pasted into tickets.
+plural() {
+    local count="$1" singular="$2" plural="${3:-${2}s}"
+    if [[ "$count" -eq 1 ]]; then echo "$singular"; else echo "$plural"; fi
+}
+
+# Reports both the count for the window and an excerpt, from a single read of
+# the log — so the number and the lines below it can never disagree.
+report_log() {
+    local label="$1" path="$2" lines="$3" count="$4"
+
+    print_section "$label"
+    if [[ ! -f "$path" ]]; then
+        echo -e "${BLUE}ℹ Not found: ${path}${NC}"
+    elif [[ ! -r "$path" ]]; then
+        echo -e "${YELLOW}⚠ Not readable by $(whoami): ${path}${NC}"
+    elif [[ "$count" -eq 0 ]]; then
+        echo -e "${GREEN}✓ No entries in the last ${HOURS}h${NC}"
+    else
+        echo -e "${YELLOW}${count} $(plural "$count" entry entries) in the last ${HOURS}h${NC} ${BLUE}(${path})${NC}"
+        echo ""
+        printf '%s\n' "$lines" | tail -n "$SAMPLE_LINES"
+        [[ "$count" -gt "$SAMPLE_LINES" ]] && echo -e "${BLUE}… showing last ${SAMPLE_LINES} of ${count}${NC}"
+    fi
+    echo ""
+}
+
+read_log() {
+    local path="$1" filter="$2"
+    [[ -f "$path" && -r "$path" ]] || return 0
+    "$filter" "$path"
+}
+
+have_journal() {
+    journalctl -n 0 >/dev/null 2>&1
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+    if [[ -n "$OUTPUT_FILE" ]]; then
+        exec > >(tee "$OUTPUT_FILE")
+    fi
+
+    local window="${HOURS} $(plural "$HOURS" hour)"
+
+    print_header "Error Monitor - ${DOMAIN} - Last ${window}"
+    echo ""
+    echo -e "${BLUE}Generated:${NC} $(date)"
+    echo -e "${BLUE}Host:${NC} $(hostname)"
+    echo -e "${BLUE}Since:${NC} ${CUTOFF_ISO}"
+    echo ""
+
+    # --- Log files ---------------------------------------------------------
+
+    local nginx_lines nginx_count
+    nginx_lines=$(read_log "$NGINX_ERROR_LOG" filter_nginx)
+    nginx_count=$(count_lines "$nginx_lines")
+    report_log "Nginx Error Log (global)" "$NGINX_ERROR_LOG" "$nginx_lines" "$nginx_count"
+
+    # Severity breakdown is only meaningful for the Nginx logs, whose lines are
+    # tagged [error]/[crit]/[warn]/…; a bare count hides a single [emerg] among
+    # hundreds of routine [notice]s.
+    if [[ "$nginx_count" -gt 0 ]]; then
+        print_section "Nginx Severity Breakdown"
+        printf '%s\n' "$nginx_lines" \
+            | grep -oE '\[(emerg|alert|crit|error|warn|notice|info)\]' \
+            | sort | uniq -c | sort -rn
+        echo ""
+    fi
+
+    local site_lines site_count
+    site_lines=$(read_log "$SITE_ERROR_LOG" filter_nginx)
+    site_count=$(count_lines "$site_lines")
+    report_log "Nginx Error Log (${DOMAIN})" "$SITE_ERROR_LOG" "$site_lines" "$site_count"
+
+    # PHP-FPM's log is version-stamped (php8.3-fpm.log), and a server mid-upgrade
+    # has more than one. Glob rather than asking `php -v`, which reports the CLI
+    # version and can differ from the version FPM actually runs.
+    print_section "PHP-FPM Error Log"
+    local php_total=0 php_log php_lines php_count found_php=0
+    for php_log in /var/log/php*-fpm.log; do
+        [[ -f "$php_log" ]] || continue
+        found_php=1
+        php_lines=$(read_log "$php_log" filter_php_fpm)
+        php_count=$(count_lines "$php_lines")
+        php_total=$((php_total + php_count))
+        if [[ "$php_count" -eq 0 ]]; then
+            echo -e "${GREEN}✓ No entries in the last ${HOURS}h${NC} ${BLUE}(${php_log})${NC}"
+        else
+            echo -e "${YELLOW}${php_count} $(plural "$php_count" entry entries) in the last ${HOURS}h${NC} ${BLUE}(${php_log})${NC}"
+            echo ""
+            printf '%s\n' "$php_lines" | tail -n "$SAMPLE_LINES"
+            [[ "$php_count" -gt "$SAMPLE_LINES" ]] && echo -e "${BLUE}… showing last ${SAMPLE_LINES} of ${php_count}${NC}"
+            echo ""
+        fi
+    done
+    [[ "$found_php" -eq 0 ]] && echo -e "${BLUE}ℹ No /var/log/php*-fpm.log found${NC}"
+    echo ""
+
+    local acorn_lines acorn_count
+    acorn_lines=$(read_log "$ACORN_LOG" filter_acorn)
+    acorn_count=$(count_lines "$acorn_lines")
+    report_log "WordPress/Acorn Log" "$ACORN_LOG" "$acorn_lines" "$acorn_count"
+
+    local mysql_lines mysql_count
+    mysql_lines=$(read_log "$MYSQL_ERROR_LOG" filter_mysql)
+    mysql_count=$(count_lines "$mysql_lines")
+    report_log "MySQL/MariaDB Error Log" "$MYSQL_ERROR_LOG" "$mysql_lines" "$mysql_count"
+
+    # --- systemd journal ---------------------------------------------------
+
+    local critical_count=0 segfault_count=0 oom_count=0
+    local journal_available=0
+    have_journal && journal_available=1
+
+    if [[ "$journal_available" -eq 0 ]]; then
+        print_section "System Journal"
+        echo -e "${YELLOW}⚠ Skipped — $(whoami) cannot read the journal.${NC}"
+        echo -e "${BLUE}  Critical errors, PHP segfaults and OOM kills are not included.${NC}"
+        echo -e "${BLUE}  Connect as root, or: sudo usermod -aG adm,systemd-journal $(whoami)${NC}"
+        echo ""
+    else
+        local critical_lines segfault_lines oom_lines
+
+        print_section "System Journal (Priority: error and above)"
+        critical_lines=$(journalctl --since "${HOURS} hours ago" -p err --no-pager 2>/dev/null | grep -v '^-- No entries' || true)
+        critical_count=$(count_lines "$critical_lines")
+        if [[ "$critical_count" -eq 0 ]]; then
+            echo -e "${GREEN}✓ No critical system errors${NC}"
+        else
+            echo -e "${RED}⚠ ${critical_count} critical system errors${NC}"
+            echo ""
+            printf '%s\n' "$critical_lines" | tail -n 20
+        fi
+        echo ""
+
+        print_section "PHP Segmentation Faults"
+        segfault_lines=$(journalctl --since "${HOURS} hours ago" --no-pager 2>/dev/null | grep -i 'segfault.*php' || true)
+        segfault_count=$(count_lines "$segfault_lines")
+        if [[ "$segfault_count" -eq 0 ]]; then
+            echo -e "${GREEN}✓ No PHP segmentation faults${NC}"
+        else
+            echo -e "${RED}⚠ ${segfault_count} PHP segmentation faults${NC}"
+            echo ""
+            printf '%s\n' "$segfault_lines" | tail -n 10
+        fi
+        echo ""
+
+        print_section "Out of Memory Events"
+        oom_lines=$(journalctl -k --since "${HOURS} hours ago" --no-pager 2>/dev/null | grep -iE 'out of memory|oom[-_]kill' || true)
+        oom_count=$(count_lines "$oom_lines")
+        if [[ "$oom_count" -eq 0 ]]; then
+            echo -e "${GREEN}✓ No OOM killer events${NC}"
+        else
+            echo -e "${RED}⚠ ${oom_count} out-of-memory events${NC}"
+            echo ""
+            printf '%s\n' "$oom_lines" | tail -n 10
+            echo ""
+            echo -e "${BLUE}  See troubleshooting/OOM.md for diagnosis and swap setup.${NC}"
+        fi
+        echo ""
+    fi
+
+    # --- Summary -----------------------------------------------------------
+
+    print_section "Summary"
+    local total=$((nginx_count + site_count + php_total + acorn_count + mysql_count + critical_count + segfault_count + oom_count))
+
+    if [[ "$total" -eq 0 ]]; then
+        echo -e "${GREEN}✓ No log entries in the last ${window}${NC}"
+    else
+        echo -e "${YELLOW}${total} log $(plural "$total" entry entries) in the last ${window}${NC}"
+        echo ""
+        echo "Breakdown:"
+        [[ "$nginx_count" -gt 0 ]]    && echo "  - Nginx (global):        $nginx_count"
+        [[ "$site_count" -gt 0 ]]     && echo "  - Nginx (${DOMAIN}):     $site_count"
+        [[ "$php_total" -gt 0 ]]      && echo "  - PHP-FPM:               $php_total"
+        [[ "$acorn_count" -gt 0 ]]    && echo "  - WordPress/Acorn:       $acorn_count"
+        [[ "$mysql_count" -gt 0 ]]    && echo "  - MySQL/MariaDB:         $mysql_count"
+        [[ "$critical_count" -gt 0 ]] && echo "  - System (priority err): $critical_count"
+        [[ "$segfault_count" -gt 0 ]] && echo "  - PHP segfaults:         $segfault_count"
+        [[ "$oom_count" -gt 0 ]]      && echo "  - OOM kills:             $oom_count"
+        echo ""
+        echo -e "${BLUE}Counts include informational lines — check the severity breakdown${NC}"
+        echo -e "${BLUE}and excerpts above before treating a total as a problem.${NC}"
+    fi
+    echo ""
+
+    if [[ "$segfault_count" -gt 0 || "$oom_count" -gt 0 ]]; then
+        echo -e "${RED}Segfaults or OOM kills need attention first — they take down requests${NC}"
+        echo -e "${RED}mid-flight and are not visible in the access log.${NC}"
+        echo ""
+    fi
+
+    print_header "Monitor Complete"
+
+    if [[ -n "$OUTPUT_FILE" ]]; then
+        echo ""
+        echo "Report saved to: $OUTPUT_FILE"
+    fi
+}
+
+main "$@"

--- a/scripts/monitoring/run-monitoring.sh
+++ b/scripts/monitoring/run-monitoring.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Run Monitoring - Combined traffic, security, and AI bot monitoring
+# Run Monitoring - Combined traffic, security, AI bot, and error monitoring
 #
-# This script runs traffic-monitor.sh, security-monitor.sh, and ai-bot-monitor.sh
-# and saves timestamped reports to an output directory.
+# This script runs traffic-monitor.sh, security-monitor.sh, ai-bot-monitor.sh,
+# and error-monitor.sh, and saves timestamped reports to an output directory.
 #
 # Usage:
 #   ssh web@example.com 'bash -s' < ./run-monitoring.sh [hours] [domain]
@@ -54,6 +54,7 @@ fi
 TRAFFIC_REPORT="${OUTPUT_DIR}/traffic-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
 SECURITY_REPORT="${OUTPUT_DIR}/security-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
 AI_BOT_REPORT="${OUTPUT_DIR}/ai-bot-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
+ERROR_REPORT="${OUTPUT_DIR}/error-monitor${DOMAIN_SUFFIX}-${TIMESTAMP}.txt"
 SUMMARY_REPORT="${OUTPUT_DIR}/monitoring-summary${DOMAIN_SUFFIX}-${DATESTAMP}.md"
 
 # Colors for output
@@ -123,6 +124,18 @@ main() {
 
     echo ""
 
+    # Run error monitor. Unlike the three above it reads the *error* logs rather
+    # than the access log, so it takes the domain instead of a log file path.
+    print_info "Running error log analysis..."
+    if [[ -f "${SCRIPT_DIR}/error-monitor.sh" ]]; then
+        bash "${SCRIPT_DIR}/error-monitor.sh" "$DOMAIN" "$HOURS" "$ERROR_REPORT"
+        print_success "Error report saved: $ERROR_REPORT"
+    else
+        echo "Warning: error-monitor.sh not found in ${SCRIPT_DIR}"
+    fi
+
+    echo ""
+
     # Generate summary report
     print_info "Generating markdown summary..."
     generate_summary
@@ -133,6 +146,7 @@ main() {
     echo "  - Traffic:  $TRAFFIC_REPORT"
     echo "  - Security: $SECURITY_REPORT"
     echo "  - AI Bots:  $AI_BOT_REPORT"
+    echo "  - Errors:   $ERROR_REPORT"
     echo "  - Summary:  $SUMMARY_REPORT"
 }
 
@@ -202,12 +216,40 @@ EOF
         fi
     fi
 
+    # Extract error counts from the error report if it exists
+    if [[ -f "$ERROR_REPORT" ]]; then
+        echo "### Error Overview" >> "$SUMMARY_REPORT"
+        echo "" >> "$SUMMARY_REPORT"
+
+        # The summary line reads "N log entries in the last H hours", or
+        # "No log entries ..." when the window was clean.
+        error_total=$(sed 's/\x1b\[[0-9;]*m//g' "$ERROR_REPORT" \
+            | grep -oE '^[0-9]+ log entr(y|ies) in the last' | awk '{print $1}' | head -1)
+        echo "- **Log Entries (all sources):** ${error_total:-0}" >> "$SUMMARY_REPORT"
+
+        segfaults=$(sed 's/\x1b\[[0-9;]*m//g' "$ERROR_REPORT" \
+            | grep -oE '^  - PHP segfaults: +[0-9]+' | awk '{print $NF}' | head -1)
+        ooms=$(sed 's/\x1b\[[0-9;]*m//g' "$ERROR_REPORT" \
+            | grep -oE '^  - OOM kills: +[0-9]+' | awk '{print $NF}' | head -1)
+        echo "- **PHP Segfaults:** ${segfaults:-0}" >> "$SUMMARY_REPORT"
+        echo "- **OOM Kills:** ${ooms:-0}" >> "$SUMMARY_REPORT"
+
+        echo "" >> "$SUMMARY_REPORT"
+
+        if [[ "${segfaults:-0}" -gt 0 || "${ooms:-0}" -gt 0 ]]; then
+            echo "> ⚠️ Segfaults or OOM kills occurred — these drop requests mid-flight" >> "$SUMMARY_REPORT"
+            echo "> and do not show up in the access log. See troubleshooting/OOM.md." >> "$SUMMARY_REPORT"
+            echo "" >> "$SUMMARY_REPORT"
+        fi
+    fi
+
     cat >> "$SUMMARY_REPORT" <<EOF
 ## Report Files
 
 - [Traffic Analysis Report]($(basename "$TRAFFIC_REPORT"))
 - [Security Analysis Report]($(basename "$SECURITY_REPORT"))
 - [AI Crawler Report]($(basename "$AI_BOT_REPORT"))
+- [Error Log Report]($(basename "$ERROR_REPORT"))
 
 ## SEO Traffic Insights
 

--- a/wp-ops
+++ b/wp-ops
@@ -8,6 +8,7 @@
 #        wp-ops --help
 #        wp-ops --json list
 #        wp-ops search <term>
+#        wp-ops docs <term>
 #        wp-ops doctor
 #        wp-ops scripts backup db example.com production
 #
@@ -96,6 +97,7 @@ SERVER_SIDE_COMMANDS="
 scripts/monitoring/traffic-monitor
 scripts/monitoring/security-monitor
 scripts/monitoring/ai-bot-monitor
+scripts/monitoring/error-monitor
 scripts/monitoring/run-monitoring
 "
 
@@ -107,6 +109,38 @@ ${command_key}
 "*) return 0 ;;
     esac
     return 1
+}
+
+# The subset of those that take an Nginx *access* log path as their first
+# argument. For these, "I already have a copy of the log here" is a meaningful
+# thing to say, and they're the ones that need gawk to parse the combined-format
+# timestamp. error-monitor reads a fixed set of system log paths for a domain and
+# filters them with plain awk, and run-monitoring's first argument is an hour
+# count — neither has a log file you could hand it locally.
+ACCESS_LOG_COMMANDS="
+scripts/monitoring/traffic-monitor
+scripts/monitoring/security-monitor
+scripts/monitoring/ai-bot-monitor
+"
+
+takes_access_log_argument() {
+    local command_key="$1"
+    case "$ACCESS_LOG_COMMANDS" in
+        *"
+${command_key}
+"*) return 0 ;;
+    esac
+    return 1
+}
+
+# Example arguments to show after the SSH redirect. Each of these scripts orders
+# its positional arguments differently, and a wrong example is worse than none.
+server_side_example_args() {
+    case "$1" in
+        scripts/monitoring/error-monitor) echo "example.com 48" ;;
+        scripts/monitoring/run-monitoring) echo "24 example.com" ;;
+        *) echo "/srv/www/example.com/logs/access.log 24" ;;
+    esac
 }
 
 # Those scripts date-filter with `date -d "N hours ago"`, which is GNU-only —
@@ -382,6 +416,7 @@ print_usage() {
     echo "  wp-ops [command] --where         Print the path to a command's script"
     echo ""
     echo "  wp-ops search <term>             Search commands by name or description"
+    echo "  wp-ops docs [term] [-l]          Search the guides (no term lists them)"
     echo "  wp-ops doctor                    Check dependencies and environment"
     echo "  wp-ops --help, -h                Show this help message"
     echo "  wp-ops --version, -v             Show version"
@@ -890,20 +925,40 @@ print_server_side_guidance() {
 
     echo "${YELLOW}${WARN} ${command_key} runs on the server, not here.${RESET}"
     echo ""
-    echo "It reads /srv/www/<site>/logs/access.log directly and uses GNU 'date -d',"
-    echo "so it has to execute on the Trellis host. Stream it over SSH — nothing"
-    echo "needs to be installed there:"
+    if [[ "$command_key" == "scripts/monitoring/error-monitor" ]]; then
+        echo "It reads /var/log/nginx/, /var/log/php*-fpm.log, /srv/www/<site>/logs/"
+        echo "and the systemd journal directly, and uses GNU 'date -d', so it has to"
+        echo "execute on the Trellis host. Stream it over SSH — nothing needs to be"
+        echo "installed there:"
+    else
+        echo "It reads /srv/www/<site>/logs/access.log directly and uses GNU 'date -d',"
+        echo "so it has to execute on the Trellis host. Stream it over SSH — nothing"
+        echo "needs to be installed there:"
+    fi
     echo ""
     echo "  ${BOLD}ssh web@example.com 'bash -s' < ${relative_path}${RESET}"
     echo ""
-    echo "Arguments go after the redirect, e.g. a different log and time window:"
+    echo "Arguments go after the redirect:"
     echo ""
     echo "  ${BOLD}ssh web@example.com 'bash -s' < ${relative_path} \\"
-    echo "      /srv/www/example.com/logs/access.log 24${RESET}"
+    echo "      $(server_side_example_args "$command_key")${RESET}"
     echo ""
+
+    if [[ "$command_key" == "scripts/monitoring/error-monitor" ]]; then
+        echo "${DIM}The systemd sections (critical errors, PHP segfaults, OOM kills) need${RESET}"
+        echo "${DIM}journal access, which the web user usually lacks — connect as root to${RESET}"
+        echo "${DIM}include them. They're reported as skipped rather than empty otherwise.${RESET}"
+        return 0
+    fi
+
     echo "${DIM}Accurate time filtering needs gawk on the server (Ubuntu ships mawk;${RESET}"
     echo "${DIM}apt install gawk). Without it the script falls back to a line estimate.${RESET}"
     echo ""
+
+    if ! takes_access_log_argument "$command_key"; then
+        return 0
+    fi
+
     if has_gnu_date; then
         echo "${DIM}Already have a log file on this machine? Pass its path and it runs here:${RESET}"
         echo "${DIM}  wp-ops ${command_key} /path/to/access.log${RESET}"
@@ -965,10 +1020,13 @@ execute_command() {
                 # /srv/www is the Trellis web root: present when we're actually
                 # on the server (run it), absent on a workstation. An explicit
                 # readable file argument is an intentional "I have the log here"
-                # — honoured, but only where GNU date exists to run it, since
-                # otherwise it dies several screens in on `date: illegal option`.
+                # — honoured for the commands that actually take a log path
+                # (error-monitor's first argument is a domain, run-monitoring's
+                # is an hour count), and only where GNU date exists to run it,
+                # since otherwise it dies several screens in on `date: illegal
+                # option`.
                 if [[ ! -d /srv/www ]]; then
-                    if [[ ! -f "${1:-}" ]]; then
+                    if ! takes_access_log_argument "$command_key" || [[ ! -f "${1:-}" ]]; then
                         print_server_side_guidance "$command_key" "$script_path"
                         return 1
                     fi
@@ -1122,6 +1180,13 @@ print_search_results() {
     if [[ -z "$matches" ]]; then
         echo "${YELLOW}No commands match '${term}'.${RESET}"
         echo ""
+        # Plenty of what this repo knows is written down rather than scripted
+        # (Nginx templates, troubleshooting guides), so point at the prose before
+        # sending someone off to browse the catalog.
+        if [[ -n "$(docs_matching_files "$term")" ]]; then
+            echo "The documentation mentions it though — try ${BOLD}wp-ops docs ${term}${RESET}."
+            echo ""
+        fi
         echo "Run ${BOLD}wp-ops${RESET} to browse everything by category."
         return 1
     fi
@@ -1142,6 +1207,134 @@ print_search_results() {
         is_server_side_command "$cmd_key" && tag="${YELLOW}(server)${RESET} "
         printf "  ${CYAN}%-40s${RESET} %s${DIM}%s${RESET}\n" "$cmd_key" "$tag" "$description"
     done <<< "$matches"
+    echo ""
+}
+
+# =============================================================================
+# Documentation Search
+# =============================================================================
+
+# This repo is more documentation than script — 60-odd guides, and two whole
+# categories (nginx/, troubleshooting/) that hold no runnable command at all.
+# `wp-ops search` only ever looked at command names and descriptions, so none of
+# that prose was reachable from the CLI; you had to know which file to open.
+
+# Matching lines shown per document before the rest are summarised. Guides are
+# long and a common term ("nginx") hits dozens of times in one file, which would
+# otherwise bury the other matching documents.
+DOC_MATCH_LIMIT=3
+
+# Width to truncate a matching line to, so a long paragraph stays on one row.
+DOC_LINE_WIDTH=96
+
+# Short terms drown in substring hits — "oom" also matches "server room", "ttl"
+# matches "settled". `-w` restores the signal without making the default
+# behaviour surprising. Intentionally unquoted at each use site: empty or "-w".
+DOC_GREP_OPTS=""
+
+find_docs() {
+    find "$REPO_ROOT" -type f -name "*.md" \
+        ! -path "*/.git/*" ! -path "*/node_modules/*" ! -path "*/vendor/*" \
+        | sort
+}
+
+# Fed by process substitution rather than a pipe, and always returning 0: under
+# `set -e` a `$(find_docs | while ...)` whose final iteration doesn't match would
+# take the whole CLI down with it.
+docs_matching_files() {
+    local term="$1"
+    local doc
+    while IFS= read -r doc; do
+        if grep -qi $DOC_GREP_OPTS -- "$term" "$doc" 2>/dev/null; then
+            echo "$doc"
+        fi
+    done < <(find_docs)
+    return 0
+}
+
+print_docs_list() {
+    local doc_count
+    doc_count=$(find_docs | wc -l | tr -d ' ')
+
+    echo "${BOLD}Documentation${RESET} ${DIM}(${doc_count} files)${RESET}"
+    echo ""
+
+    local doc
+    while IFS= read -r doc; do
+        printf "  ${CYAN}%s${RESET}\n" "${doc#${REPO_ROOT}/}"
+    done < <(find_docs)
+
+    echo ""
+    echo "${DIM}Search inside them with: wp-ops docs <term>${RESET}"
+    echo ""
+}
+
+print_docs_results() {
+    local term="$1"
+    local paths_only="${2:-}"
+
+    if [[ -z "$term" ]]; then
+        print_docs_list
+        return 0
+    fi
+
+    local matching_files
+    matching_files=$(docs_matching_files "$term")
+
+    if [[ -z "$matching_files" ]]; then
+        echo "${YELLOW}No documents match '${term}'.${RESET}"
+        echo ""
+        echo "Try ${BOLD}wp-ops search ${term}${RESET} to look for a command instead."
+        return 1
+    fi
+
+    # Machine/pipe-friendly mode, so `wp-ops docs oom -l | xargs $EDITOR` works.
+    if [[ -n "$paths_only" ]]; then
+        local doc
+        while IFS= read -r doc; do
+            echo "${doc#${REPO_ROOT}/}"
+        done <<< "$matching_files"
+        return 0
+    fi
+
+    local file_count noun
+    file_count=$(echo "$matching_files" | wc -l | tr -d ' ')
+    noun="documents"
+    [[ "$file_count" -eq 1 ]] && noun="document"
+
+    echo "${BOLD}${file_count} ${noun} matching '${term}':${RESET}"
+    echo ""
+
+    local doc match_count line line_number text
+    while IFS= read -r doc; do
+        match_count=$(grep -ci $DOC_GREP_OPTS -- "$term" "$doc" 2>/dev/null || echo 0)
+
+        printf "  ${CYAN}%s${RESET} ${DIM}(%s)${RESET}\n" \
+            "${doc#${REPO_ROOT}/}" "$match_count match$([[ "$match_count" -eq 1 ]] || echo es)"
+
+        while IFS= read -r line; do
+            line_number="${line%%:*}"
+            text="${line#*:}"
+            # Markdown indentation and list markers carry no meaning once a line
+            # is shown out of context, so collapse the leading whitespace.
+            text=$(echo "$text" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]\{2,\}/ /g')
+            if [[ ${#text} -gt $DOC_LINE_WIDTH ]]; then
+                text="${text:0:$((DOC_LINE_WIDTH - 1))}…"
+            fi
+            printf "    ${DIM}%5s${RESET}  %s\n" "$line_number" "$text"
+        done < <(grep -in $DOC_GREP_OPTS -- "$term" "$doc" 2>/dev/null | head -"$DOC_MATCH_LIMIT")
+
+        if [[ "$match_count" -gt "$DOC_MATCH_LIMIT" ]]; then
+            printf "    ${DIM}%5s  … %s more${RESET}\n" "" "$((match_count - DOC_MATCH_LIMIT))"
+        fi
+        echo ""
+    done <<< "$matching_files"
+
+    if [[ -z "$DOC_GREP_OPTS" ]]; then
+        echo "${DIM}Whole words only: wp-ops docs ${term} -w   ·   paths only: wp-ops docs ${term} -l${RESET}"
+    else
+        echo "${DIM}Paths only (for piping to an editor): wp-ops docs ${term} -l${RESET}"
+    fi
     echo ""
 }
 
@@ -1254,10 +1447,12 @@ run_doctor() {
     check_env_dir "WP_SITE_DIR" "needed by wp-cli/ and bedrock/ scripts" detect_wp_site_dir || true
     echo ""
 
-    local command_count
+    local command_count doc_count
     command_count=$(get_all_commands | wc -l | tr -d ' ')
+    doc_count=$(find_docs | wc -l | tr -d ' ')
     echo "${BOLD}Catalog${RESET}"
     printf "  ${GREEN}%s${RESET} ${DIM}%s commands discovered in %s${RESET}\n" "$CHECK" "$command_count" "$REPO_ROOT"
+    printf "  ${GREEN}%s${RESET} ${DIM}%s documents searchable with 'wp-ops docs <term>'${RESET}\n" "$CHECK" "$doc_count"
     echo ""
 
     if [[ $missing_required -eq 1 ]]; then
@@ -1430,7 +1625,7 @@ _wp_ops_completion() {
     local categories="$categories_list"
 
     if [[ \${cword} -eq 1 ]]; then
-        COMPREPLY=(\$(compgen -W "--help --version --json --completion search doctor \$categories" -- "\${cur}"))
+        COMPREPLY=(\$(compgen -W "--help --version --json --completion search docs doctor \$categories" -- "\${cur}"))
     elif [[ \${cword} -eq 2 ]]; then
         local category="\${words[1]}"
         local commands=""
@@ -1481,6 +1676,7 @@ main() {
         print_usage
         print_categories
         echo "Run 'wp-ops search <term>' to find a command"
+        echo "Run 'wp-ops docs <term>' to search the documentation"
         echo "Run 'wp-ops doctor' to check dependencies and environment"
         echo "Run 'wp-ops --json' for machine-readable command list"
         return 0
@@ -1492,6 +1688,7 @@ main() {
             print_usage
             print_categories
             echo "Run 'wp-ops search <term>' to find a command"
+            echo "Run 'wp-ops docs <term>' to search the documentation"
             echo "Run 'wp-ops doctor' to check dependencies and environment"
             echo "Run 'wp-ops --json' for machine-readable command list"
             return 0
@@ -1511,6 +1708,22 @@ main() {
             ;;
         search|--search)
             print_search_results "${2:-}"
+            return $?
+            ;;
+        docs|--docs)
+            shift
+            local docs_term="" docs_paths_only=""
+            # -l is accepted on either side of the term, since which one you
+            # reach for first depends on whether you're piping or reading.
+            local docs_arg
+            for docs_arg in "$@"; do
+                case "$docs_arg" in
+                    -l|--files|--paths) docs_paths_only=1 ;;
+                    -w|--word) DOC_GREP_OPTS="-w" ;;
+                    *) [[ -z "$docs_term" ]] && docs_term="$docs_arg" ;;
+                esac
+            done
+            print_docs_results "$docs_term" "$docs_paths_only"
             return $?
             ;;
         doctor|--doctor)


### PR DESCRIPTION
Completes the monitoring set and makes the repository's documentation reachable from the CLI. Released as 3.9.0.

## error-monitor.sh

The existing monitors (`traffic`, `security`, `ai-bot`) read the *access* log and answer "who is visiting?". This one reads the *error* logs and answers "is anything broken?" — nginx (global and per-site, with a severity breakdown), PHP-FPM, WordPress/Acorn exceptions, MySQL/MariaDB, and the systemd journal (priority-`err`, PHP segfaults, OOM kills).

Runs on the server like its siblings, takes `[domain] [hours] [output_file]`, and is wired into `run-monitoring.sh` as a fourth report. The markdown summary gains an error section that calls out segfaults and OOM kills separately — those drop requests mid-flight and leave no access-log trace.

Migrated from a client project where it hardcoded one server and one domain. Parameterizing it was the small part; three bugs needed fixing:

- **The time window did nothing.** The original counted `tail -100 | wc -l`, which reports ~100 for any non-empty log regardless of the `[hours]` argument. Each source is now filtered by its own timestamp format (nginx `2026/07/31 …`, PHP-FPM `[31-Jul-2026 …]`, Acorn `[2026-07-31 …]`, MySQL ISO). All four sort chronologically as text, so plain `awk` string comparison suffices — unlike the access-log monitors, this needs **no gawk** on the server.
- **The nginx count could not work.** It combined `find`'s output path with a line count into one value, making `[ "$x" -gt 0 ]` fail outright on a two-line string.
- **`set -e` could abort the summary** when a breakdown count was zero, since `[ "$OOM" -gt 0 ] && echo …` returns 1.

Also: PHP-FPM logs are found by globbing `/var/log/php*-fpm.log` rather than asking `php -v` (the CLI version can differ from the version FPM runs, and a server mid-upgrade has more than one log); Acorn stack-trace continuation lines stay attached to their entry; counts and excerpts come from a single read of each file so they cannot disagree.

Where the journal is not readable — the `web` user usually can't — those sections report as **skipped** rather than empty. "No errors" and "no permission" otherwise look identical, which is exactly wrong while chasing an outage. Connect as `root` to include them.

## wp-ops docs

A large part of what this repo knows is written down rather than scripted: ~60 guides, plus two categories (`nginx/`, `troubleshooting/`) with no runnable command at all. `wp-ops search` only ever looked at command names and descriptions, so none of that prose was reachable from the CLI.

```bash
wp-ops docs                    # list every guide
wp-ops docs "search-replace"   # matching lines, grouped by document
wp-ops docs oom -w             # whole words only
wp-ops docs oom -l             # paths only, for piping to $EDITOR
```

`-w` earned its place during testing: `oom` matched "server **room**" across 7 documents; `-w` cuts that to 5 with the real hits intact. A failed `wp-ops search` now checks the documentation and points there. Added to `--help`, bash completion, and `doctor` (which reports 66 commands / 62 documents).

## Server-side guidance fix

The guidance printed when a server-side command is run locally was written for the access-log monitors but applied to all of them. It described reading `access.log`, suggested a log path as the first argument (`run-monitoring`'s is an hour count, `error-monitor`'s is a domain), and offered to run them locally against a file they do not accept. Guidance, example arguments, and the local-log-file escape hatch are now scoped to the three commands that genuinely take an access log path.

## Testing

Verified against log fixtures for all four timestamp formats at both 24h and 1h windows: out-of-window entries excluded at both sizes, Acorn continuation lines kept with their entry, missing and unreadable logs distinguished, and `run-monitoring`'s summary-extraction regexes matched against real output. CLI paths exercised end to end — `docs` (term, `-w`, `-l`, no term, no match), the `search` cross-link, per-command server-side guidance for `error-monitor` / `run-monitoring` / `traffic-monitor`, `--json`, and `doctor`.