### PR TITLE
Annotate trellis playbooks with command manifests (Phase A, M2 group 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - 2026-07-31
+
+### Added
+
+- **trellis/backup**, **trellis/monitoring** - The second manifest rollout group (per `docs/cli-ux-plan.md`) is annotated: all 10 Ansible playbook commands (`database-backup`, `database-pull`, `database-push`, `files-backup`, `files-pull`, `files-push`, `quick-status`, `security-scan`, `setup-monitoring`, `traffic-report`). Each now declares `site`/`env` as required `@arg`s plus their optional `-e key=value` extras (`hours`, `threshold`, `email`, `log_path`), so `--help` shows exactly what a playbook expects instead of leaving it to `variable-check.yml`'s runtime failure to explain.
+- **wp-ops CLI** - `execute_playbook()` now renders `--help` from the manifest when one exists, the same short-circuit the generic script dispatcher already had. Previously every `trellis/**/*.yml` command's `--help` was a fixed three-line stub regardless of manifest data, so annotating a playbook had no visible effect until this wired up.
+
 ## [3.10.0] - 2026-07-31
 
 ### Added

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -1,9 +1,12 @@
 # CLI UX Plan: Command Manifest + Go Rewrite
 
-> **Status (2026-07-31):** M1 is implemented on `feature/cli-manifest-phase-a`
-> — manifest spec, bash parser, `wp-ops manifest lint`, and the first two
-> command groups (`scripts/backup/*`, `scripts/monitoring/*`, 10 commands)
-> annotated. Not yet merged. See "Progress" under Phase A below for details.
+> **Status (2026-07-31):** M1 shipped in 3.10.0 and is merged to `main`
+> (`feature/cli-manifest-phase-a`, PR #134) — manifest spec, bash parser,
+> `wp-ops manifest lint`, and the first two command groups
+> (`scripts/backup/*`, `scripts/monitoring/*`, 10 commands) annotated.
+> Rollout group 2 (`trellis/backup/*.yml`, `trellis/monitoring/*.yml`, 10
+> commands) is now also annotated, on `feature/cli-manifest-m2`, shipping in
+> 3.11.0 — see "Progress" under Phase A below for details.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -162,9 +165,16 @@ readable in the source file.
 Annotate in dependency order, most-confusing-first:
 
 1. `scripts/backup/*` (2), `scripts/monitoring/*` (8) — the commands in the
-   worked example above. **Done, on `feature/cli-manifest-phase-a`.**
-2. `trellis/**/*.yml` (12) — every one needs `site` and `env`; today that's
-   only discoverable by reading `variable-check.yml`.
+   worked example above. **Done, merged in 3.10.0.**
+2. `trellis/**/*.yml` (10 commands — `variable-check.yml` is an imported
+   playbook, not a discoverable command, so the real count is 10, not 12);
+   every one needs `site` and `env`, today that's only discoverable by
+   reading `variable-check.yml`. **Done, on `feature/cli-manifest-m2`,
+   shipping in 3.11.0.** Also required a fix to `execute_playbook()`, whose
+   `--help` branch called its own hardcoded usage text unconditionally
+   instead of checking `has_manifest` first — the same short-circuit the
+   generic script dispatcher already had. Without it, annotating a `.yml`
+   command had no visible effect on `--help`.
 3. `wp-cli/**` (11) and `bedrock/**` (1).
 4. `wordpress-utilities/**` (5) — snippets, mostly `@desc` + `@doc`.
 5. The remaining `scripts/**`.
@@ -183,9 +193,11 @@ Annotate in dependency order, most-confusing-first:
   and `--json` all pick it up for free.
 - Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
   **Mechanism done**, coverage partial: it checks the manifest first and
-  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 10
-  annotated commands are manifest-driven so far. The list itself is only
-  fully redundant — and removable — once rollout group 2–5 land (M2).
+  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 20
+  annotated commands (10 from group 1, 10 from group 2) are manifest-driven
+  so far — all 10 trellis playbooks are `@runs local`, so the list itself is
+  unchanged by this group. It's only fully redundant — and removable — once
+  rollout groups 3–5 land too.
 - Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
   **Done** — `print_manifest_help()` short-circuits the script-probe entirely
   when a manifest exists, so commands with no `--help` handling of their own
@@ -319,8 +331,8 @@ purely additive distribution.
 
 | # | Scope | Version | Status |
 |---|---|---|---|
-| M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done** (`feature/cli-manifest-phase-a`, not merged) |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | Not started |
+| M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — trellis playbooks annotated (20/66 total), guided prompts and remaining groups not started |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
 | M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |

--- a/trellis/backup/database-backup.yml
+++ b/trellis/backup/database-backup.yml
@@ -1,5 +1,14 @@
 ---
 # Back up a site's database from any environment (development/staging/production).
+#
+# @desc     Back up a site's database from any environment (development/staging/production)
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging|development}  Target environment
+# @example  wp-ops trellis/backup/database-backup -e site=example.com -e env=production
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: database-backup.yml

--- a/trellis/backup/database-pull.yml
+++ b/trellis/backup/database-pull.yml
@@ -1,5 +1,14 @@
 ---
 # Pull a site's database from a remote environment into development, with URL search-replace.
+#
+# @desc     Pull a site's database from a remote environment into development, with URL search-replace
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging}  Remote environment to pull from
+# @example  wp-ops trellis/backup/database-pull -e site=example.com -e env=production
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: database-pull.yml

--- a/trellis/backup/database-push.yml
+++ b/trellis/backup/database-push.yml
@@ -1,5 +1,14 @@
 ---
 # Push development's database to a remote environment, with URL search-replace.
+#
+# @desc     Push development's database to a remote environment, with URL search-replace
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging}  Remote environment to push to
+# @example  wp-ops trellis/backup/database-push -e site=example.com -e env=staging
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: database-push.yml

--- a/trellis/backup/files-backup.yml
+++ b/trellis/backup/files-backup.yml
@@ -1,5 +1,14 @@
 ---
 # Back up a site's uploads directory from any environment (development/staging/production).
+#
+# @desc     Back up a site's uploads directory from any environment (development/staging/production)
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging|development}  Target environment
+# @example  wp-ops trellis/backup/files-backup -e site=example.com -e env=production
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: files-backup.yml

--- a/trellis/backup/files-pull.yml
+++ b/trellis/backup/files-pull.yml
@@ -1,5 +1,14 @@
 ---
 # Pull a site's uploads directory from a remote environment into development.
+#
+# @desc     Pull a site's uploads directory from a remote environment into development via rsync
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging}  Remote environment to pull from
+# @example  wp-ops trellis/backup/files-pull -e site=example.com -e env=production
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: files-pull.yml

--- a/trellis/backup/files-push.yml
+++ b/trellis/backup/files-push.yml
@@ -1,5 +1,14 @@
 ---
 # Push development's uploads directory to a remote environment.
+#
+# @desc     Push development's uploads directory to a remote environment via rsync
+# @category backup
+# @runs     local
+# @requires ansible-playbook
+# @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env   required  {production|staging}  Remote environment to push to
+# @example  wp-ops trellis/backup/files-push -e site=example.com -e env=staging
+# @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: files-push.yml

--- a/trellis/monitoring/quick-status.yml
+++ b/trellis/monitoring/quick-status.yml
@@ -1,5 +1,15 @@
 ---
 # Quick health check for a site: recent status codes, errors, and service status.
+#
+# @desc     Quick health check for a site: recent status codes, errors, and service status
+# @category monitoring
+# @runs     local
+# @requires ansible-playbook
+# @arg      site       required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env        required  {production|staging|development}  Target environment
+# @flag     log_path  optional  {/path/to/access.log}  Override the default per-site access log path
+# @example  wp-ops trellis/monitoring/quick-status -e site=example.com -e env=production
+# @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: quick-status.yml

--- a/trellis/monitoring/security-scan.yml
+++ b/trellis/monitoring/security-scan.yml
@@ -1,5 +1,17 @@
 ---
 # Scan a site's Nginx logs for attack patterns and suspicious activity.
+#
+# @desc     Scan a site's Nginx logs for attack patterns and suspicious activity
+# @category monitoring
+# @runs     local
+# @requires ansible-playbook
+# @arg      site         required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env          required  {production|staging|development}  Target environment
+# @flag     hours       optional  {24}  How many hours of log history to scan
+# @flag     threshold   optional  {100}  Requests-per-IP alert threshold
+# @flag     log_path    optional  {/path/to/access.log}  Override the default per-site access log path
+# @example  wp-ops trellis/monitoring/security-scan -e site=example.com -e env=production
+# @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: security-scan.yml

--- a/trellis/monitoring/setup-monitoring.yml
+++ b/trellis/monitoring/setup-monitoring.yml
@@ -1,5 +1,16 @@
 ---
 # Install cron jobs for daily traffic reports and periodic security scans.
+#
+# @desc     Install cron jobs for daily traffic reports and periodic security scans
+# @category monitoring
+# @runs     local
+# @requires ansible-playbook
+# @arg      site        required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env         required  {production|staging|development}  Target environment
+# @flag     email      optional  {alerts@example.com}  Address to send monitoring alerts to
+# @flag     log_path   optional  {/path/to/access.log}  Override the default per-site access log path
+# @example  wp-ops trellis/monitoring/setup-monitoring -e site=example.com -e env=production
+# @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: setup-monitoring.yml

--- a/trellis/monitoring/traffic-report.yml
+++ b/trellis/monitoring/traffic-report.yml
@@ -1,5 +1,16 @@
 ---
 # Generate a traffic analysis report from a site's Nginx access log.
+#
+# @desc     Generate a traffic analysis report from a site's Nginx access log
+# @category monitoring
+# @runs     local
+# @requires ansible-playbook
+# @arg      site        required  {example.com}  Site name as in wordpress_sites.yml
+# @arg      env         required  {production|staging|development}  Target environment
+# @flag     hours      optional  {24}  How many hours of log history to include
+# @flag     log_path   optional  {/path/to/access.log}  Override the default per-site access log path
+# @example  wp-ops trellis/monitoring/traffic-report -e site=example.com -e env=production
+# @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:
     playbook: traffic-report.yml

--- a/wp-ops
+++ b/wp-ops
@@ -927,15 +927,22 @@ execute_playbook() {
     shift 2
 
     if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-        local description
-        description=$(get_description "$command_key")
-        echo "Usage: wp-ops $command_key -e site=<site> -e env=<development|staging|production> [-e key=value ...]"
-        echo ""
-        echo "Description: $description"
-        echo ""
-        echo "Playbook: $script_path"
-        echo "Runs via ansible-playbook against the Trellis project at \$TRELLIS_DIR"
-        echo "(currently: ${TRELLIS_DIR:-not set})"
+        if has_manifest "$command_key"; then
+            print_manifest_help "$command_key" "$script_path"
+            echo ""
+            echo "Runs via ansible-playbook against the Trellis project at \$TRELLIS_DIR"
+            echo "(currently: ${TRELLIS_DIR:-not set})"
+        else
+            local description
+            description=$(get_description "$command_key")
+            echo "Usage: wp-ops $command_key -e site=<site> -e env=<development|staging|production> [-e key=value ...]"
+            echo ""
+            echo "Description: $description"
+            echo ""
+            echo "Playbook: $script_path"
+            echo "Runs via ansible-playbook against the Trellis project at \$TRELLIS_DIR"
+            echo "(currently: ${TRELLIS_DIR:-not set})"
+        fi
         return 0
     fi
 


### PR DESCRIPTION
## Summary

- Annotates all 10 `trellis/backup/*.yml` and `trellis/monitoring/*.yml` Ansible playbook commands with `@desc`/`@category`/`@runs`/`@requires`/`@arg`/`@flag`/`@example`/`@doc` manifest directives, per `docs/cli-ux-plan.md`'s rollout group 2.
- Fixes `execute_playbook()` in `wp-ops`: its `--help` branch printed a fixed usage stub unconditionally instead of checking `has_manifest` first, like the generic script dispatcher already does. Without this, annotating a `.yml` command had no visible effect on `--help`.
- Updates `docs/cli-ux-plan.md` to reflect M1 being merged and M2 group 2 progress, and adds the `3.11.0` changelog entry.

## Test plan

- [x] `wp-ops manifest lint` passes (20 annotated commands, 0 problems)
- [x] `wp-ops trellis/backup/database-backup --help` and `wp-ops trellis/monitoring/security-scan --help` render arguments/flags/examples from the manifest
- [x] `wp-ops --json list` includes `runs_on`/`requires`/`doc` for all 10 trellis commands
- [x] `wp-ops scripts/backup/db-backup --help` (M1, non-yml) still renders correctly — no regression from the `execute_playbook()` change
- [x] `wp-ops search backup` and `wp-ops doctor` still work (66 commands discovered)