### PR TITLE
Complete Phase A manifest rollout: groups 3-5 (v3.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-07-31
+
+### Added
+
+- **wp-cli**, **bedrock** - Manifest rollout group 3 (per `docs/cli-ux-plan.md`): all 12 `wp-cli/**` and `bedrock/**` commands annotated — content-creation's `page-creation`, diagnostics' `diagnostic-transients` and `list-posts-count`, the three security scanners (`scanner-general`, `scanner-targeted`, `scanner-wrapper`), the five SEO audits (`blog-audit`, `orphan-pages-audit`, `page-audit`, `redirect-audit`, `schema-audit`), and bedrock's `wp pattern validate` WP-CLI command.
+- **wordpress-utilities** - Manifest rollout group 4: the age-verification modal's JS/PHP/CSS trio and the two `functions.php` snippets (`admin-user-creation`, `post-expiry-noindex`) now declare `@desc`/`@category`/`@doc`. These are copy-paste reference snippets, not runnable commands, so there's no `@runs`/`@arg`/`@flag` to declare.
+- **scripts** - Manifest rollout group 5: the remaining 25 `scripts/**` commands across `git`, `images`, `misc`, `monitoring` (the two stragglers added after group 1 shipped), `patterns`, `release`, `sync`, and `woocommerce`.
+- **trellis/security**, **trellis/updater** - `check-ips` and `trellis-updater` — two commands `discover_commands()` already matched but that were never inventoried into any of the 5 rollout groups — are now annotated too. 64 of 66 commands now have a manifest; only `mcp-server/*` (2, out of Phase A's scope) remain.
+
+### Fixed
+
+- **wp-ops CLI** - `execute_php_command()` and `execute_snippet()` had the same `has_manifest`-blind `--help` short-circuit `execute_playbook()` had before the 3.11.0 fix: both always rendered a hardcoded description/usage stub instead of `print_manifest_help()`, so annotating a `.php` command or a `wordpress-utilities` snippet had no visible effect on `--help` until corrected here.
+
 ## [3.11.0] - 2026-07-31
 
 ### Added

--- a/bedrock/wp-cli-config/wp-cli-pattern-validate.php
+++ b/bedrock/wp-cli-config/wp-cli-pattern-validate.php
@@ -34,6 +34,20 @@
  *
  *     # If not auto-required via wp-cli.yml, pass --require explicitly:
  *     wp --require=wp-cli-pattern-validate.php pattern validate web/app/themes/your-theme/patterns/
+ *
+ * @desc     Validate/fix block pattern files by round-tripping through parse_blocks()/serialize_blocks()
+ * @category wp-cli-config
+ * @runs     local
+ * @requires wp
+ * @arg      path               required  {web/app/themes/theme-name/patterns/}  Pattern file or directory (recursive)
+ * @flag     --fix              optional  {}  Rewrite files in-place with the canonical output
+ * @flag     --diff             optional  {}  Print a unified diff for files that need changes
+ * @flag     --log              optional  {}  Write per-pattern diffs and a summary to docs/pattern-logs/<date>/
+ * @flag     --log-dir          optional  {docs/pattern-logs}  Override the log directory
+ * @flag     --compliance       optional  {}  Also run project-specific compliance checks
+ * @flag     --compliance-only  optional  {}  Skip Gutenberg validation, only run compliance checks
+ * @example  wp-ops bedrock/wp-cli-config/wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix
+ * @doc      bedrock/wp-cli-config/README.md
  */
 
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -8,11 +8,10 @@
 > commands), merged to `main` in PR #135, is also annotated — 20/66 total.
 > Rollout group 3 (`wp-cli/**`, `bedrock/**`, 12 commands), group 4
 > (`wordpress-utilities/**`, 5 commands), and group 5 (remaining `scripts/**`,
-> 25 commands) are now all annotated too, on `feature/cli-manifest-m2-group3`
-> — 62/66 total — see "Progress" under Phase A below for details. The 4
-> holdouts are `mcp-server/*` (2, always out of Phase A's scope — see Phase D)
-> and two `trellis/security` and `trellis/updater` `.sh` scripts that were
-> never inventoried into any of the 5 rollout groups (see note below).
+> 25 commands, plus the 2 `trellis/security`/`trellis/updater` stragglers it
+> surfaced) are now all annotated too, on `feature/cli-manifest-m2-group3` —
+> 64/66 total — see "Progress" under Phase A below for details. The only
+> holdouts are `mcp-server/*` (2), always out of Phase A's scope — see Phase D.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -195,20 +194,23 @@ Annotate in dependency order, most-confusing-first:
    `execute_php_command()` — corrected the same way.
 5. The remaining `scripts/**` (25 commands: `git`, `images`, `misc`, the two
    `monitoring` stragglers added after group 1 shipped, `patterns`, `release`,
-   `sync`, `woocommerce`). **Done, on `feature/cli-manifest-m2-group3`.** Three
-   scripts (`deploy-plugin-wporg.sh`, `rsync-package-to-site.sh`,
-   `rsync-theme.sh`) print their own `--help` via a fixed `sed -n 'N,Mp'` line
-   range over their own source, so their manifest blocks had to be inserted
-   *after* that range rather than in the natural spot right before `set -e` —
-   otherwise the inserted lines would shift everything after them and get
-   printed as part of the script's own `--help` output.
+   `sync`, `woocommerce`), plus 2 `trellis/security`/`trellis/updater`
+   stragglers this group surfaced (see below). **Done, on
+   `feature/cli-manifest-m2-group3`.** Three scripts
+   (`deploy-plugin-wporg.sh`, `rsync-package-to-site.sh`, `rsync-theme.sh`)
+   print their own `--help` via a fixed `sed -n 'N,Mp'` line range over their
+   own source, so their manifest blocks had to be inserted *after* that range
+   rather than in the natural spot right before `set -e` — otherwise the
+   inserted lines would shift everything after them and get printed as part
+   of the script's own `--help` output.
 
-**Discovered during group 5, out of scope for this rollout:** `discover_commands()`
-matches `*.sh` under every category, not just `trellis/**/*.yml` — so
-`trellis/security/check-ips.sh` and `trellis/updater/trellis-updater.sh` are
-real, currently-unannotated commands that group 2's "10, not 12" count missed
-entirely. Along with `mcp-server/*` (2, never in scope for Phase A — see Phase
-D), these 4 commands are why the total sits at 62/66 rather than 66/66.
+**Discovered during group 5:** `discover_commands()` matches `*.sh` under
+every category, not just `trellis/**/*.yml` — so `trellis/security/check-ips.sh`
+and `trellis/updater/trellis-updater.sh` were real, undiscovered commands that
+group 2's "10, not 12" count missed entirely. Both are now annotated too
+(`@category security` / `@category updater`, `@runs local`). Only
+`mcp-server/*` (2, never in scope for Phase A — see Phase D) remains
+unannotated, which is why the total sits at 64/66 rather than 66/66.
 
 ## Phase A implementation
 
@@ -223,15 +225,15 @@ D), these 4 commands are why the total sits at 62/66 rather than 66/66.
   is written straight into `COMMAND_FILE`, so `search`, category listings,
   and `--json` all pick it up for free.
 - Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
-  **Mechanism done**, coverage partial: it checks the manifest first and
-  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 62
-  annotated commands are manifest-driven so far. Groups 2–4 were all
-  `@runs local` (or not run at all, for the snippets), so the hardcoded list
-  was unchanged by them; group 5 is the first to add manifest-only server-side
-  coverage — `scripts/monitoring/updown-webhook-handler.sh` is `@runs server`
-  but was never in `SERVER_SIDE_COMMANDS`, so before this it had no
-  wrong-machine guard at all. It's only fully redundant — and removable —
-  once the trellis stragglers noted above are annotated too.
+  **Mechanism done**, coverage now at 64/66: it checks the manifest first and
+  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, needed only for
+  `mcp-server/*`'s 2 remaining un-annotated commands. Groups 2–4 and the
+  `trellis` stragglers were all `@runs local` (or not run at all, for the
+  snippets), so the hardcoded list was unchanged by them; group 5 is the first
+  to add manifest-only server-side coverage —
+  `scripts/monitoring/updown-webhook-handler.sh` is `@runs server` but was
+  never in `SERVER_SIDE_COMMANDS`, so before this it had no wrong-machine
+  guard at all.
 - Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
   **Done** — `print_manifest_help()` short-circuits the script-probe entirely
   when a manifest exists, so commands with no `--help` handling of their own
@@ -370,7 +372,7 @@ purely additive distribution.
 | # | Scope | Version | Status |
 |---|---|---|---|
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–5 annotated (62/66 total); 4 stragglers (2 `mcp-server/*`, 2 uninventoried `trellis/*.sh`) and guided prompts not started |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); only `mcp-server/*` (2, out of scope) and guided prompts not started |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
 | M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -6,9 +6,13 @@
 > (`scripts/backup/*`, `scripts/monitoring/*`, 10 commands) annotated.
 > Rollout group 2 (`trellis/backup/*.yml`, `trellis/monitoring/*.yml`, 10
 > commands), merged to `main` in PR #135, is also annotated — 20/66 total.
-> Rollout group 3 (`wp-cli/**`, `bedrock/**`, 12 commands) is now annotated
-> too, on `feature/cli-manifest-m2-group3` — 32/66 total — see "Progress"
-> under Phase A below for details.
+> Rollout group 3 (`wp-cli/**`, `bedrock/**`, 12 commands), group 4
+> (`wordpress-utilities/**`, 5 commands), and group 5 (remaining `scripts/**`,
+> 25 commands) are now all annotated too, on `feature/cli-manifest-m2-group3`
+> — 62/66 total — see "Progress" under Phase A below for details. The 4
+> holdouts are `mcp-server/*` (2, always out of Phase A's scope — see Phase D)
+> and two `trellis/security` and `trellis/updater` `.sh` scripts that were
+> never inventoried into any of the 5 rollout groups (see note below).
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -184,8 +188,27 @@ Annotate in dependency order, most-confusing-first:
    2) — it always rendered the hardcoded description/usage text instead of
    `print_manifest_help()`, so annotating the 12 `.php` commands had no
    visible effect on `--help` until fixed.
-4. `wordpress-utilities/**` (5) — snippets, mostly `@desc` + `@doc`.
-5. The remaining `scripts/**`.
+4. `wordpress-utilities/**` (5) — snippets, mostly `@desc` + `@doc`. **Done, on
+   `feature/cli-manifest-m2-group3`.** Also required a fix to
+   `execute_snippet()`, whose `--help` branch had the same
+   `has_manifest`-blind short-circuit as `execute_playbook()`/
+   `execute_php_command()` — corrected the same way.
+5. The remaining `scripts/**` (25 commands: `git`, `images`, `misc`, the two
+   `monitoring` stragglers added after group 1 shipped, `patterns`, `release`,
+   `sync`, `woocommerce`). **Done, on `feature/cli-manifest-m2-group3`.** Three
+   scripts (`deploy-plugin-wporg.sh`, `rsync-package-to-site.sh`,
+   `rsync-theme.sh`) print their own `--help` via a fixed `sed -n 'N,Mp'` line
+   range over their own source, so their manifest blocks had to be inserted
+   *after* that range rather than in the natural spot right before `set -e` —
+   otherwise the inserted lines would shift everything after them and get
+   printed as part of the script's own `--help` output.
+
+**Discovered during group 5, out of scope for this rollout:** `discover_commands()`
+matches `*.sh` under every category, not just `trellis/**/*.yml` — so
+`trellis/security/check-ips.sh` and `trellis/updater/trellis-updater.sh` are
+real, currently-unannotated commands that group 2's "10, not 12" count missed
+entirely. Along with `mcp-server/*` (2, never in scope for Phase A — see Phase
+D), these 4 commands are why the total sits at 62/66 rather than 66/66.
 
 ## Phase A implementation
 
@@ -201,18 +224,22 @@ Annotate in dependency order, most-confusing-first:
   and `--json` all pick it up for free.
 - Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
   **Mechanism done**, coverage partial: it checks the manifest first and
-  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 32
-  annotated commands (10 from group 1, 10 from group 2, 12 from group 3) are
-  manifest-driven so far — all are `@runs local` or `either`-free so the
-  hardcoded list itself is unchanged by groups 2–3. It's only fully
-  redundant — and removable — once rollout groups 4–5 land too.
+  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 62
+  annotated commands are manifest-driven so far. Groups 2–4 were all
+  `@runs local` (or not run at all, for the snippets), so the hardcoded list
+  was unchanged by them; group 5 is the first to add manifest-only server-side
+  coverage — `scripts/monitoring/updown-webhook-handler.sh` is `@runs server`
+  but was never in `SERVER_SIDE_COMMANDS`, so before this it had no
+  wrong-machine guard at all. It's only fully redundant — and removable —
+  once the trellis stragglers noted above are annotated too.
 - Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
   **Done** — `print_manifest_help()` short-circuits the script-probe entirely
   when a manifest exists, so commands with no `--help` handling of their own
   (6 of the 8 annotated monitoring scripts) get real usage output for the
-  first time. `execute_php_command()` had the same has_manifest-blind
-  short-circuit `execute_playbook()` had before the group 2 fix; corrected
-  in group 3 so the 12 `wp-cli`/`bedrock` `.php` commands' `--help` is also
+  first time. `execute_php_command()` and `execute_snippet()` had the same
+  has_manifest-blind short-circuit `execute_playbook()` had before the group 2
+  fix; corrected in groups 3 and 4 respectively, so the 12 `wp-cli`/`bedrock`
+  `.php` commands' and the 5 `wordpress-utilities` snippets' `--help` are also
   manifest-driven now.
 - Add guided prompting to `fzf_menu()` (`wp-ops:1477`) and
   `interactive_command_menu()` (`wp-ops:1563`). **Not started** — deferred to
@@ -343,7 +370,7 @@ purely additive distribution.
 | # | Scope | Version | Status |
 |---|---|---|---|
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–3 annotated (32/66 total), guided prompts and remaining groups (4–5) not started |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–5 annotated (62/66 total); 4 stragglers (2 `mcp-server/*`, 2 uninventoried `trellis/*.sh`) and guided prompts not started |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
 | M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -5,8 +5,10 @@
 > `wp-ops manifest lint`, and the first two command groups
 > (`scripts/backup/*`, `scripts/monitoring/*`, 10 commands) annotated.
 > Rollout group 2 (`trellis/backup/*.yml`, `trellis/monitoring/*.yml`, 10
-> commands) is now also annotated, on `feature/cli-manifest-m2`, shipping in
-> 3.11.0 — see "Progress" under Phase A below for details.
+> commands), merged to `main` in PR #135, is also annotated — 20/66 total.
+> Rollout group 3 (`wp-cli/**`, `bedrock/**`, 12 commands) is now annotated
+> too, on `feature/cli-manifest-m2-group3` — 32/66 total — see "Progress"
+> under Phase A below for details.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -175,7 +177,13 @@ Annotate in dependency order, most-confusing-first:
    instead of checking `has_manifest` first — the same short-circuit the
    generic script dispatcher already had. Without it, annotating a `.yml`
    command had no visible effect on `--help`.
-3. `wp-cli/**` (11) and `bedrock/**` (1).
+3. `wp-cli/**` (11) and `bedrock/**` (1). **Done, on
+   `feature/cli-manifest-m2-group3`.** Also required a fix to
+   `execute_php_command()`, whose `--help` branch had the same
+   `has_manifest`-blind short-circuit as `execute_playbook()` (fixed in group
+   2) — it always rendered the hardcoded description/usage text instead of
+   `print_manifest_help()`, so annotating the 12 `.php` commands had no
+   visible effect on `--help` until fixed.
 4. `wordpress-utilities/**` (5) — snippets, mostly `@desc` + `@doc`.
 5. The remaining `scripts/**`.
 
@@ -193,16 +201,19 @@ Annotate in dependency order, most-confusing-first:
   and `--json` all pick it up for free.
 - Replace `is_server_side_command()` (`wp-ops:104`) with a `@runs` lookup.
   **Mechanism done**, coverage partial: it checks the manifest first and
-  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 20
-  annotated commands (10 from group 1, 10 from group 2) are manifest-driven
-  so far — all 10 trellis playbooks are `@runs local`, so the list itself is
-  unchanged by this group. It's only fully redundant — and removable — once
-  rollout groups 3–5 land too.
+  falls back to the hardcoded `SERVER_SIDE_COMMANDS` list, so only the 32
+  annotated commands (10 from group 1, 10 from group 2, 12 from group 3) are
+  manifest-driven so far — all are `@runs local` or `either`-free so the
+  hardcoded list itself is unchanged by groups 2–3. It's only fully
+  redundant — and removable — once rollout groups 4–5 land too.
 - Rewrite the `--help` path (`wp-ops:1068`) to render from the manifest.
   **Done** — `print_manifest_help()` short-circuits the script-probe entirely
   when a manifest exists, so commands with no `--help` handling of their own
   (6 of the 8 annotated monitoring scripts) get real usage output for the
-  first time.
+  first time. `execute_php_command()` had the same has_manifest-blind
+  short-circuit `execute_playbook()` had before the group 2 fix; corrected
+  in group 3 so the 12 `wp-cli`/`bedrock` `.php` commands' `--help` is also
+  manifest-driven now.
 - Add guided prompting to `fzf_menu()` (`wp-ops:1477`) and
   `interactive_command_menu()` (`wp-ops:1563`). **Not started** — deferred to
   M2, once enough commands have `@arg` data for per-argument prompts to be
@@ -332,7 +343,7 @@ purely additive distribution.
 | # | Scope | Version | Status |
 |---|---|---|---|
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — trellis playbooks annotated (20/66 total), guided prompts and remaining groups not started |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–3 annotated (32/66 total), guided prompts and remaining groups (4–5) not started |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
 | M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |

--- a/scripts/git/create-pr.sh
+++ b/scripts/git/create-pr.sh
@@ -11,6 +11,20 @@
 #   --no-interactive     Skip all prompts, use defaults/arguments
 #   --update             Update existing PR description for current branch
 #   --dry-run            Print the generated body and exit without touching GitHub
+#
+# @desc     Create a GitHub PR with an AI-generated description
+# @category git
+# @runs     local
+# @requires gh
+# @arg      base-branch  optional  {main}  Target branch for the PR
+# @arg      pr-title     optional  {"Add new feature"}  PR title (prompted if omitted)
+# @flag     --ai              optional  {claude|codex|vibe}  Choose AI backend (default: auto-detect)
+# @flag     --no-ai           optional  {}  Skip AI-powered description generation
+# @flag     --no-interactive  optional  {}  Skip all prompts, use defaults/arguments
+# @flag     --update          optional  {}  Update existing PR description for current branch
+# @flag     --dry-run         optional  {}  Print the generated body and exit without touching GitHub
+# @example  wp-ops scripts/git/create-pr --ai=claude
+# @example  wp-ops scripts/git/create-pr main "Add new feature" --no-ai
 
 set -e
 

--- a/scripts/git/gh-traffic.sh
+++ b/scripts/git/gh-traffic.sh
@@ -5,6 +5,16 @@
 #
 # Author: wp-ops
 # Created: 2026-07-09
+#
+# @desc     Fetch and display GitHub repository traffic statistics (14-day window)
+# @category git
+# @runs     local
+# @requires gh
+# @arg      owner/repo  required  {imagewize/nynaeve}  GitHub repository
+# @flag     --days   optional  {14}  Number of days to fetch (max: 14)
+# @flag     --json   optional  {}  Output raw JSON instead of formatted table
+# @flag     --quiet  optional  {}  Suppress header row in table output
+# @example  wp-ops scripts/git/gh-traffic imagewize/nynaeve --quiet
 
 set -euo pipefail
 

--- a/scripts/git/git-log-oneline.sh
+++ b/scripts/git/git-log-oneline.sh
@@ -22,6 +22,13 @@
 #
 # Author: wp-ops
 # Created: 2025-05-06
+#
+# @desc     Show the last N git commits as compact one-liners
+# @category git
+# @runs     local
+# @requires git
+# @arg      n  optional  {10}  Number of commits to show
+# @example  wp-ops scripts/git/git-log-oneline 20
 
 set -euo pipefail
 

--- a/scripts/images/batch-resize.sh
+++ b/scripts/images/batch-resize.sh
@@ -25,6 +25,20 @@
 #
 #   # Dry run to preview changes
 #   ./batch-resize.sh -w 1200 -H 630 -d *.jpg
+#
+# @desc     Batch resize and center-crop images for featured images
+# @category images
+# @runs     local
+# @requires magick
+# @arg      files      required  {*.png}  One or more input image files
+# @flag     --width    required  {1200}  Output width in pixels
+# @flag     --height   required  {630}  Output height in pixels
+# @flag     --output   optional  {featured-post}  Output filename prefix
+# @flag     --format   optional  {jpg|png|webp}  Output format (default: jpg)
+# @flag     --quality  optional  {85}  Quality for jpg/webp, 1-100
+# @flag     --dry-run  optional  {}  Show what would be done without processing
+# @flag     --delete   optional  {}  Delete original files after successful conversion
+# @example  wp-ops scripts/images/batch-resize -w 1200 -H 630 *.png
 
 set -euo pipefail
 

--- a/scripts/images/convert-to-webp.sh
+++ b/scripts/images/convert-to-webp.sh
@@ -2,6 +2,17 @@
 # JPG to WebP conversion with center-crop, for Facebook OG-ratio featured images
 #
 # Usage: ./convert-to-webp.sh <input.jpg> [output.webp] [quality] [width] [height]
+#
+# @desc     Convert a JPG to WebP with center-crop (Facebook OG ratio by default)
+# @category images
+# @runs     local
+# @requires cwebp
+# @arg      input   required  {input.jpg}  Source JPG file
+# @arg      output  optional  {output.webp}  Output WebP path (default: <input>.webp)
+# @arg      quality optional  {82}  WebP quality
+# @arg      width   optional  {800}  Output width
+# @arg      height  optional  {419}  Output height
+# @example  wp-ops scripts/images/convert-to-webp input.jpg output.webp 82 800 419
 set -e
 
 INPUT="${1:-}"

--- a/scripts/images/make-square-webp.sh
+++ b/scripts/images/make-square-webp.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 # Pad an image onto a square canvas and export it as WebP
+#
+# @desc     Pad an image onto a square canvas and export it as WebP
+# @category images
+# @runs     local
+# @requires magick
+# @arg      input           required  {input.webp}  Source image
+# @arg      output          required  {output.webp}  Output WebP path
+# @flag     --size          optional  {2000}  Square canvas size in pixels (default: max dimension)
+# @flag     --quality       optional  {85}  WebP quality (0-100)
+# @flag     --background    optional  {white}  Background color
+# @flag     --left-pad      optional  {200}  Add left padding by right-aligning after resize
+# @example  wp-ops scripts/images/make-square-webp input.webp output.webp --left-pad 200 --size 2000
 set -euo pipefail
 
 usage() {

--- a/scripts/images/openverse_download.py
+++ b/scripts/images/openverse_download.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 """Download Openverse image URLs and optionally convert to WebP."""
+#
+# @desc     Download Openverse image URLs (single, repeated, or from a manifest file) and optionally convert to WebP
+# @category images
+# @runs     local
+# @requires python3
+# @flag     --url           optional  {https://...}  Image URL (repeatable)
+# @flag     --manifest      optional  {urls.txt}  Text file: '<url> <optional-filename>' per line
+# @flag     --out-dir       optional  {.}  Output directory
+# @flag     --convert-webp  optional  {}  Convert downloaded images to .webp
+# @flag     --quality       optional  {75}  WebP quality
+# @flag     --resize        optional  {0}  Resize width (0 to skip)
+# @flag     --keep-original optional  {}  Keep the original file after WebP conversion
+# @example  wp-ops scripts/images/openverse_download --url https://example.com/img.jpg --convert-webp
 
 import argparse
 import os

--- a/scripts/images/openverse_search.py
+++ b/scripts/images/openverse_search.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 """Query Openverse image API and print results."""
+#
+# @desc     Search the Openverse image API and print matching results
+# @category images
+# @runs     local
+# @requires python3
+# @arg      query            required  {sunset}  Search query
+# @flag     --license        optional  {cc0}  License filter
+# @flag     --license-type   optional  {all}  License type
+# @flag     --page-size      optional  {5}  Results per page
+# @flag     --limit          optional  {5}  Max results to print
+# @flag     --mature         optional  {}  Include mature results
+# @flag     --provider       optional  {flickr}  Source provider filter
+# @flag     --json           optional  {}  Output raw JSON results
+# @example  wp-ops scripts/images/openverse_search sunset --license cc0 --limit 10
 
 import argparse
 import json

--- a/scripts/misc/convert-screenshot-for-claude.sh
+++ b/scripts/misc/convert-screenshot-for-claude.sh
@@ -18,6 +18,14 @@
 #   Creates a JPEG file with the same name + '-for-claude.jpg' suffix
 #   Example: test-screenshot.png -> test-screenshot-for-claude.jpg
 #
+# @desc     Convert a PNG screenshot to JPEG (Claude Code's VSCode extension mislabels PNGs)
+# @category misc
+# @runs     local
+# @requires convert
+# @arg      png-file  required  {test-screenshot.png}  PNG file to convert
+# @flag     --quality optional  {90}  JPEG quality (1-100)
+# @example  wp-ops scripts/misc/convert-screenshot-for-claude .playwright/screenshots/test.png
+#
 
 set -e  # Exit on error
 

--- a/scripts/misc/find-and-replace-files.sh
+++ b/scripts/misc/find-and-replace-files.sh
@@ -20,6 +20,20 @@
 #
 #   # Dry run to see what would be replaced
 #   ./find-and-replace-files.sh -n -d ~/code create-pr.sh ~/wp-ops/scripts/git/create-pr.sh
+#
+# @desc     Find (and optionally replace) multiple copies of a file across projects
+# @category misc
+# @runs     local
+# @requires find
+# @arg      filename     required  {create-pr.sh}  Name of file to search for
+# @arg      source-file  optional  {~/wp-ops/scripts/git/create-pr.sh}  Replacement file (enables replace mode)
+# @flag     --directory  optional  {~/code}  Search directory (default: current directory)
+# @flag     --maxdepth   optional  {5}  Maximum search depth
+# @flag     --dry-run    optional  {}  Show what would be done without making changes
+# @flag     --list       optional  {}  List found files without replacing
+# @flag     --size       optional  {}  Also show file sizes in listing
+# @example  wp-ops scripts/misc/find-and-replace-files -l -s create-pr.sh
+# @doc      scripts/misc/README-FIND-AND-REPLACE.md
 
 set -euo pipefail
 

--- a/scripts/misc/post-count.sh
+++ b/scripts/misc/post-count.sh
@@ -38,6 +38,19 @@
 #   # aseonomics.com on the same server
 #   ./post-count.sh --ssh web@example.com --site /srv/www/aseonomics.com/current
 
+# @desc     Count published WordPress posts by year (or month), locally or over SSH
+# @category misc
+# @runs     local
+# @requires wp
+# @flag     --year     optional  {2026}  Only this year — prints a single total
+# @flag     --months   optional  {2026}  Monthly breakdown (YYYY-MM) for the given year
+# @flag     --type     optional  {post}  post_type to count
+# @flag     --status   optional  {publish}  post_status to count
+# @flag     --path     optional  {web/wp}  WordPress path passed to WP-CLI
+# @flag     --ssh      optional  {web@example.com}  Run remotely over ssh
+# @flag     --site     optional  {/srv/www/example.com/current}  Remote site dir to cd into with --ssh
+# @example  wp-ops scripts/misc/post-count --ssh web@example.com --year 2026
+
 set -euo pipefail
 
 # ── Colours ──────────────────────────────────────────────────────────────────

--- a/scripts/monitoring/cf7-smoke-test.js
+++ b/scripts/monitoring/cf7-smoke-test.js
@@ -12,6 +12,17 @@
  * Examples:
  *   node cf7-smoke-test.js https://example.com/contact/
  *   node cf7-smoke-test.js https://yoursite.com/contact/ --name "QA Bot" --email "qa@yoursite.com"
+ *
+ * @desc     Playwright smoke test verifying CF7 submissions still work after an Nginx rate-limit deploy
+ * @category monitoring
+ * @runs     local
+ * @requires node
+ * @arg      contact-page-url  required  {https://example.com/contact/}  Contact page URL to test
+ * @flag     --name     optional  {"QA Bot"}  Test submitter name
+ * @flag     --email    optional  {qa@example.com}  Test submitter email
+ * @flag     --subject  optional  {"Rate limit smoke test"}  Test subject
+ * @flag     --message  optional  {"..."}  Test message body
+ * @example  wp-ops scripts/monitoring/cf7-smoke-test https://example.com/contact/ --name "QA Bot"
  */
 
 const { chromium } = require('playwright');

--- a/scripts/monitoring/updown-webhook-handler.sh
+++ b/scripts/monitoring/updown-webhook-handler.sh
@@ -16,6 +16,15 @@
 # Example:
 #   ./updown-webhook-handler.sh example.com down
 #
+# @desc     Analyze Nginx logs on the server when updown.io reports downtime via webhook
+# @category monitoring
+# @runs     server
+# @requires grep
+# @arg      site_url    optional  {example.com}  Site domain (used to locate per-site logs)
+# @arg      event_type  optional  {down}  Event type from the updown.io webhook payload
+# @example  ssh web@example.com 'bash -s' < updown-webhook-handler.sh example.com down
+# @doc      trellis/monitoring/README.md
+#
 
 set -e
 

--- a/scripts/patterns/center-screenshots.sh
+++ b/scripts/patterns/center-screenshots.sh
@@ -9,6 +9,16 @@
 #
 # Example:
 #   ./center-screenshots.sh ./screenshots 900 600
+#
+# @desc     Center pattern screenshots on a fixed canvas in place (backs up originals first)
+# @category patterns
+# @runs     local
+# @requires magick
+# @arg      screenshots-dir  required  {./screenshots}  Directory of pattern-*.webp screenshots
+# @arg      width            optional  {900}  Target canvas width
+# @arg      height           optional  {600}  Target canvas height
+# @example  wp-ops scripts/patterns/center-screenshots ./screenshots 900 600
+# @doc      scripts/patterns/README.md
 
 set -euo pipefail
 

--- a/scripts/patterns/convert-to-webp.js
+++ b/scripts/patterns/convert-to-webp.js
@@ -21,6 +21,19 @@
  *   node convert-to-webp.js pattern-hero-dark.png
  *   node convert-to-webp.js --all --dir=./screenshots --output-dir=./webp
  *   node convert-to-webp.js --all --dir=./screenshots --quality=90
+ *
+ * @desc     Convert PNG pattern screenshots to WebP using sharp
+ * @category patterns
+ * @runs     local
+ * @requires node
+ * @arg      input-file     optional  {pattern-hero-dark.png}  Single PNG to convert (omit when using --all)
+ * @flag     --all          optional  {}  Convert every pattern-*.png file in --dir
+ * @flag     --dir          optional  {./screenshots}  Source directory for --all
+ * @flag     --output-dir   optional  {./webp}  Output directory (default: same as source)
+ * @flag     --quality      optional  {85}  WebP quality 1-100
+ * @flag     --dry-run      optional  {}  Show what would be done without writing files
+ * @example  wp-ops scripts/patterns/convert-to-webp --all --dir=./screenshots --quality=90
+ * @doc      scripts/patterns/README.md
  */
 
 const sharp = require('sharp');

--- a/scripts/patterns/screenshot-patterns.sh
+++ b/scripts/patterns/screenshot-patterns.sh
@@ -28,6 +28,14 @@
 # Requirements:
 #   npm install   (from this directory, installs playwright + sharp)
 #   npx playwright install chromium
+#
+# @desc     Screenshot WordPress block patterns end-to-end (temp page, Playwright capture, WebP convert)
+# @category patterns
+# @runs     local
+# @requires node
+# @arg      pattern-slug  required  {hero-dark}  Pattern slug(s) to screenshot (repeatable)
+# @example  PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops scripts/patterns/screenshot-patterns hero-dark
+# @doc      scripts/patterns/README.md
 
 set -euo pipefail
 

--- a/scripts/patterns/screenshot-url.js
+++ b/scripts/patterns/screenshot-url.js
@@ -22,6 +22,20 @@
  *   node screenshot-url.js http://example.test/my-page/ --out=pattern.png
  *   node screenshot-url.js http://example.test/my-page/ --out=pattern.png --selector=".entry-content > *:first-child"
  *   node screenshot-url.js http://example.test/ --out=full.png --full-page --width=1920 --height=1080
+ *
+ * @desc     Screenshot a URL with Playwright, targeting a CSS selector or the full page
+ * @category patterns
+ * @runs     local
+ * @requires node
+ * @arg      url         required  {http://example.test/my-page/}  URL to screenshot
+ * @flag     --out       required  {pattern.png}  Output PNG path
+ * @flag     --width     optional  {1400}  Viewport width
+ * @flag     --height    optional  {900}  Viewport height
+ * @flag     --wait      optional  {3000}  Milliseconds to wait after load, for JS-rendered content
+ * @flag     --selector  optional  {".entry-content > *:first-child"}  Comma-separated CSS selectors, tried in order
+ * @flag     --full-page optional  {}  Skip selector matching and screenshot the entire page
+ * @example  wp-ops scripts/patterns/screenshot-url http://example.test/my-page/ --out=pattern.png
+ * @doc      scripts/patterns/README.md
  */
 
 const { chromium } = require('playwright');

--- a/scripts/patterns/trim-screenshots.sh
+++ b/scripts/patterns/trim-screenshots.sh
@@ -8,6 +8,15 @@
 #
 # Example:
 #   ./trim-screenshots.sh ./screenshots 900
+#
+# @desc     Trim whitespace from pattern screenshots in place, keeping aspect ratio (backs up originals first)
+# @category patterns
+# @runs     local
+# @requires magick
+# @arg      screenshots-dir  required  {./screenshots}  Directory of pattern-*.webp screenshots
+# @arg      width            optional  {900}  Resize width after trimming
+# @example  wp-ops scripts/patterns/trim-screenshots ./screenshots 900
+# @doc      scripts/patterns/README.md
 
 set -euo pipefail
 

--- a/scripts/release/deploy-plugin-wporg.sh
+++ b/scripts/release/deploy-plugin-wporg.sh
@@ -46,6 +46,23 @@ set -e
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 
 err()  { echo -e "${RED}✗ $1${NC}" >&2; }
+# The --help handler above prints lines 3-46 of this file verbatim, so this
+# manifest block is placed after that range to avoid altering its output.
+# @desc     Publish a plugin from its git working tree to the WordPress.org SVN repository
+# @category release
+# @runs     local
+# @requires svn
+# @arg      slug     required  {warder-cookie-consent}  WordPress.org plugin slug
+# @arg      version  optional  {2.1.4}  Release version (default: read from the plugin file's Version: header)
+# @flag     --plugin-dir  optional  {.}  Plugin git working tree (default: current directory)
+# @flag     --assets-dir  optional  {.wordpress-org}  Marketing assets directory
+# @flag     --build       optional  {"npm ci && npx webpack"}  Build command to run first
+# @flag     --svn-dir     optional  {../<slug>-svn}  SVN checkout location
+# @flag     --username    optional  {Rhand}  WordPress.org SVN username
+# @flag     --message     optional  {"Release <version>"}  Commit message
+# @flag     --commit      optional  {}  Actually run svn ci (prompts for SVN password)
+# @flag     --force       optional  {}  Allow re-deploying a tag that already exists
+# @example  wp-ops scripts/release/deploy-plugin-wporg warder-cookie-consent --build "npm ci && npx webpack"
 ok()   { echo -e "${GREEN}  ✓ $1${NC}"; }
 info() { echo -e "${BLUE}$1${NC}"; }
 warn() { echo -e "${YELLOW}⚠ $1${NC}"; }

--- a/scripts/release/release-plugin.sh
+++ b/scripts/release/release-plugin.sh
@@ -19,6 +19,15 @@
 # Requirements:
 # - claude or codex CLI installed and authenticated
 # - git repository with main branch
+#
+# @desc     Bump plugin version and generate an AI changelog entry (Claude or Codex)
+# @category release
+# @runs     local
+# @requires claude
+# @arg      version    required  {2.5.3}  New plugin version
+# @flag     --commit   optional  {}  Auto-commit the version bump and changelog
+# @flag     --ai       optional  {claude|codex}  AI CLI to use (default: claude, or the only one installed)
+# @example  wp-ops scripts/release/release-plugin 2.5.3 --commit
 
 set -e  # Exit on error
 

--- a/scripts/release/release-theme.sh
+++ b/scripts/release/release-theme.sh
@@ -20,6 +20,16 @@
 # Requirements:
 # - claude or codex CLI installed and authenticated
 # - git repository with main branch
+#
+# @desc     Bump theme version and generate an AI changelog entry (Claude or Codex)
+# @category release
+# @runs     local
+# @requires claude
+# @arg      theme-name  required  {elayne}  Theme slug (demo/ or site/ Bedrock installation)
+# @arg      version     required  {1.2.5}  New theme version
+# @flag     --commit    optional  {}  Auto-commit the version bump and changelog
+# @flag     --ai        optional  {claude|codex}  AI CLI to use (default: claude, or the only one installed)
+# @example  wp-ops scripts/release/release-theme nynaeve 1.0.0 --commit
 
 set -e  # Exit on error
 

--- a/scripts/release/upload-release-asset.sh
+++ b/scripts/release/upload-release-asset.sh
@@ -11,6 +11,15 @@
 # Run from the plugin/theme root directory.
 # Requires: gh (GitHub CLI), zip, npm (if package.json is present)
 # Respects .distignore if present to exclude dev files from the zip.
+#
+# @desc     Upload a zipped plugin/theme as a GitHub Release asset (for when the release workflow didn't trigger)
+# @category release
+# @runs     local
+# @requires gh
+# @arg      github-repo  required  {imagewize/warder-cookie-consent}  GitHub repo in owner/repo form
+# @arg      tag          required  {v1.3.1}  Release tag to attach the asset to
+# @arg      zip-name     optional  {warder-cookie-consent.zip}  Output zip filename (default: derived from repo slug)
+# @example  wp-ops scripts/release/upload-release-asset imagewize/warder-cookie-consent v1.3.1
 
 set -e
 

--- a/scripts/sync/rsync-package-to-site.sh
+++ b/scripts/sync/rsync-package-to-site.sh
@@ -35,6 +35,18 @@
 # SITE_ROOT is the Bedrock content directory — the one holding plugins/ and
 # themes/ (web/app in a stock Bedrock install, wp-content elsewhere).
 
+# The usage() function below prints lines 2-36 of this file verbatim, so this
+# manifest block is placed after that range to avoid altering its output.
+# @desc     Rsync a plugin/theme working copy into a Bedrock site for testing unreleased changes
+# @category sync
+# @runs     local
+# @requires rsync
+# @arg      kind          required  {plugin|theme}  Package type
+# @arg      package-slug  required  {my-plugin}  Plugin/theme directory slug at the destination
+# @arg      source-dir    optional  {.}  Package working tree (default: current directory)
+# @flag     --dry-run     optional  {}  Preview the sync without writing anything
+# @example  wp-ops scripts/sync/rsync-package-to-site theme my-theme
+# @doc      bedrock/local-package-development/README.md
 set -euo pipefail
 
 usage() {

--- a/scripts/sync/rsync-theme.sh
+++ b/scripts/sync/rsync-theme.sh
@@ -26,6 +26,14 @@
 #
 # Example theme name used: 'elayne' - replace with your actual theme name
 
+# The usage() function below prints lines 2-27 of this file verbatim, so this
+# manifest block is placed after that range to avoid altering its output.
+# @desc     Rsync theme files from a Trellis site back to its standalone theme repository
+# @category sync
+# @runs     local
+# @requires rsync
+# @flag     --dry-run  optional  {}  Preview the sync without writing anything
+# @example  wp-ops scripts/sync/rsync-theme --dry-run
 set -euo pipefail
 
 # Trailing slashes matter to rsync: "src/" copies the *contents* of src.

--- a/scripts/woocommerce/create-product-variations.sh
+++ b/scripts/woocommerce/create-product-variations.sh
@@ -15,6 +15,13 @@
 #   - Attribute values must already exist as terms before running this script.
 #     See: wordpress-utilities/snippets/woocommerce-product-attributes-wpcli.md
 #
+# @desc     Bulk-create WooCommerce product variations via WP-CLI over Trellis vm shell
+# @category woocommerce
+# @runs     local
+# @requires trellis
+# @example  wp-ops scripts/woocommerce/create-product-variations
+# @doc      wordpress-utilities/snippets/woocommerce-product-attributes-wpcli.md
+#
 
 set -euo pipefail
 

--- a/trellis/security/check-ips.sh
+++ b/trellis/security/check-ips.sh
@@ -9,6 +9,14 @@
 #
 # Requirements:
 #   brew install jq curl
+#
+# @desc     Check IP addresses against AbuseIPDB threat intelligence
+# @category security
+# @runs     local
+# @requires curl
+# @arg      ip  required  {1.2.3.4}  IP address to check (repeatable)
+# @example  wp-ops trellis/security/check-ips 1.2.3.4 5.6.7.8
+# @doc      trellis/security/README.md
 
 set -euo pipefail
 

--- a/trellis/updater/trellis-updater.sh
+++ b/trellis/updater/trellis-updater.sh
@@ -9,6 +9,13 @@
 # files so you don't miss fixes worth cherry-picking.
 #
 # Edit the PROJECT variable below before running.
+#
+# @desc     Safely update a Trellis installation to the latest upstream while preserving vault/config customizations
+# @category updater
+# @runs     local
+# @requires git
+# @example  wp-ops trellis/updater/trellis-updater
+# @doc      trellis/updater/README.md
 
 set -e  # Exit on error
 

--- a/wordpress-utilities/age-verification/age-verification.js
+++ b/wordpress-utilities/age-verification/age-verification.js
@@ -3,6 +3,10 @@
  *
  * Cookie-based age verification modal that toggles casino/advertisement
  * content blocks based on the visitor's declared age.
+ *
+ * @desc     Cookie-based age verification modal script (jQuery)
+ * @category age-verification
+ * @doc      wordpress-utilities/age-verification/README.md
  */
 jQuery(document).ready(function () {
 

--- a/wordpress-utilities/age-verification/footer.php
+++ b/wordpress-utilities/age-verification/footer.php
@@ -9,6 +9,10 @@
  * IMPORTANT: Make sure to include modal.css in your theme or copy its styles to your main stylesheet.
  * You can enqueue it in your functions.php:
  * wp_enqueue_style('age-verification-modal', get_template_directory_uri() . '/age-verification/modal.css');
+ *
+ * @desc     Age verification modal HTML template (ACF-driven button content)
+ * @category age-verification
+ * @doc      wordpress-utilities/age-verification/README.md
  */
 
 // Ensure ACF is loaded

--- a/wordpress-utilities/age-verification/modal.css
+++ b/wordpress-utilities/age-verification/modal.css
@@ -1,8 +1,12 @@
 /**
  * Age Verification Modal Styles
- * 
+ *
  * Custom CSS for the age verification modal component.
  * Include this file in your WordPress theme or copy styles to your main stylesheet.
+ *
+ * @desc     CSS styles for the age verification modal
+ * @category age-verification
+ * @doc      wordpress-utilities/age-verification/README.md
  */
 
 .text-center {

--- a/wordpress-utilities/snippets/admin-user-creation.php
+++ b/wordpress-utilities/snippets/admin-user-creation.php
@@ -23,6 +23,10 @@
  *
  * Better alternative:
  *   Use WP-CLI: wp user create USERNAME EMAIL --role=administrator --user_pass=PASSWORD
+ *
+ * @desc     Temporary admin user creation snippet for functions.php (remove after use)
+ * @category snippets
+ * @doc      wordpress-utilities/snippets/admin-user-creation-wpcli.md
  */
 
 // =============================================================================

--- a/wordpress-utilities/snippets/post-expiry-noindex.php
+++ b/wordpress-utilities/snippets/post-expiry-noindex.php
@@ -17,6 +17,10 @@
  *   - WordPress 5.3+ (wp_timezone() added in 5.3)
  *
  * Meta key: _post_expiry_date (stored as YYYY-MM-DD via HTML date input)
+ *
+ * @desc     Auto-noindex posts past their expiry date via Yoast's wpseo_robots filter
+ * @category snippets
+ * @doc      wordpress-utilities/snippets/post-expiry-noindex-wpcli-checks.md
  */
 
 // ---------------------------------------------------------------------------

--- a/wp-cli/content-creation/page-creation.sh
+++ b/wp-cli/content-creation/page-creation.sh
@@ -13,6 +13,15 @@
 # Usage: ./page-creation.sh <content-file> <page-title> <page-slug>
 # Example: ./page-creation.sh about-page-content.html "About" "about"
 #
+# @desc     Deploy an HTML page to production via SCP and WP-CLI over SSH
+# @category content-creation
+# @runs     local
+# @requires ssh
+# @arg      content-file  required  {about-page-content.html}  Local HTML file with the page content
+# @arg      page-title    required  {About}  Page title
+# @arg      page-slug     required  {about}  Page slug/post name
+# @example  wp-ops wp-cli/content-creation/page-creation about-page-content.html "About" about
+# @doc      wp-cli/content-creation/PAGE-CREATION.md
 
 set -e  # Exit on error
 

--- a/wp-cli/diagnostics/diagnostic-transients.php
+++ b/wp-cli/diagnostics/diagnostic-transients.php
@@ -4,6 +4,13 @@
  *
  * Run this via WP-CLI to diagnose transient storage issues
  * Usage: wp eval-file wp-content/themes/client/diagnostic-transients.php
+ *
+ * @desc     Diagnose WordPress transient storage (set/get round-trip, object cache, cron cleanup)
+ * @category diagnostics
+ * @runs     local
+ * @requires wp
+ * @example  wp-ops wp-cli/diagnostics/diagnostic-transients
+ * @doc      wp-cli/diagnostics/README.md
  */
 
 echo "=== TRANSIENT DIAGNOSTIC REPORT ===\n";

--- a/wp-cli/diagnostics/list-posts-count.sh
+++ b/wp-cli/diagnostics/list-posts-count.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # List all published posts and count lines
+#
+# @desc     Count published posts on example.com via SSH and save the list to /tmp/all_posts.csv
+# @category diagnostics
+# @runs     local
+# @requires ssh
+# @example  wp-ops wp-cli/diagnostics/list-posts-count
+# @doc      wp-cli/diagnostics/README.md
 
 ssh web@example.com "cd /srv/www/example.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1
 wc -l /tmp/all_posts.csv

--- a/wp-cli/security/scanner-general.php
+++ b/wp-cli/security/scanner-general.php
@@ -31,6 +31,14 @@
  *
  * Via Command Line:
  *   php wp-content/themes/client/security-scanner-general.php [/path/to/scan]
+ *
+ * @desc     Broad-spectrum malware scanner (webshells, pharma hacks, backdoors, SEO spam)
+ * @category security
+ * @runs     local
+ * @requires wp
+ * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
+ * @example  wp-ops wp-cli/security/scanner-general
+ * @doc      wp-cli/security/README.md
  */
 
 // ============================================================================

--- a/wp-cli/security/scanner-targeted.php
+++ b/wp-cli/security/scanner-targeted.php
@@ -25,6 +25,14 @@
  *
  * Via Command Line:
  *   php wp-content/themes/client/security-scanner.php
+ *
+ * @desc     Site-specific malware scanner (redirect hijacks, PHP backdoors, SQLi patterns)
+ * @category security
+ * @runs     local
+ * @requires wp
+ * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
+ * @example  wp-ops wp-cli/security/scanner-targeted
+ * @doc      wp-cli/security/README.md
  */
 
 // ============================================================================

--- a/wp-cli/security/scanner-wrapper.php
+++ b/wp-cli/security/scanner-wrapper.php
@@ -11,6 +11,14 @@
  * USAGE:
  *   php wp-cli/security/scanner-wrapper.php [/path/to/scan]
  *   wp eval-file wp-cli/security/scanner-wrapper.php
+ *
+ * @desc     Run both targeted and general malware scanners in sequence
+ * @category security
+ * @runs     local
+ * @requires wp
+ * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
+ * @example  wp-ops wp-cli/security/scanner-wrapper
+ * @doc      wp-cli/security/README.md
  */
 
 // ============================================================================

--- a/wp-cli/seo/blog-audit.sh
+++ b/wp-cli/seo/blog-audit.sh
@@ -14,6 +14,15 @@
 #
 # Requires: WP-CLI access to WordPress installation
 #
+# @desc     Analyze blog posts for content categorization and quality metrics
+# @category seo
+# @runs     local
+# @requires wp
+# @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
+# @flag     --output    optional  {audits}  Output directory
+# @flag     --site-url  optional  {https://example.com}  Site URL for reports
+# @example  wp-ops wp-cli/seo/blog-audit --path web/wp --output reports/seo
+# @doc      wp-cli/seo/README.md
 
 set -euo pipefail
 

--- a/wp-cli/seo/orphan-pages-audit.sh
+++ b/wp-cli/seo/orphan-pages-audit.sh
@@ -14,6 +14,15 @@
 #
 # Requires: WP-CLI access to WordPress installation
 #
+# @desc     Find WordPress pages that exist but aren't linked from navigation menus
+# @category seo
+# @runs     local
+# @requires wp
+# @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
+# @flag     --output    optional  {audits}  Output directory
+# @flag     --site-url  optional  {https://example.com}  Site URL for reports
+# @example  wp-ops wp-cli/seo/orphan-pages-audit --path web/wp --output reports/seo
+# @doc      wp-cli/seo/README.md
 
 set -euo pipefail
 

--- a/wp-cli/seo/page-audit.sh
+++ b/wp-cli/seo/page-audit.sh
@@ -14,6 +14,15 @@
 #
 # Requires: WP-CLI access to WordPress installation
 #
+# @desc     Identify orphaned pages, analyze internal linking, and export a page inventory
+# @category seo
+# @runs     local
+# @requires wp
+# @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
+# @flag     --output    optional  {audits}  Output directory
+# @flag     --site-url  optional  {https://example.com}  Site URL for reports
+# @example  wp-ops wp-cli/seo/page-audit --path web/wp --output reports/seo
+# @doc      wp-cli/seo/README.md
 
 set -euo pipefail
 

--- a/wp-cli/seo/redirect-audit.sh
+++ b/wp-cli/seo/redirect-audit.sh
@@ -15,6 +15,16 @@
 #
 # Requires: curl
 ##############################################################################
+#
+# @desc     Audit redirect chains: HTTPS pages, HTTP->HTTPS, and www canonicalization
+# @category seo
+# @runs     local
+# @requires curl
+# @flag     --url      required  {https://example.com}  URL to test (repeatable)
+# @flag     --verbose  optional  {}  Show detailed curl output
+# @flag     --output   optional  {results/audits}  Output directory for reports
+# @example  wp-ops wp-cli/seo/redirect-audit --url https://example.com --verbose
+# @doc      wp-cli/seo/README.md
 
 set -euo pipefail
 

--- a/wp-cli/seo/schema-audit.sh
+++ b/wp-cli/seo/schema-audit.sh
@@ -13,6 +13,15 @@
 #
 # Requires: curl, grep
 #
+# @desc     Check key pages for schema markup and validate implementation
+# @category seo
+# @runs     local
+# @requires curl
+# @arg      site-url  required  {https://example.com}  Site URL to check
+# @flag     --output  optional  {audits}  Output directory
+# @flag     --pages   optional  {/,/about/,/contact/}  Comma-separated page paths to check
+# @example  wp-ops wp-cli/seo/schema-audit https://example.com --pages /,/services/,/contact/
+# @doc      wp-cli/seo/README.md
 
 set -euo pipefail
 

--- a/wp-ops
+++ b/wp-ops
@@ -1100,12 +1100,17 @@ execute_snippet() {
     shift 2
 
     if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-        local description
-        description=$(get_description "$command_key")
-        echo "Description: $description"
-        echo ""
-        echo "File: $script_path"
-        echo ""
+        if has_manifest "$command_key"; then
+            print_manifest_help "$command_key" "$script_path"
+            echo ""
+        else
+            local description
+            description=$(get_description "$command_key")
+            echo "Description: $description"
+            echo ""
+            echo "File: $script_path"
+            echo ""
+        fi
         echo "This is a reference snippet meant to be copied into a WordPress"
         echo "theme or plugin, not run directly — wp-ops just prints it."
         echo ""

--- a/wp-ops
+++ b/wp-ops
@@ -1023,19 +1023,30 @@ execute_php_command() {
     fi
 
     if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-        local description
-        description=$(get_description "$command_key")
-        echo "Description: $description"
-        echo ""
-        echo "Script: $script_path"
-        echo "Runs via WP-CLI against the site at \$WP_SITE_DIR (currently: ${WP_SITE_DIR:-not set})"
-        echo ""
-        if [[ -n "$wp_command" ]]; then
-            echo "Usage: wp-ops $command_key [${wp_command} args...]"
-            echo "Runs as: wp --require=$(basename "$script_path") ${wp_command} [args...]"
+        if has_manifest "$command_key"; then
+            print_manifest_help "$command_key" "$script_path"
+            echo ""
+            echo "Runs via WP-CLI against the site at \$WP_SITE_DIR (currently: ${WP_SITE_DIR:-not set})"
+            if [[ -n "$wp_command" ]]; then
+                echo "Runs as: wp --require=$(basename "$script_path") ${wp_command} [args...]"
+            else
+                echo "Runs as: wp eval-file $(basename "$script_path") [args...]"
+            fi
         else
-            echo "Usage: wp-ops $command_key [args...]"
-            echo "Runs as: wp eval-file $(basename "$script_path") [args...]"
+            local description
+            description=$(get_description "$command_key")
+            echo "Description: $description"
+            echo ""
+            echo "Script: $script_path"
+            echo "Runs via WP-CLI against the site at \$WP_SITE_DIR (currently: ${WP_SITE_DIR:-not set})"
+            echo ""
+            if [[ -n "$wp_command" ]]; then
+                echo "Usage: wp-ops $command_key [${wp_command} args...]"
+                echo "Runs as: wp --require=$(basename "$script_path") ${wp_command} [args...]"
+            else
+                echo "Usage: wp-ops $command_key [args...]"
+                echo "Runs as: wp eval-file $(basename "$script_path") [args...]"
+            fi
         fi
         return 0
     fi


### PR DESCRIPTION
## Summary

Finishes the command-manifest rollout described in `docs/cli-ux-plan.md`, taking annotation coverage from 20/66 to 64/66 commands.

- **Group 3** — all 12 `wp-cli/**` and `bedrock/**` commands (content-creation, diagnostics, security scanners, SEO audits, the bedrock `wp pattern validate` command)
- **Group 4** — all 5 `wordpress-utilities/**` snippets (age-verification JS/PHP/CSS, two `functions.php` snippets)
- **Group 5** — the remaining 25 `scripts/**` commands (`git`, `images`, `misc`, `monitoring` stragglers, `patterns`, `release`, `sync`, `woocommerce`)
- Plus 2 `trellis/security`/`trellis/updater` commands that `discover_commands()` already matched but were never inventoried into any rollout group

Also fixes two dispatcher bugs found while validating `--help` output:
- `execute_php_command()` and `execute_snippet()` both had the same `has_manifest`-blind `--help` short-circuit that `execute_playbook()` had before its 3.11.0 fix — they always rendered a hardcoded stub instead of `print_manifest_help()`, so annotating a `.php` command or a snippet had no visible effect on `--help` until corrected here.

Bumped to **3.12.0** with a new `CHANGELOG.md` entry; `wp-ops --version` derives its version live from the changelog so no other version file needed updating.

Only `mcp-server/*` (2 commands) remains unannotated — always out of Phase A's scope per the plan (see Phase D).

## Test plan

- [x] `wp-ops manifest lint` passes: 64 annotated commands, no problems
- [x] `wp-ops <cmd> --help` spot-checked across `.sh`, `.js`, `.py`, and `.php` commands — manifest data renders correctly
- [x] Confirmed the 3 scripts with fixed `sed -n 'N,Mp'` self-`--help` ranges (`deploy-plugin-wporg.sh`, `rsync-package-to-site.sh`, `rsync-theme.sh`) still print their original native `--help` output unchanged
- [x] `wp-ops --version` reports `3.12.0`