### PR TITLE
Add command manifest system to wp-ops (Phase A, M1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - 2026-07-31
+
+### Added
+
+- **wp-ops CLI** - Command manifest: scripts can now declare `@desc`, `@category`, `@runs`, `@requires`, `@arg`, `@flag`, `@example`, and `@doc` directives in their header comment, parsed by a new `parse_manifest`/`load_manifest` pair in `wp-ops` (see `docs/cli-ux-plan.md`). Every element of the CLI's UI used to be scraped from source at runtime — a description grepped from the first `#` comment, `--help` output probed from the script itself with a generic stub on failure, and a hand-maintained `SERVER_SIDE_COMMANDS` list covering 5 of 66 commands. A manifest replaces the scrape/probe for the commands that have one: `get_description()` prefers `@desc`, `--help` renders directly from the declaration instead of risking a probe that runs the script with `--help` as a stray positional argument, and `is_server_side_command()` checks `@runs` before falling back to the hardcoded list. Annotation is incremental — unannotated scripts keep working exactly as before.
+- **wp-ops CLI** - `wp-ops manifest lint`: validates every annotated command's directives (missing `@desc`, an `@runs` value other than `local`/`server`/`either`, a malformed `@arg`/`@flag` line, or an `@doc` path that doesn't exist) and exits non-zero on the first problem found, so a manifest can't silently drift from the script it describes.
+- **scripts/backup**, **scripts/monitoring** - The first two command groups are annotated: `db-backup`, `site-backup`, and all 8 monitoring scripts (`traffic-monitor`, `security-monitor`, `ai-bot-monitor`, `error-monitor`, `run-monitoring`, `404-checker`, `redirect-check`, `server-monitor`). `--help` on any of them now lists arguments, flags, requirements, and examples straight from the manifest — including the ones that never implemented `--help` themselves.
+
 ## [3.9.1] - 2026-07-31
 
 ### Fixed

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -1,5 +1,10 @@
 # CLI UX Plan: Command Manifest + Go Rewrite
 
+> **Status (2026-07-31):** M1 is implemented on `feature/cli-manifest-phase-a`
+> — manifest spec, bash parser, `wp-ops manifest lint`, and the first two
+> command groups (`scripts/backup/*`, `scripts/monitoring/*`, 10 commands)
+> annotated. Not yet merged. See "Progress" under Phase A below for details.
+
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
 [trellis-cli](https://github.com/roots/trellis-cli).
@@ -52,6 +57,11 @@ isn't in `SERVER_SIDE_COMMANDS`, so the guard at `wp-ops:1012-1036` never
 fires and nothing says so.
 
 There is no way to reach that conclusion from the UI.
+
+**Status:** this specific failure was patched directly in 3.9.1 (`--help` text
+added to both backup scripts, both registered in `SERVER_SIDE_COMMANDS`) and
+then superseded in 3.10.0 by the manifest doing the same job generically — see
+"Immediate fixes" below and "Progress" under Phase A.
 
 ### Related: the CLI and MCP server have forked
 
@@ -152,7 +162,7 @@ readable in the source file.
 Annotate in dependency order, most-confusing-first:
 
 1. `scripts/backup/*` (2), `scripts/monitoring/*` (8) — the commands in the
-   worked example above.
+   worked example above. **Done, on `feature/cli-manifest-phase-a`.**
 2. `trellis/**/*.yml` (12) — every one needs `site` and `env`; today that's
    only discoverable by reading `variable-check.yml`.
 3. `wp-cli/**` (11) and `bedrock/**` (1).
@@ -162,16 +172,37 @@ Annotate in dependency order, most-confusing-first:
 ## Phase A implementation
 
 - `parse_manifest()` — extract directives from a file into a tab-delimited
-  record.
+  record. **Done** — `manifest_directive_lines()` + `load_manifest()`,
+  storing `command_key|directive|value` rows in a temp file per run
+  (`get_all_commands`'s sibling: `manifest_get`/`manifest_get_all`/
+  `has_manifest`).
 - Extend `discover_commands()` (`wp-ops:214`) to prefer manifest data, falling
   back to the current scrape for un-annotated scripts. **Annotation can be
-  incremental** — nothing breaks mid-rollout.
+  incremental** — nothing breaks mid-rollout. **Done** — a manifest `@desc`
+  is written straight into `COMMAND_FILE`, so `search`, category listings,
+  and `--json` all pick it up for free.
 - Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
+  **Mechanism done**, coverage partial: it checks the manifest first and
+  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 10
+  annotated commands are manifest-driven so far. The list itself is only
+  fully redundant — and removable — once rollout group 2–5 land (M2).
 - Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
+  **Done** — `print_manifest_help()` short-circuits the script-probe entirely
+  when a manifest exists, so commands with no `--help` handling of their own
+  (6 of the 8 annotated monitoring scripts) get real usage output for the
+  first time.
 - Add guided prompting to `fzf_menu()` (`wp-ops:1477`) and
-  `interactive_command_menu()` (`wp-ops:1563`).
+  `interactive_command_menu()` (`wp-ops:1563`). **Not started** — deferred to
+  M2, once enough commands have `@arg` data for per-argument prompts to be
+  worth the UI change everywhere, not just for 10 commands.
 - Add `wp-ops manifest lint` — fails on missing or malformed directives. Wire
-  into CI so new scripts can't regress.
+  into CI so new scripts can't regress. **Parser and command done**
+  (`wp-ops manifest lint`, checks `@desc` presence, `@runs` enum, `@arg`/
+  `@flag` requiredness, and `@doc` file existence). **CI wiring not done.**
+- `--json`'s existing `runs_on` field is now manifest-derived where a
+  manifest exists; `requires` and `doc` fields were added alongside it
+  (empty string when unset, so the schema stays stable across annotated and
+  un-annotated commands).
 
 Ships as **3.10.0** (parser + first two groups) and **3.11.0** (full coverage
 plus guided prompts). No breaking changes.
@@ -286,23 +317,24 @@ purely additive distribution.
 
 # Milestones
 
-| # | Scope | Version |
-|---|---|---|
-| M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 |
-| M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta |
-| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 |
-| M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 |
-| M6 | `trellis-wpops` symlink | 4.1.0 |
+| # | Scope | Version | Status |
+|---|---|---|---|
+| M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done** (`feature/cli-manifest-phase-a`, not merged) |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | Not started |
+| M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
+| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
+| M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |
+| M6 | `trellis-wpops` symlink | 4.1.0 | Not started |
 
 ## Immediate fixes (do now, independent of the plan)
 
-Both are ~10 minutes and fix the exact reported failure:
+Both shipped in 3.9.1, ahead of and independent of this plan:
 
-1. Add a real `--help` / usage block to `scripts/backup/db-backup.sh` and
-   `scripts/backup/site-backup.sh`.
-2. Add both to `SERVER_SIDE_COMMANDS` (`wp-ops:88-102`) so the existing
-   server-side guidance fires.
+1. ~~Add a real `--help` / usage block to `scripts/backup/db-backup.sh` and
+   `scripts/backup/site-backup.sh`.~~ **Done** (3.9.1).
+2. ~~Add both to `SERVER_SIDE_COMMANDS` (`wp-ops:88-102`) so the existing
+   server-side guidance fires.~~ **Done** (3.9.1), then superseded in 3.10.0
+   by the `@runs server` manifest directive on both scripts.
 
 # Risks
 

--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -16,6 +16,15 @@
 #
 # staging and development additionally produce a second dump with the site URL
 # rewritten for that environment; production produces the plain dump only.
+#
+# @desc     Back up a Trellis site database with WP-CLI, gzip it, and prune backups older than 30 days
+# @category backup
+# @runs     server
+# @requires wp
+# @arg      site-name    optional  {example.com}  Site directory under /srv/www
+# @arg      backup-type  optional  {production|staging|development}  Backup type
+# @example  ssh web@example.com 'bash -s' < db-backup.sh example.com production
+# @doc      trellis/backup/README.md
 
 set -euo pipefail
 

--- a/scripts/backup/site-backup.sh
+++ b/scripts/backup/site-backup.sh
@@ -13,6 +13,14 @@
 # Usage:
 #   ssh web@example.com 'bash -s' < ./site-backup.sh [site-name]
 #   ./site-backup.sh example.com      # on the server itself
+#
+# @desc     Full backup of a Trellis site: database, uploads, config, and plugins/themes
+# @category backup
+# @runs     server
+# @requires wp
+# @arg      site-name  optional  {example.com}  Site directory under /srv/www
+# @example  ssh web@example.com 'bash -s' < site-backup.sh example.com
+# @doc      trellis/backup/README.md
 
 set -euo pipefail
 

--- a/scripts/monitoring/404-checker.sh
+++ b/scripts/monitoring/404-checker.sh
@@ -11,6 +11,18 @@
 #   ./404-checker.sh https://example.com
 #   ./404-checker.sh --mode spider https://example.com
 #   ./404-checker.sh --output results.txt https://example.com
+#
+# @desc     Check a site's internal links for broken (4xx/5xx) responses
+# @category monitoring
+# @runs     local
+# @requires curl
+# @arg      site-url  required  {https://example.com}  Site to check
+# @flag     --mode     optional  {global|spider}  global checks homepage links (~30s); spider recursively crawls (~5-10 min)
+# @flag     --output   optional  Append broken-link results to this file
+# @flag     --timeout  optional  {10}  curl max-time per request, in seconds
+# @flag     --level    optional  {3}  Spider depth for --mode spider
+# @example  wp-ops scripts/monitoring/404-checker https://example.com
+# @example  wp-ops scripts/monitoring/404-checker --mode spider https://example.com
 
 # ── Colours ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'

--- a/scripts/monitoring/ai-bot-monitor.sh
+++ b/scripts/monitoring/ai-bot-monitor.sh
@@ -10,6 +10,16 @@
 #   ./ai-bot-monitor.sh /srv/www/demo.example.com/logs/access.log 6 # Demo site, last 6 hours
 #   ./ai-bot-monitor.sh /srv/www/example.com/logs/access.log 168    # Last 7 days
 #
+# @desc     Analyze AI crawler traffic (GPTBot, ClaudeBot, etc.) from an Nginx access log
+# @category monitoring
+# @runs     server
+# @requires gawk
+# @arg      log_file     optional  {/srv/www/example.com/logs/access.log}  Nginx access log path
+# @arg      hours        optional  {24}  How many hours back to analyze
+# @arg      output_file  optional  Path to save the report instead of printing it
+# @example  ssh web@example.com 'bash -s' < ai-bot-monitor.sh
+# @example  ssh web@example.com 'bash -s' < ai-bot-monitor.sh /srv/www/example.com/logs/access.log 168
+# @doc      trellis/monitoring/README.md
 
 set -e
 

--- a/scripts/monitoring/error-monitor.sh
+++ b/scripts/monitoring/error-monitor.sh
@@ -22,6 +22,15 @@
 # rather than empty — connect as root, or add the user to the adm/systemd-journal
 # group, to include them.
 #
+# @desc     Surface errors from Nginx, PHP-FPM, WordPress, MySQL, and systemd for a domain
+# @category monitoring
+# @runs     server
+# @arg      domain       optional  {example.com}  Site domain (used to find /srv/www/<domain>/logs/)
+# @arg      hours        optional  {24}  How many hours back to analyze
+# @arg      output_file  optional  Path to save the report instead of printing it
+# @example  ssh web@example.com 'bash -s' < error-monitor.sh
+# @example  ssh root@example.com 'bash -s' < error-monitor.sh example.com 48
+# @doc      trellis/monitoring/README.md
 
 set -uo pipefail
 

--- a/scripts/monitoring/redirect-check.sh
+++ b/scripts/monitoring/redirect-check.sh
@@ -2,6 +2,13 @@
 # redirect-check.sh - Mass check URLs for redirects using curl
 # Usage: bash redirect-check.sh [url1] [url2] ...
 #   or edit the URLs array below
+#
+# @desc     Mass-check a list of URLs for redirects with curl
+# @category monitoring
+# @runs     local
+# @requires curl
+# @arg      urls  optional  One or more URLs to check; falls back to the hardcoded list in the script when omitted
+# @example  wp-ops scripts/monitoring/redirect-check https://example.com/old-page/
 
 # Check if URLs are provided as arguments, otherwise use defaults
 if [ $# -gt 0 ]; then

--- a/scripts/monitoring/run-monitoring.sh
+++ b/scripts/monitoring/run-monitoring.sh
@@ -20,6 +20,15 @@
 #   cd /srv/www/example.com/current
 #   ./run-monitoring.sh 24
 #
+# @desc     Run traffic, security, AI-bot, and error monitoring together and save timestamped reports
+# @category monitoring
+# @runs     server
+# @requires gawk
+# @arg      hours   optional  {24}  How many hours back to analyze
+# @arg      domain  optional  {example.com}  Site domain
+# @example  ssh web@example.com 'bash -s' < run-monitoring.sh
+# @example  ssh web@example.com 'bash -s' < run-monitoring.sh 24 othersite.com
+# @doc      trellis/monitoring/README.md
 
 set -e
 

--- a/scripts/monitoring/security-monitor.sh
+++ b/scripts/monitoring/security-monitor.sh
@@ -10,6 +10,17 @@
 #   ./security-monitor.sh /srv/www/demo.example.com/logs/access.log 1 50     # Demo site, 1 hour, alert > 50
 #   ./security-monitor.sh /var/log/nginx/access.log 24 100                     # Global logs, 24h, alert > 100
 #
+# @desc     Detect malicious activity (wp-login/xmlrpc abuse, high-volume IPs) in an Nginx access log
+# @category monitoring
+# @runs     server
+# @requires gawk
+# @arg      log_file        optional  {/srv/www/example.com/logs/access.log}  Nginx access log path
+# @arg      hours           optional  {24}  How many hours back to analyze
+# @arg      alert_threshold optional  {100}  Flag a single IP once it exceeds this many requests
+# @arg      output_file     optional  Path to save the report instead of printing it
+# @example  ssh web@example.com 'bash -s' < security-monitor.sh
+# @example  ssh web@example.com 'bash -s' < security-monitor.sh /srv/www/demo.example.com/logs/access.log 1 50
+# @doc      trellis/monitoring/README.md
 
 set -e
 

--- a/scripts/monitoring/server-monitor.sh
+++ b/scripts/monitoring/server-monitor.sh
@@ -10,6 +10,14 @@
 #   ./server-monitor.sh web@example.com
 #   ./server-monitor.sh root@example.com "php-fpm: pool wordpress"
 #
+# @desc     Live CPU, memory, disk, and PHP-FPM process snapshot of a server over SSH
+# @category monitoring
+# @runs     local
+# @requires ssh
+# @arg      ssh-target            required  {web@example.com}  SSH target to connect to
+# @arg      php-fpm-pool-pattern  optional  {php-fpm: pool}  Pattern to match PHP-FPM pool processes
+# @example  wp-ops scripts/monitoring/server-monitor web@example.com
+# @doc      trellis/monitoring/README.md
 
 set -euo pipefail
 

--- a/scripts/monitoring/traffic-monitor.sh
+++ b/scripts/monitoring/traffic-monitor.sh
@@ -10,6 +10,16 @@
 #   ./traffic-monitor.sh /srv/www/demo.example.com/logs/access.log 6  # Demo site, last 6 hours
 #   ./traffic-monitor.sh /var/log/nginx/access.log 24             # Global logs, last 24 hours
 #
+# @desc     Analyze legitimate traffic from an Nginx access log
+# @category monitoring
+# @runs     server
+# @requires gawk
+# @arg      log_file     optional  {/srv/www/example.com/logs/access.log}  Nginx access log path
+# @arg      hours        optional  {24}  How many hours back to analyze
+# @arg      output_file  optional  Path to save the report instead of printing it
+# @example  ssh web@example.com 'bash -s' < traffic-monitor.sh
+# @example  ssh web@example.com 'bash -s' < traffic-monitor.sh /srv/www/demo.example.com/logs/access.log 6
+# @doc      trellis/monitoring/README.md
 
 set -e
 

--- a/wp-ops
+++ b/wp-ops
@@ -125,6 +125,13 @@ ${command_key}
 
 is_server_side_command() {
     local command_key="$1"
+    local manifest_runs
+    manifest_runs=$(manifest_get "$command_key" "runs")
+    if [[ -n "$manifest_runs" ]]; then
+        [[ "$manifest_runs" == "server" ]]
+        return $?
+    fi
+
     case "$SERVER_SIDE_COMMANDS" in
         *"
 ${command_key}
@@ -191,9 +198,10 @@ get_version() {
 # This avoids associative array issues with bash 3.2
 COMMAND_FILE=$(mktemp /tmp/wp-ops-commands.XXXXXX)
 CATEGORY_FILE=$(mktemp /tmp/wp-ops-categories.XXXXXX)
+MANIFEST_FILE=$(mktemp /tmp/wp-ops-manifest.XXXXXX)
 
 # Cleanup on exit
-trap "rm -f '$COMMAND_FILE' '$CATEGORY_FILE'" EXIT
+trap "rm -f '$COMMAND_FILE' '$CATEGORY_FILE' '$MANIFEST_FILE'" EXIT
 
 # =============================================================================
 # Command Discovery
@@ -235,9 +243,161 @@ clean_description() {
     echo "$description"
 }
 
+# =============================================================================
+# Command Manifest
+# =============================================================================
+#
+# A block of "@directive value" lines in a script's header comment, e.g.:
+#
+#   # @desc     Back up a Trellis site database with WP-CLI
+#   # @category backup
+#   # @runs     server
+#   # @requires wp
+#   # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+#   # @flag     --retention-days  optional  {30}  Days of backups to keep
+#   # @example  wp-ops backup db example.com production
+#   # @doc      trellis/backup/README.md
+#
+# Annotation is optional and incremental: unannotated scripts keep working via
+# the existing header-scrape/probe fallbacks. See docs/cli-ux-plan.md.
+#
+# Stored as command_key|directive|value in MANIFEST_FILE, one line per
+# directive occurrence — @arg/@flag/@example can repeat per command. Storing
+# rather than parsing on demand means "does this command have a manifest at
+# all" and "give me every @arg" are both a single grep, not a re-read of the
+# source file.
+
+# Strips the leading comment marker (#, //, or *) from a script's header block
+# so "@directive value" is recognizable regardless of the file's language.
+manifest_directive_lines() {
+    local script_path="$1"
+    head -80 "$script_path" 2>/dev/null \
+        | sed -E 's/^[[:space:]]*(#|\/\/|\*)[[:space:]]?//' \
+        | grep -E '^@[a-zA-Z]+([[:space:]]|$)'
+}
+
+load_manifest() {
+    local command_key="$1"
+    local script_path="$2"
+    local line directive value
+
+    while IFS= read -r line; do
+        # read's last variable absorbs the remainder of the line as-is (minus
+        # the leading whitespace that separated it from $directive), which is
+        # exactly "first token, then the rest verbatim" — unlike a manual
+        # glob-based split, it isn't tripped up by multiple spaces or tabs.
+        read -r directive value <<< "$line"
+
+        case "$directive" in
+            @desc|@category|@runs|@requires|@doc|@example|@arg|@flag)
+                echo "${command_key}|${directive#@}|${value}" >> "$MANIFEST_FILE"
+                ;;
+        esac
+    done < <(manifest_directive_lines "$script_path")
+}
+
+has_manifest() {
+    grep -q "^${1}|" "$MANIFEST_FILE" 2>/dev/null
+}
+
+# First value for a single-valued directive (desc, category, runs, requires, doc).
+manifest_get() {
+    local command_key="$1" directive="$2"
+    grep "^${command_key}|${directive}|" "$MANIFEST_FILE" 2>/dev/null | head -1 | cut -d'|' -f3-
+}
+
+# All values for a repeatable directive (arg, flag, example), one per line, in
+# source order.
+manifest_get_all() {
+    local command_key="$1" directive="$2"
+    grep "^${command_key}|${directive}|" "$MANIFEST_FILE" 2>/dev/null | cut -d'|' -f3-
+}
+
+# Renders one "@arg"/"@flag" value ("name required|optional {choices-or-default} description")
+manifest_print_param_line() {
+    local line="$1"
+    local name required rest choices="" description
+
+    name=$(awk '{print $1}' <<< "$line")
+    required=$(awk '{print $2}' <<< "$line")
+    rest=$(sed -E 's/^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]*//' <<< "$line")
+
+    if [[ "$rest" =~ ^\{([^}]*)\}[[:space:]]*(.*)$ ]]; then
+        choices="${BASH_REMATCH[1]}"
+        description="${BASH_REMATCH[2]}"
+    else
+        description="$rest"
+    fi
+
+    if [[ -n "$choices" ]]; then
+        printf "  %-18s %-9s {%s}  %s\n" "$name" "$required" "$choices" "$description"
+    else
+        printf "  %-18s %-9s %s\n" "$name" "$required" "$description"
+    fi
+}
+
+print_manifest_help() {
+    local command_key="$1"
+    local script_path="$2"
+    local desc runs doc requires
+
+    desc=$(manifest_get "$command_key" "desc")
+    runs=$(manifest_get "$command_key" "runs")
+    doc=$(manifest_get "$command_key" "doc")
+    requires=$(manifest_get "$command_key" "requires")
+
+    echo "Usage: wp-ops $command_key [args...]"
+    echo ""
+    [[ -n "$desc" ]] && { echo "$desc"; echo ""; }
+
+    local args
+    args=$(manifest_get_all "$command_key" "arg")
+    if [[ -n "$args" ]]; then
+        echo "Arguments:"
+        local line
+        while IFS= read -r line; do
+            manifest_print_param_line "$line"
+        done <<< "$args"
+        echo ""
+    fi
+
+    local flags
+    flags=$(manifest_get_all "$command_key" "flag")
+    if [[ -n "$flags" ]]; then
+        echo "Flags:"
+        local line
+        while IFS= read -r line; do
+            manifest_print_param_line "$line"
+        done <<< "$flags"
+        echo ""
+    fi
+
+    [[ -n "$requires" ]] && { echo "Requires: $requires"; echo ""; }
+
+    if [[ "$runs" == "server" ]]; then
+        echo "Runs on the server — run without --help for SSH instructions."
+        echo ""
+    fi
+
+    local examples
+    examples=$(manifest_get_all "$command_key" "example")
+    if [[ -n "$examples" ]]; then
+        echo "Examples:"
+        local line
+        while IFS= read -r line; do
+            echo "  $line"
+        done <<< "$examples"
+        echo ""
+    fi
+
+    [[ -n "$doc" ]] && echo "Docs: $doc"
+    echo "Script: $script_path"
+}
+
 discover_commands() {
     > "$COMMAND_FILE"
     > "$CATEGORY_FILE"
+    > "$MANIFEST_FILE"
 
     for i in "${!CATEGORIES[@]}"; do
         category="${CATEGORIES[$i]}"
@@ -291,6 +451,25 @@ discover_commands() {
             command_key="${command_key%.css}"
             command_key="${command_key%.py}"
 
+            load_manifest "$command_key" "$script_path"
+
+            # A manifest @desc is authoritative — written straight into
+            # COMMAND_FILE so every reader of it (search, category listings,
+            # --json) sees the same description get_description() would return,
+            # without every call site having to know to prefer the manifest.
+            description=$(manifest_get "$command_key" "desc")
+            if [[ -n "$description" ]]; then
+                echo "${command_key}|${description}" >> "$COMMAND_FILE"
+
+                if [[ -z "$category_commands" ]]; then
+                    category_commands="$command_key"
+                else
+                    category_commands="${category_commands},${command_key}"
+                fi
+
+                continue
+            fi
+
             description=""
             if [[ -f "$script_path" ]]; then
                 case "$script_path" in
@@ -338,6 +517,12 @@ discover_commands() {
 
 get_description() {
     local command_key="$1"
+    local manifest_desc
+    manifest_desc=$(manifest_get "$command_key" "desc")
+    if [[ -n "$manifest_desc" ]]; then
+        echo "$manifest_desc"
+        return 0
+    fi
     grep "^${command_key}|" "$COMMAND_FILE" 2>/dev/null | head -1 | cut -d'|' -f2-
 }
 
@@ -442,6 +627,7 @@ print_usage() {
     echo "  wp-ops search <term>             Search commands by name or description"
     echo "  wp-ops docs [term] [-l]          Search the guides (no term lists them)"
     echo "  wp-ops doctor                    Check dependencies and environment"
+    echo "  wp-ops manifest lint             Validate annotated commands' @directives"
     echo "  wp-ops --help, -h                Show this help message"
     echo "  wp-ops --version, -v             Show version"
     echo "  wp-ops --json                    Output command list as JSON"
@@ -551,8 +737,12 @@ print_json() {
             local runs_on="local"
             is_server_side_command "$cmd_key" && runs_on="server"
 
-            printf '  {"category": "%s", "command": "%s", "description": "%s", "path": "%s", "runs_on": "%s"}' \
-                "$category" "$cmd_key" "$description" "$cmd_key" "$runs_on"
+            local requires doc
+            requires=$(manifest_get "$cmd_key" "requires" | sed 's/\\/\\\\/g; s/"/\\"/g')
+            doc=$(manifest_get "$cmd_key" "doc" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+            printf '  {"category": "%s", "command": "%s", "description": "%s", "path": "%s", "runs_on": "%s", "requires": "%s", "doc": "%s"}' \
+                "$category" "$cmd_key" "$description" "$cmd_key" "$runs_on" "$requires" "$doc"
         done
     done
     
@@ -1100,6 +1290,14 @@ execute_command() {
     fi
     
     if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+        # A manifest is authoritative and doesn't require probing the script
+        # (which, for scripts with no --help handling of their own, risks
+        # actually running with "--help" as a positional argument).
+        if has_manifest "$command_key"; then
+            print_manifest_help "$command_key" "$script_path"
+            return 0
+        fi
+
         # Buffer output so a failed probe (e.g. a script that treats --help as
         # a positional file argument and errors on stdout) never leaks to the
         # user; only a successful probe's output gets printed.
@@ -1508,6 +1706,94 @@ run_doctor() {
 }
 
 # =============================================================================
+# Manifest Lint
+# =============================================================================
+
+# Validates one annotated command's directives; prints one line per problem
+# found and returns the count as its exit status (bash caps that at 255, which
+# a real script isn't going to hit).
+lint_manifest_command() {
+    local command_key="$1"
+    local errors=0
+
+    if [[ -z "$(manifest_get "$command_key" "desc")" ]]; then
+        echo "  ${RED}${CROSS}${RESET} ${command_key}: missing @desc"
+        errors=$((errors + 1))
+    fi
+
+    local runs
+    runs=$(manifest_get "$command_key" "runs")
+    if [[ -n "$runs" ]]; then
+        case "$runs" in
+            local|server|either) ;;
+            *)
+                echo "  ${RED}${CROSS}${RESET} ${command_key}: @runs '${runs}' must be local, server, or either"
+                errors=$((errors + 1))
+                ;;
+        esac
+    fi
+
+    local line name required
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        name=$(awk '{print $1}' <<< "$line")
+        required=$(awk '{print $2}' <<< "$line")
+        if [[ -z "$name" || -z "$required" ]]; then
+            echo "  ${RED}${CROSS}${RESET} ${command_key}: malformed '${line}' (expected: name required|optional {choices-or-default} description)"
+            errors=$((errors + 1))
+            continue
+        fi
+        case "$required" in
+            required|optional) ;;
+            *)
+                echo "  ${RED}${CROSS}${RESET} ${command_key}: '${name}' requiredness must be 'required' or 'optional', got '${required}'"
+                errors=$((errors + 1))
+                ;;
+        esac
+    done < <(manifest_get_all "$command_key" "arg"; manifest_get_all "$command_key" "flag")
+
+    local doc
+    doc=$(manifest_get "$command_key" "doc")
+    if [[ -n "$doc" && ! -f "${REPO_ROOT}/${doc}" ]]; then
+        echo "  ${RED}${CROSS}${RESET} ${command_key}: @doc points at a missing file '${doc}'"
+        errors=$((errors + 1))
+    fi
+
+    return "$errors"
+}
+
+run_manifest_lint() {
+    local total_errors=0
+    local total_checked=0
+    local command_key cmd_errors
+
+    echo "${BOLD}wp-ops manifest lint${RESET}"
+    echo ""
+
+    for command_key in $(get_all_commands); do
+        has_manifest "$command_key" || continue
+        total_checked=$((total_checked + 1))
+        cmd_errors=0
+        lint_manifest_command "$command_key" || cmd_errors=$?
+        total_errors=$((total_errors + cmd_errors))
+    done
+
+    if [[ $total_checked -eq 0 ]]; then
+        echo "${YELLOW}${WARN} No annotated commands found.${RESET}"
+        return 0
+    fi
+
+    if [[ $total_errors -gt 0 ]]; then
+        echo ""
+        echo "${RED}${CROSS} ${total_errors} problem(s) across ${total_checked} annotated command(s).${RESET}"
+        return 1
+    fi
+
+    echo "${GREEN}${CHECK} ${total_checked} annotated command(s), no problems found.${RESET}"
+    return 0
+}
+
+# =============================================================================
 # Interactive Menu
 # =============================================================================
 
@@ -1666,7 +1952,7 @@ _wp_ops_completion() {
     local categories="$categories_list"
 
     if [[ \${cword} -eq 1 ]]; then
-        COMPREPLY=(\$(compgen -W "--help --version --json --completion search docs doctor \$categories" -- "\${cur}"))
+        COMPREPLY=(\$(compgen -W "--help --version --json --completion search docs doctor manifest \$categories" -- "\${cur}"))
     elif [[ \${cword} -eq 2 ]]; then
         local category="\${words[1]}"
         local commands=""
@@ -1770,6 +2056,19 @@ main() {
         doctor|--doctor)
             run_doctor
             return $?
+            ;;
+        manifest|--manifest)
+            case "${2:-lint}" in
+                lint)
+                    run_manifest_lint
+                    return $?
+                    ;;
+                *)
+                    echo "${RED}${CROSS} Unknown manifest subcommand: ${2}${RESET}"
+                    echo "Usage: wp-ops manifest lint"
+                    return 1
+                    ;;
+            esac
             ;;
     esac
     


### PR DESCRIPTION
## Summary

Implements M1 of the [CLI UX plan](docs/cli-ux-plan.md)'s Phase A — the command manifest. This is a complete, safe-to-merge increment of Phase A, not the whole of it; M2 (annotate the remaining 56 commands, guided per-argument prompts, fully retiring the hardcoded server-side list) is tracked separately in the plan doc.

- Scripts can declare `@desc`/`@category`/`@runs`/`@requires`/`@arg`/`@flag`/`@example`/`@doc` directives in their header comment.
- `wp-ops` parses these (`load_manifest`, `manifest_get`, `manifest_get_all`, `has_manifest`) and prefers them in `get_description()`, `--help` rendering, `is_server_side_command()`, and `--json` — falling back to the existing scrape/probe/hardcoded-list behavior for the 56 un-annotated commands, so rollout is incremental and nothing regresses mid-migration.
- New `wp-ops manifest lint` validates `@desc` presence, `@runs` enum, `@arg`/`@flag` shape, and `@doc` file existence.
- Annotates the first rollout group: `scripts/backup/{db-backup,site-backup}` and all 8 `scripts/monitoring/*` scripts (10 commands total). These now get real, consistent `--help` output generated from the manifest — several of the monitoring scripts never implemented `--help` themselves and previously fell through to a generic, unhelpful stub.
- `docs/cli-ux-plan.md` updated with a status banner and per-item progress notes; `CHANGELOG.md` gets a `3.10.0` entry.

## Test plan

- [x] `bash -n wp-ops` — syntax OK
- [x] `wp-ops manifest lint` — 10 annotated commands, no problems
- [x] Injected a bad `@runs` value and confirmed lint catches it, then reverted
- [x] `wp-ops scripts/backup/db-backup --help` / `scripts/monitoring/404-checker --help` / `scripts/monitoring/run-monitoring --help` — render args/flags/requires/examples from the manifest
- [x] `wp-ops scripts/release/release-plugin --help` (un-annotated) — unchanged probe/stub fallback still works
- [x] `wp-ops --json` — command count unchanged at 66; annotated commands carry new `requires`/`doc` fields
- [x] `wp-ops search backup` — shows manifest `@desc`, not the stale scraped description
- [x] `wp-ops scripts --help` (category listing) — manifest descriptions render correctly
- [x] `wp-ops doctor` — unaffected
- [x] `wp-ops scripts/backup/db-backup example.com production` (run locally) — server-side guard still fires via `@runs server`, same guidance as before