### PR TITLE
Fix backup command discoverability, plan CLI UX rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] - 2026-07-31
+
+### Fixed
+
+- **scripts/backup** - `db-backup.sh` and `site-backup.sh` had no `--help` handling, so `wp-ops scripts/backup/db-backup --help` fell through to the generic stub whose only advice was to run `db-backup.sh --help` — the thing that had just failed. Both now document their positional arguments, their defaults, and the fact that they write to `/srv/backups/` on the server.
+- **wp-ops CLI** - Both backup scripts are now registered as server-side commands. They hardcode `/srv/www/<site>` and `/srv/backups/`, so running one from a workstation failed with `Site directory not found: /srv/www/example.com` — indistinguishable from a broken command. Invoking one locally now prints the `ssh host 'bash -s' < script` form with correct example arguments, and points at `trellis/backup/database-pull` / `files-pull` for the common case of wanting the archive on *this* machine rather than left on the server. `runs_on` in `--json` reports them accordingly.
+
 ## [3.9.0] - 2026-07-31
 
 ### Added

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -1,0 +1,324 @@
+# CLI UX Plan: Command Manifest + Go Rewrite
+
+A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
+declarative, self-documenting tool with the ergonomics of
+[trellis-cli](https://github.com/roots/trellis-cli).
+
+Two phases, deliberately sequenced:
+
+- **Phase A — Manifest.** Every command declares its description, arguments,
+  and where it runs. Shipped in the existing bash CLI, so the UX improves
+  before any rewrite starts.
+- **Phase C — Go binary.** Replace the 1,816-line bash dispatcher with a Cobra
+  CLI that reads the same manifest. Real flag parsing, generated help, shell
+  completions, a single installable binary.
+
+Phase A is a prerequisite, not an alternative. Go does not know what
+`db-backup.sh` expects either.
+
+## The problem
+
+`wp-ops` has **no metadata**. Every element of the UI is scraped from source
+files at runtime:
+
+| UI element | How it's produced | Location |
+|---|---|---|
+| Command description | `grep -m1 '^#\s'` over the first 20 lines | `wp-ops:288` |
+| Description cleanup | First sentence, truncated to 72 chars | `wp-ops:189` |
+| fzf preview | `head -40` of the raw file | `wp-ops:1497` |
+| "Runs on server" warning | Hardcoded list of 5 of 66 commands | `wp-ops:88-102` |
+| `--help` | Probe `script --help`; fall back to a stub | `wp-ops:1068-1077` |
+| Shell completion | Hand-written bash function | `wp-ops:1615` |
+
+There is nothing to render a good UI *from*, so the interactive picker can only
+offer a single blank `Arguments:` box.
+
+### Worked example: the failure this plan fixes
+
+A user wants to back up a production database.
+
+1. `wp-ops` → fzf picker → selects `scripts/backup/db-backup`.
+2. Prompt: `Arguments (leave blank for none, --help for usage):`. No indication
+   that it wants `<site-name> <backup-type>`.
+3. They type `--help`. `db-backup.sh` has no `--help` handling, so the probe at
+   `wp-ops:1068` fails and they get the generic stub: *"Run 'db-backup.sh
+   --help' for script-specific options."* Circular.
+4. They guess `example.com production`. It fails with `Site directory not
+   found: /srv/www/example.com`.
+
+The script hardcodes `/srv/www/$SITE_NAME` and `/srv/backups/`
+(`scripts/backup/db-backup.sh:14-17`) — it **only runs on the server**. But it
+isn't in `SERVER_SIDE_COMMANDS`, so the guard at `wp-ops:1012-1036` never
+fires and nothing says so.
+
+There is no way to reach that conclusion from the UI.
+
+### Related: the CLI and MCP server have forked
+
+`mcp-server/config/sites.example.json` already models exactly what the CLI
+lacks — per-site, per-environment connection details:
+
+```json
+"client.nl": { "production": {
+  "sshHost": "client@client.nl",
+  "remotePath": "/home/client/public_html",
+  "wpBin": "~/wp-cli.phar",
+  "phpBin": "/opt/plesk/php/8.2/bin/php"
+}}
+```
+
+`mcp-server/src/tools/dbBackup.ts:60-79` resolves site+env to Trellis VM / SSH /
+local and streams the dump over stdout. **The MCP server can back up production
+over SSH. The CLI cannot.** Every release widens the gap.
+
+## Current inventory
+
+66 commands, four execution modes:
+
+| Category | Count | Executor | Location |
+|---|---|---|---|
+| `scripts` | 35 | direct exec (`.sh`, `.js`, `.py`) | `wp-ops:1085` |
+| `trellis` | 12 | Ansible playbook (`.yml`) | `execute_playbook`, `wp-ops:710` |
+| `wp-cli` | 11 | WP-CLI / PHP (`.php`) | `execute_php_command`, `wp-ops:790` |
+| `wordpress-utilities` | 5 | snippet → clipboard | `execute_snippet`, `wp-ops:865` |
+| `mcp-server` | 2 | direct exec | — |
+| `bedrock` | 1 | WP-CLI / PHP | — |
+
+`nginx` and `troubleshooting` are docs-only. File types: 39 `.sh`, 13 `.yml`,
+10 `.php`, 4 `.js`, 2 `.py`, 1 `.css`.
+
+All four executors must survive the rewrite.
+
+---
+
+# Phase A — Command manifest
+
+## Directive format
+
+A block of `@` directives in the script's header comment. Comment syntax varies
+by file type (`#`, `//`, `*`), so the parser strips the leading comment marker
+before matching.
+
+```bash
+#!/usr/bin/env bash
+# Trellis Database Backup Script
+#
+# @desc     Back up a Trellis site database with WP-CLI
+# @category backup
+# @runs     server
+# @requires wp
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging|development}  Target environment
+# @flag     --retention-days  optional  {30}  Days of backups to keep
+# @example  wp-ops backup db example.com production
+# @doc      trellis/backup/README.md
+```
+
+### Directives
+
+| Directive | Purpose |
+|---|---|
+| `@desc` | One-line description. Replaces the scrape at `wp-ops:288`. |
+| `@category` | Logical group. Decouples grouping from directory layout. |
+| `@runs` | `local` \| `server` \| `either`. Replaces `SERVER_SIDE_COMMANDS`. |
+| `@requires` | Binaries needed. Feeds `wp-ops doctor` (`wp-ops:1394`). |
+| `@arg` | `NAME  required\|optional  {choices-or-default}  Description` |
+| `@flag` | Same shape, for named flags. |
+| `@example` | Copy-pasteable invocation. Multiple allowed. |
+| `@doc` | Repo-relative guide path. Feeds `wp-ops docs`. |
+
+`@arg` parses as: whitespace-separated name and requiredness, an optional
+`{...}` field holding either a default or `|`-separated choices, then the rest
+of the line as free-text description. Robust to `awk` field splitting and
+readable in the source file.
+
+## What the manifest unlocks
+
+1. **Per-argument prompts.** The picker asks for `site` and `env` separately,
+   showing the description and offering choices, instead of one blank box.
+2. **Real `--help` for every command**, generated from the declaration. No more
+   probing a script that may not support it, no more stub.
+3. **Generic `@runs server` guard.** `SERVER_SIDE_COMMANDS` becomes derived
+   rather than hardcoded, so `db-backup` is covered automatically — along with
+   any script added later.
+4. **Curated fzf preview** — usage, args, examples — instead of `head -40`.
+5. **Dependency-aware `doctor`** — `@requires` tells you which commands are
+   currently unusable and why.
+6. **Richer `--json`.** It already emits a `runs_on` field; the manifest turns
+   that into a full contract the MCP server can consume.
+
+## Phase A rollout
+
+Annotate in dependency order, most-confusing-first:
+
+1. `scripts/backup/*` (2), `scripts/monitoring/*` (8) — the commands in the
+   worked example above.
+2. `trellis/**/*.yml` (12) — every one needs `site` and `env`; today that's
+   only discoverable by reading `variable-check.yml`.
+3. `wp-cli/**` (11) and `bedrock/**` (1).
+4. `wordpress-utilities/**` (5) — snippets, mostly `@desc` + `@doc`.
+5. The remaining `scripts/**`.
+
+## Phase A implementation
+
+- `parse_manifest()` — extract directives from a file into a tab-delimited
+  record.
+- Extend `discover_commands()` (`wp-ops:214`) to prefer manifest data, falling
+  back to the current scrape for un-annotated scripts. **Annotation can be
+  incremental** — nothing breaks mid-rollout.
+- Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
+- Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
+- Add guided prompting to `fzf_menu()` (`wp-ops:1477`) and
+  `interactive_command_menu()` (`wp-ops:1563`).
+- Add `wp-ops manifest lint` — fails on missing or malformed directives. Wire
+  into CI so new scripts can't regress.
+
+Ships as **3.10.0** (parser + first two groups) and **3.11.0** (full coverage
+plus guided prompts). No breaking changes.
+
+---
+
+# Phase C — Go binary
+
+## Framework
+
+**Cobra**, not `hashicorp/cli`.
+
+trellis-cli uses [`hashicorp/cli`](https://github.com/hashicorp/cli) (the
+maintained fork of mitchellh/cli), which is why its help output looks the way it
+does. Cobra gives us better flag handling and — decisively — free completions
+for bash, zsh, fish, and PowerShell, replacing the hand-written
+`print_completion` at `wp-ops:1615`.
+
+## Architecture
+
+```
+main.go                       Cobra root, registers commands from the catalog
+internal/manifest/            Directive parser + validator (shared with lint)
+internal/catalog/             Embedded catalog.json + lookup/search
+internal/exec/
+  shell.go                    .sh / .js / .py  → direct exec
+  ansible.go                  .yml             → port of execute_playbook (wp-ops:710)
+  wpcli.go                    .php             → port of execute_php_command (wp-ops:790)
+  snippet.go                  snippets         → port of execute_snippet (wp-ops:865)
+internal/detect/              Port of detect_trellis_dir (wp-ops:593)
+                              and detect_wp_site_dir (wp-ops:627)
+internal/registry/            sites.json — schema shared with the MCP server
+internal/ui/                  Bubble Tea picker (replaces the fzf dependency)
+```
+
+**Build-time catalog.** A `go:generate` step parses all 66 manifests into
+`catalog.json`, embedded via `go:embed`. No runtime filesystem scan; a malformed
+manifest fails the build rather than degrading the UI.
+
+## Carried over from the bash CLI
+
+The scripts themselves are **not** rewritten. The binary shells out exactly as
+today. Logic worth porting rather than reinventing:
+
+- Symlink-resolving `REPO_ROOT` detection (`wp-ops:26-33`)
+- Trellis and WP site directory detection + confirmation (`wp-ops:593-681`)
+- GNU `date` detection and its guidance path (`wp-ops:149`, `wp-ops:972`)
+- Ambiguous-basename resolution (`wp-ops:1105`) and did-you-mean
+  (`wp-ops:1136`)
+- `docs` search (`wp-ops:1235-1346`) and `doctor` (`wp-ops:1394`)
+
+## Distribution
+
+`goreleaser` → Homebrew tap (`imagewize/tap`) + `go install`. Replaces the
+PATH-append in `install.sh`.
+
+**Open decision — where do the scripts live?**
+
+- **(a) Embed them.** `go:embed` the script tree; extract to a cache dir on
+  first run. `brew install wp-ops` becomes fully self-contained. `--where`
+  points at the extracted copy.
+- **(b) Locate the checkout.** Binary resolves a repo root from `WP_OPS_ROOT` or
+  config, as today.
+
+**Recommendation: (a), with `WP_OPS_ROOT` as a development override.** Most
+users want the tool, not the repo. Contributors set the env var and iterate on
+scripts without rebuilding. Note that several assets (nginx configs, WP
+snippets) exist to be *copied into projects* — extraction handles this fine.
+
+## Compatibility
+
+- `wp-ops <category>/<command>` keys keep working — they are how the docs, the
+  MCP server, and muscle memory refer to commands.
+- Short forms are added on top: `wp-ops backup db example.com production`.
+- `--json`, `--where`, `search`, `docs`, `doctor` keep their current contracts.
+
+---
+
+# Phase D — Site registry convergence
+
+Once Go owns the CLI, adopt the MCP server's registry
+(`mcp-server/src/registry.ts`, `config/sites.example.json`) as the shared
+source of truth at `~/.config/wp-ops/sites.json`.
+
+This is what answers *"how do I run the production backup?"* end to end:
+
+```
+wp-ops backup db example.com production --on production
+```
+
+The CLI resolves `sshHost` from the registry and streams the command to the
+server — the dispatch `dbBackup.ts:60-79` already implements. The bash CLI
+cannot do this; it's the single largest capability gain in the plan.
+
+# Phase E — trellis-cli plugin symlink
+
+trellis-cli's plugin system is a kubectl-style PATH passthrough: `main.go:232-234`
+scans `$PATH` for executables named `trellis-*` and registers them, executing
+via `syscall.Exec` (`cmd/passthrough.go`).
+
+Symlinking the binary as `trellis-wpops` makes `trellis wpops backup db ...`
+work for Trellis users. **One install step, not an architecture.**
+
+It contributes nothing to the UX problem — `Synopsis()` is hardcoded to
+*"Third party plugin: Forward command to …"* (`cmd/passthrough.go:43`) and
+`plugin/help_func.go` prints a bare name list. It also cannot express the
+non-Trellis half of the catalog (`scripts/images`, `scripts/patterns`,
+`scripts/release`, `scripts/git`, `bedrock`, `wordpress-utilities`). It is
+purely additive distribution.
+
+---
+
+# Milestones
+
+| # | Scope | Version |
+|---|---|---|
+| M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 |
+| M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta |
+| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 |
+| M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 |
+| M6 | `trellis-wpops` symlink | 4.1.0 |
+
+## Immediate fixes (do now, independent of the plan)
+
+Both are ~10 minutes and fix the exact reported failure:
+
+1. Add a real `--help` / usage block to `scripts/backup/db-backup.sh` and
+   `scripts/backup/site-backup.sh`.
+2. Add both to `SERVER_SIDE_COMMANDS` (`wp-ops:88-102`) so the existing
+   server-side guidance fires.
+
+# Risks
+
+- **Dual maintenance during M3–M4.** Mitigated by having the Go binary read the
+  *same* manifest the bash CLI reads. The bash implementation is deleted only at
+  4.0.0.
+- **Manifest drift.** Mitigated by `manifest lint` in CI and by the build-time
+  catalog failing the build on malformed input.
+- **Go build in the release path.** New for this repo; goreleaser plus a tap is
+  well-trodden, and the scripts remain runnable directly if the binary is
+  unavailable.
+
+# Non-goals
+
+- Rewriting the 66 scripts in Go. They stay shell/PHP/Python/YAML.
+- Replacing the MCP server. It keeps its own entry point; the two converge on a
+  shared registry and manifest, not a shared process.
+- Upstreaming commands into trellis-cli. Roots' scope is Trellis project
+  management, not a general WordPress ops catalog.

--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -3,11 +3,41 @@
 # Trellis Database Backup Script
 # Focused database backup using WP-CLI for WordPress sites on Trellis
 #
-# Usage: ./db-backup.sh [site-name] [backup-type]
-# Example: ./db-backup.sh example.com production
+# Runs on the server: it reads /srv/www/<site-name> and writes to
+# /srv/backups/<site-name>/database, so both paths have to be the host's own.
+# Stream it over SSH the same way as the monitoring scripts — nothing needs to
+# be installed on the server.
+#
+# Usage:
+#   ssh web@example.com 'bash -s' < ./db-backup.sh [site-name] [backup-type]
+#   ./db-backup.sh example.com production     # on the server itself
+#
 # Backup types: production, staging, development
+#
+# staging and development additionally produce a second dump with the site URL
+# rewritten for that environment; production produces the plain dump only.
 
 set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Usage: $(basename "$0") [site-name] [backup-type]"
+    echo ""
+    echo "Back up a Trellis site database with WP-CLI, gzip it, write a summary"
+    echo "file alongside it, and prune backups older than 30 days."
+    echo ""
+    echo "Arguments:"
+    echo "  site-name    Site directory under /srv/www (default: example.com)"
+    echo "  backup-type  production | staging | development (default: production)"
+    echo ""
+    echo "Runs on the server — /srv/www and /srv/backups are the host's paths."
+    echo "From your machine:"
+    echo "  ssh web@example.com 'bash -s' < $(basename "$0") example.com production"
+    echo ""
+    echo "Writes to /srv/backups/<site-name>/database/ on the server. To pull a"
+    echo "copy down to your machine instead, use the Ansible playbook:"
+    echo "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production"
+    exit 0
+fi
 
 # Configuration
 SITE_NAME="${1:-example.com}"

--- a/scripts/backup/site-backup.sh
+++ b/scripts/backup/site-backup.sh
@@ -3,10 +3,40 @@
 # Trellis Site Backup Script
 # Complete backup solution for WordPress sites running on Trellis
 #
-# Usage: ./site-backup.sh [site-name]
-# Example: ./site-backup.sh example.com
+# Backs up database, uploads, config files and plugins/themes in one pass.
+#
+# Runs on the server: it reads /srv/www/<site-name> and writes to
+# /srv/backups/<site-name>, so both paths have to be the host's own. Stream it
+# over SSH the same way as the monitoring scripts — nothing needs to be
+# installed on the server.
+#
+# Usage:
+#   ssh web@example.com 'bash -s' < ./site-backup.sh [site-name]
+#   ./site-backup.sh example.com      # on the server itself
 
 set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Usage: $(basename "$0") [site-name]"
+    echo ""
+    echo "Full backup of a Trellis site: database, uploads, config files, and"
+    echo "plugins/themes/mu-plugins. Writes a manifest and prunes backups older"
+    echo "than 30 days."
+    echo ""
+    echo "Arguments:"
+    echo "  site-name    Site directory under /srv/www (default: example.com)"
+    echo ""
+    echo "Runs on the server — /srv/www and /srv/backups are the host's paths."
+    echo "From your machine:"
+    echo "  ssh web@example.com 'bash -s' < $(basename "$0") example.com"
+    echo ""
+    echo "Writes to /srv/backups/<site-name>/{database,files,config}/ on the"
+    echo "server. To pull copies down to your machine instead, use the Ansible"
+    echo "playbooks:"
+    echo "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production"
+    echo "  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production"
+    exit 0
+fi
 
 # Configuration - Update these variables for your setup
 SITE_NAME="${1:-example.com}"

--- a/wp-ops
+++ b/wp-ops
@@ -88,10 +88,11 @@ CHECK="✓"
 CROSS="✗"
 WARN="!"
 
-# Commands that execute on the server rather than on this machine. They read
-# /srv/www/<site>/logs/ as local files and use GNU `date -d`, and are invoked by
-# streaming them to the host: ssh web@host 'bash -s' < run-monitoring.sh. Running
-# them here fails on a missing log path, which reads as a broken command rather
+# Commands that execute on the server rather than on this machine, and are
+# invoked by streaming them to the host: ssh web@host 'bash -s' < script.sh.
+# The monitors read /srv/www/<site>/logs/ as local files and use GNU `date -d`;
+# the backup scripts read /srv/www/<site> and write to /srv/backups/. Running
+# either here fails on a missing path, which reads as a broken command rather
 # than as "wrong machine" — so wp-ops says so up front instead.
 SERVER_SIDE_COMMANDS="
 scripts/monitoring/traffic-monitor
@@ -99,7 +100,28 @@ scripts/monitoring/security-monitor
 scripts/monitoring/ai-bot-monitor
 scripts/monitoring/error-monitor
 scripts/monitoring/run-monitoring
+scripts/backup/db-backup
+scripts/backup/site-backup
 "
+
+# The subset that back up to /srv/backups/ on the server. Called out separately
+# because the Ansible playbooks under trellis/backup/ do the same job *and*
+# retrieve the archive to this machine, which is usually what someone reaching
+# for a backup from their workstation actually wants.
+BACKUP_COMMANDS="
+scripts/backup/db-backup
+scripts/backup/site-backup
+"
+
+is_backup_command() {
+    local command_key="$1"
+    case "$BACKUP_COMMANDS" in
+        *"
+${command_key}
+"*) return 0 ;;
+    esac
+    return 1
+}
 
 is_server_side_command() {
     local command_key="$1"
@@ -139,6 +161,8 @@ server_side_example_args() {
     case "$1" in
         scripts/monitoring/error-monitor) echo "example.com 48" ;;
         scripts/monitoring/run-monitoring) echo "24 example.com" ;;
+        scripts/backup/db-backup) echo "example.com production" ;;
+        scripts/backup/site-backup) echo "example.com" ;;
         *) echo "/srv/www/example.com/logs/access.log 24" ;;
     esac
 }
@@ -925,7 +949,11 @@ print_server_side_guidance() {
 
     echo "${YELLOW}${WARN} ${command_key} runs on the server, not here.${RESET}"
     echo ""
-    if [[ "$command_key" == "scripts/monitoring/error-monitor" ]]; then
+    if is_backup_command "$command_key"; then
+        echo "It reads /srv/www/<site> and writes the archive to /srv/backups/<site>,"
+        echo "so both paths have to be the host's own. Stream it over SSH — nothing"
+        echo "needs to be installed there:"
+    elif [[ "$command_key" == "scripts/monitoring/error-monitor" ]]; then
         echo "It reads /var/log/nginx/, /var/log/php*-fpm.log, /srv/www/<site>/logs/"
         echo "and the systemd journal directly, and uses GNU 'date -d', so it has to"
         echo "execute on the Trellis host. Stream it over SSH — nothing needs to be"
@@ -943,6 +971,19 @@ print_server_side_guidance() {
     echo "  ${BOLD}ssh web@example.com 'bash -s' < ${relative_path} \\"
     echo "      $(server_side_example_args "$command_key")${RESET}"
     echo ""
+
+    if is_backup_command "$command_key"; then
+        echo "${DIM}That leaves the archive on the server. To back up *and* retrieve a copy${RESET}"
+        echo "${DIM}to this machine in one step, use the Ansible playbooks instead:${RESET}"
+        echo ""
+        if [[ "$command_key" == "scripts/backup/db-backup" ]]; then
+            echo "${DIM}  wp-ops trellis/backup/database-pull -e site=example.com -e env=production${RESET}"
+        else
+            echo "${DIM}  wp-ops trellis/backup/database-pull -e site=example.com -e env=production${RESET}"
+            echo "${DIM}  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production${RESET}"
+        fi
+        return 0
+    fi
 
     if [[ "$command_key" == "scripts/monitoring/error-monitor" ]]; then
         echo "${DIM}The systemd sections (critical errors, PHP segfaults, OOM kills) need${RESET}"


### PR DESCRIPTION
Fixes the "how do I actually run this?" gap for the backup scripts, and documents a plan for fixing it structurally across all 66 commands.

## The reported problem

Picking `scripts/backup/db-backup` from the fuzzy picker gives you a blank `Arguments:` prompt with no indication it wants `<site-name> <backup-type>`. Typing `--help` returns the generic stub whose only advice is to run `db-backup.sh --help` — the thing that just failed. Guessing `example.com production` then fails with `Site directory not found: /srv/www/example.com`, because the script hardcodes `/srv/www/<site>` and `/srv/backups/` and only runs on the server. Nothing in the UI says so.

## Fixes

**Real `--help` on both backup scripts.** `db-backup.sh` and `site-backup.sh` now follow the `error-monitor.sh` pattern — early guard, `-h` alias, positional arguments and defaults spelled out. Header comments updated too, since those are what the fzf preview renders.

**Both registered as server-side commands.** Adding them to `SERVER_SIDE_COMMANDS` alone would have printed the wrong guidance: the existing text describes reading `access.log` and needing `gawk` on the server, neither of which applies to a backup. So `print_server_side_guidance` gains an `is_backup_command` branch, and `server_side_example_args` gains correct examples. The monitoring commands' output is unchanged.

The backup branch also points at `trellis/backup/database-pull` and `files-pull`, because someone reaching for a backup from their workstation usually wants to end up holding the archive — not to leave it on the server, which is all the shell scripts do.

Before:

```
$ wp-ops scripts/backup/db-backup example.com production
[2026-07-31 14:01:29] ERROR: Site directory not found: /srv/www/example.com
```

After:

```
$ wp-ops scripts/backup/db-backup example.com production
! scripts/backup/db-backup runs on the server, not here.

It reads /srv/www/<site> and writes the archive to /srv/backups/<site>,
so both paths have to be the host's own. Stream it over SSH — nothing
needs to be installed there:

  ssh web@example.com 'bash -s' < scripts/backup/db-backup.sh

Arguments go after the redirect:

  ssh web@example.com 'bash -s' < scripts/backup/db-backup.sh \
      example.com production

That leaves the archive on the server. To back up *and* retrieve a copy
to this machine in one step, use the Ansible playbooks instead:

  wp-ops trellis/backup/database-pull -e site=example.com -e env=production
```

## Plan document

[`docs/cli-ux-plan.md`](https://github.com/imagewize/wp-ops/blob/improve/cli-ux/docs/cli-ux-plan.md) records why this class of bug keeps recurring and how to end it.

The CLI has no metadata. Descriptions come from `grep -m1 '^#\s'`, the preview from `head -40`, the server-side warning from a hardcoded list of 5 of 66 commands, and `--help` from probing a script that may not support it. There is nothing to render a good UI *from*, which is why the picker can only offer one blank box — and why this PR fixes two scripts by hand rather than the underlying gap.

Phases:

- **A — Manifest.** `@desc` / `@runs` / `@arg` / `@requires` directives per script, parsed by the existing bash CLI. Yields per-argument prompts, generated `--help`, and a derived server-side guard that would have covered `db-backup` automatically. Annotation is incremental; un-annotated scripts keep the current scrape.
- **C — Go binary.** Cobra dispatcher reading the same manifest. Free shell completions, replacing the hand-written `print_completion`. The 66 scripts are not rewritten.
- **D — Site registry.** Adopt the MCP server's `sites.json` so the CLI can do `--on production` over SSH. Today `mcp-server/src/tools/dbBackup.ts` can back up production remotely and the CLI cannot; the two have forked.
- **E — `trellis-wpops` symlink** for trellis-cli's PATH plugin loader.

The doc also records why extending trellis-cli directly was rejected: its plugin API is a kubectl-style `syscall.Exec` passthrough with a hardcoded synopsis, so it cannot express command help at all, and it can't house the non-Trellis half of the catalog.

## Notes

- Version bumped to 3.9.1 via `CHANGELOG.md`, which is where `get_version` reads from.
- Both scripts still default to `example.com` when called with no arguments. On a real server that silently targets a possibly-wrong site. Making the argument required is a behavior change beyond the scope here — flagged as exactly what Phase A's `@arg site required` catches by construction.

## Testing

- `bash -n` clean on all three modified scripts.
- `--help` and `-h` verified through `wp-ops` for both commands.
- Bare invocation verified to print the new guidance and exit non-zero.
- `runs_on` in `--json` reports `server` for both.
- Regression-checked `traffic-monitor` and `error-monitor` guidance — byte-identical.
