### PR TITLE
Add guided per-argument prompting to the interactive menus (M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.0] - 2026-07-31
+
+### Added
+
+- **wp-ops CLI** - Guided argument prompting (per `docs/cli-ux-plan.md`, M2): the fzf picker and the fallback `select`-based interactive menu now prompt once per `@arg`/`@flag` declared on a command, instead of a single blank `Arguments (leave blank for none):` box. Each prompt shows the directive's description, offers its `|`-separated choices or default inline, and — for a required field — reprompts rather than silently passing nothing. Boolean flags (`@flag` with an empty `{}`) get a `y/N` prompt instead of a value box. Commands with no manifest, or a manifest with no `@arg`/`@flag` at all (the `wordpress-utilities` snippets), keep the original free-text prompt unchanged. Every guided run ends with an "Additional arguments" catch-all, since a manifest line is only prompted once and can't express a repeatable flag (e.g. `redirect-audit`'s `--url`, shown passed twice in its own `@example`).
+
+### Fixed
+
+- **wp-ops CLI** - The guided prompt's per-line loop originally iterated with `while read line; do prompt_one_manifest_param ...; done <<< "$args"`, which rebinds stdin to the heredoc for the loop's entire body — so the nested `read -p` inside `prompt_one_manifest_param` silently consumed the *next manifest line* instead of the user's typed answer, and the real answer ended up satisfying a later, unrelated prompt. Fixed by collecting lines into a plain array first and walking that with a `for` loop, which never touches stdin.
+
 ## [3.12.0] - 2026-07-31
 
 ### Added

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -12,6 +12,9 @@
 > surfaced) are now all annotated too, on `feature/cli-manifest-m2-group3` —
 > 64/66 total — see "Progress" under Phase A below for details. The only
 > holdouts are `mcp-server/*` (2), always out of Phase A's scope — see Phase D.
+> Guided per-argument prompting in `fzf_menu()`/`interactive_command_menu()`,
+> M2's last item besides CI lint wiring, shipped in 3.13.0 — see "Phase A
+> implementation" below.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -244,9 +247,18 @@ unannotated, which is why the total sits at 64/66 rather than 66/66.
   `.php` commands' and the 5 `wordpress-utilities` snippets' `--help` are also
   manifest-driven now.
 - Add guided prompting to `fzf_menu()` (`wp-ops:1477`) and
-  `interactive_command_menu()` (`wp-ops:1563`). **Not started** — deferred to
-  M2, once enough commands have `@arg` data for per-argument prompts to be
-  worth the UI change everywhere, not just for 10 commands.
+  `interactive_command_menu()` (`wp-ops:1563`). **Done, shipped in 3.13.0.**
+  Both now call a shared `prompt_manifest_args()`, which prompts once per
+  `@arg`/`@flag` — showing its description, its `|`-separated choices or
+  default inline, and reprompting on a blank required field — instead of one
+  free-text box. Commands with no manifest data at all keep the original
+  prompt. Ends with an "Additional arguments" catch-all, since a manifest
+  line is only prompted once and can't express a repeatable flag. Required a
+  fix along the way: the natural `while read line; do ...; done <<< "$args"`
+  loop rebinds stdin to the heredoc for its body, so the nested `read -p`
+  inside the per-line prompt was consuming the next manifest line instead of
+  the user's answer — fixed by collecting lines into an array first and
+  walking that with a plain `for`.
 - Add `wp-ops manifest lint` — fails on missing or malformed directives. Wire
   into CI so new scripts can't regress. **Parser and command done**
   (`wp-ops manifest lint`, checks `@desc` presence, `@runs` enum, `@arg`/
@@ -372,7 +384,7 @@ purely additive distribution.
 | # | Scope | Version | Status |
 |---|---|---|---|
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
-| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); only `mcp-server/*` (2, out of scope) and guided prompts not started |
+| M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **In progress** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); guided prompts shipped in 3.13.0; only `mcp-server/*` (2, out of scope) and CI lint wiring remain |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | Not started |
 | M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |

--- a/wp-ops
+++ b/wp-ops
@@ -313,26 +313,39 @@ manifest_get_all() {
     grep "^${command_key}|${directive}|" "$MANIFEST_FILE" 2>/dev/null | cut -d'|' -f3-
 }
 
+# Parses one "@arg"/"@flag" value ("name required|optional {choices-or-default}
+# description") into the _MP_* globals. No bash-4 namerefs (macOS ships 3.2),
+# so this is the shared parse step for both manifest_print_param_line and the
+# guided prompt in prompt_manifest_args — each interprets _MP_BRACES its own
+# way (raw for display, choices-vs-default split for prompting).
+manifest_parse_param_line() {
+    local line="$1"
+    local rest
+
+    _MP_NAME=$(awk '{print $1}' <<< "$line")
+    _MP_REQUIRED=$(awk '{print $2}' <<< "$line")
+    rest=$(sed -E 's/^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]*//' <<< "$line")
+
+    _MP_BRACES=""
+    _MP_DESC=""
+
+    if [[ "$rest" =~ ^\{([^}]*)\}[[:space:]]*(.*)$ ]]; then
+        _MP_BRACES="${BASH_REMATCH[1]}"
+        _MP_DESC="${BASH_REMATCH[2]}"
+    else
+        _MP_DESC="$rest"
+    fi
+}
+
 # Renders one "@arg"/"@flag" value ("name required|optional {choices-or-default} description")
 manifest_print_param_line() {
     local line="$1"
-    local name required rest choices="" description
+    manifest_parse_param_line "$line"
 
-    name=$(awk '{print $1}' <<< "$line")
-    required=$(awk '{print $2}' <<< "$line")
-    rest=$(sed -E 's/^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]*//' <<< "$line")
-
-    if [[ "$rest" =~ ^\{([^}]*)\}[[:space:]]*(.*)$ ]]; then
-        choices="${BASH_REMATCH[1]}"
-        description="${BASH_REMATCH[2]}"
+    if [[ -n "$_MP_BRACES" ]]; then
+        printf "  %-18s %-9s {%s}  %s\n" "$_MP_NAME" "$_MP_REQUIRED" "$_MP_BRACES" "$_MP_DESC"
     else
-        description="$rest"
-    fi
-
-    if [[ -n "$choices" ]]; then
-        printf "  %-18s %-9s {%s}  %s\n" "$name" "$required" "$choices" "$description"
-    else
-        printf "  %-18s %-9s %s\n" "$name" "$required" "$description"
+        printf "  %-18s %-9s %s\n" "$_MP_NAME" "$_MP_REQUIRED" "$_MP_DESC"
     fi
 }
 
@@ -392,6 +405,128 @@ print_manifest_help() {
 
     [[ -n "$doc" ]] && echo "Docs: $doc"
     echo "Script: $script_path"
+}
+
+# Prompts for a single @arg/@flag line, appending the answer to the global
+# PROMPTED_ARGS array. $2 is "arg" or "flag": a flag with no {value} (or an
+# empty {}) is a boolean and contributes just its own name; a flag with a
+# value contributes its name and the typed value as two tokens (matching how
+# every annotated script's own parser expects them — see @example lines,
+# always space-separated, never `--flag=value`); an arg contributes only the
+# typed value. Bracketed content is choices when it's `|`-separated; a single
+# bracketed value is a real default for an optional field but only an
+# illustrative example for a required one (required fields can't have a
+# usable default), so the hint text and blank handling differ accordingly.
+prompt_one_manifest_param() {
+    local line="$1" kind="$2"
+    manifest_parse_param_line "$line"
+
+    local is_boolean=false choices="" bracket_value="" hint=""
+    if [[ "$kind" == "flag" && -z "$_MP_BRACES" ]]; then
+        is_boolean=true
+    elif [[ "$_MP_BRACES" == *"|"* ]]; then
+        choices="$_MP_BRACES"
+    else
+        bracket_value="$_MP_BRACES"
+    fi
+
+    [[ -n "$_MP_DESC" ]] && echo "  ${DIM}${_MP_DESC}${RESET}"
+
+    if [[ "$is_boolean" == true ]]; then
+        local answer
+        read -r -p "  ${_MP_NAME}? [y/N] " answer
+        [[ "$answer" =~ ^[Yy] ]] && PROMPTED_ARGS+=("$_MP_NAME")
+        return 0
+    fi
+
+    if [[ -n "$choices" ]]; then
+        hint=" [${choices}]"
+    elif [[ -n "$bracket_value" ]]; then
+        if [[ "$_MP_REQUIRED" == "required" ]]; then
+            hint=" (e.g. ${bracket_value})"
+        else
+            hint=" [default: ${bracket_value}]"
+        fi
+    fi
+
+    local value
+    while true; do
+        read -r -p "  ${_MP_NAME}${hint}: " value
+        if [[ -z "$value" ]]; then
+            if [[ "$_MP_REQUIRED" == "required" ]]; then
+                echo "  ${YELLOW}${_MP_NAME} is required.${RESET}"
+                continue
+            fi
+            return 0
+        fi
+        if [[ -n "$choices" && "|${choices}|" != *"|${value}|"* ]]; then
+            echo "  ${YELLOW}Note: \"${value}\" isn't one of ${choices} — using it anyway.${RESET}"
+        fi
+        break
+    done
+
+    if [[ "$kind" == "flag" ]]; then
+        PROMPTED_ARGS+=("$_MP_NAME" "$value")
+    else
+        PROMPTED_ARGS+=("$value")
+    fi
+}
+
+# Prompts once per @arg/@flag declared for cmd_key, populating the global
+# PROMPTED_ARGS array in source order (args first, then flags). Falls back to
+# the original single free-text prompt when the command has no manifest, or a
+# manifest with no @arg/@flag at all. Always ends with a catch-all free-text
+# prompt, since guided prompting only asks once per declared line — it can't
+# express a repeatable flag (e.g. redirect-audit's `--url`, which the
+# @example shows passed twice) — and it's a safety net if a line's bracketed
+# content doesn't fit the choices-or-default heuristic above.
+PROMPTED_ARGS=()
+prompt_manifest_args() {
+    local cmd_key="$1"
+    PROMPTED_ARGS=()
+
+    local args="" flags=""
+    if has_manifest "$cmd_key"; then
+        args=$(manifest_get_all "$cmd_key" "arg")
+        flags=$(manifest_get_all "$cmd_key" "flag")
+    fi
+
+    if [[ -z "$args" && -z "$flags" ]]; then
+        read -r -p "Arguments (leave blank for none, --help for usage): " -a PROMPTED_ARGS
+        return 0
+    fi
+
+    echo "${DIM}Enter to accept a default or skip an optional field.${RESET}"
+    echo ""
+
+    # Collected into arrays first, then walked with a plain `for` — a `while
+    # read <<< ...` loop rebinds stdin to the heredoc for its whole body, so
+    # the nested `read -p` inside prompt_one_manifest_param would consume the
+    # *next manifest line* instead of the user's answer.
+    local line args_lines=() flags_lines=()
+    if [[ -n "$args" ]]; then
+        while IFS= read -r line; do
+            args_lines+=("$line")
+        done <<< "$args"
+    fi
+    if [[ -n "$flags" ]]; then
+        while IFS= read -r line; do
+            flags_lines+=("$line")
+        done <<< "$flags"
+    fi
+
+    for line in "${args_lines[@]+"${args_lines[@]}"}"; do
+        prompt_one_manifest_param "$line" "arg"
+    done
+
+    for line in "${flags_lines[@]+"${flags_lines[@]}"}"; do
+        prompt_one_manifest_param "$line" "flag"
+    done
+
+    echo ""
+    local more=()
+    read -r -p "Additional arguments (leave blank for none): " -a more
+    PROMPTED_ARGS+=("${more[@]+"${more[@]}"}")
 }
 
 discover_commands() {
@@ -1855,12 +1990,11 @@ fzf_menu() {
     printf "  ${DIM}%s${RESET}\n" "$(get_description "$cmd_key")"
     echo ""
 
-    local extra_args=()
-    read -r -p "Arguments (leave blank for none, --help for usage): " -a extra_args
+    prompt_manifest_args "$cmd_key"
 
     echo ""
     # Guard against set -e: a failing command shouldn't abort the picker loop.
-    execute_command "$cmd_key" "${extra_args[@]+"${extra_args[@]}"}" || true
+    execute_command "$cmd_key" "${PROMPTED_ARGS[@]+"${PROMPTED_ARGS[@]}"}" || true
     return 0
 }
 
@@ -1947,13 +2081,12 @@ interactive_command_menu() {
         echo "${DIM}${description}${RESET}"
         echo ""
 
-        local extra_args=()
-        read -r -p "Arguments (leave blank for none): " -a extra_args
+        prompt_manifest_args "$full_command_key"
 
         echo ""
         # Guard against set -e: a failed command must return control to the
         # interactive menu, not abort the whole wp-ops session.
-        execute_command "$full_command_key" "${extra_args[@]+"${extra_args[@]}"}" || true
+        execute_command "$full_command_key" "${PROMPTED_ARGS[@]+"${PROMPTED_ARGS[@]}"}" || true
         break
     done
 }


### PR DESCRIPTION
## Summary
- `fzf_menu()` and `interactive_command_menu()` now prompt once per `@arg`/`@flag` declared on a command (description, inline choices/default, `y/N` for boolean flags, reprompt on blank required field) instead of a single free-text `Arguments:` box. Commands with no manifest data keep the original prompt, and every guided run ends with an "Additional arguments" catch-all for repeatable flags.
- Fixes a stdin-rebinding bug found while building this: `while read line; do ...; done <<< "$args"` redirects stdin to the heredoc for its whole body, so the nested `read -p` inside the per-line prompt was silently consuming the next manifest line instead of the user's typed answer.
- Bumps to 3.13.0; closes out the last of M2 besides `manifest lint` CI wiring and the out-of-scope `mcp-server/*` pair (see `docs/cli-ux-plan.md`).

## Test plan
- [x] `bash -n wp-ops`
- [x] `wp-ops manifest lint` (64/66 annotated, no problems)
- [x] Manual test harness (sourced functions, no TTY) covering: required+choices arg, optional arg skip-on-blank, required example-value flag, boolean flag, non-manifest fallback
- [x] End-to-end run through the real `select`-based interactive menu with piped input