### PR TITLE
Scope M4 (Go CLI completion) into a dedicated tracker doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.1] - 2026-08-01
+
+### Added
+
+- **docs** - Scoped out M4 (remaining Go executors, Bubble Tea picker, completions, goreleaser + tap, per `docs/cli-ux-plan.md` Phase C) into a new tracker doc, `docs/m4-go-cli-completion.md`, following M3's format: an ordered task breakdown (`internal/exec/wpcli.go`, `internal/exec/snippet.go`, the interactive picker, shell completions, `docs` search, goreleaser/tap distribution), four flagged open decisions (embed vs. locate scripts, `docs` command inclusion, picker scope vs. bash's two picker paths, typed flags vs. the `DisableFlagParsing` M3 chose), and explicit M4 done criteria. `cli-ux-plan.md`'s M4 milestone row and M3's tracker doc now point at it. Also corrected `cli-ux-plan.md` and `docs/m3-go-skeleton.md`, both of which still described M3 as "implemented, not yet merged" on a feature branch after PR #140 had already merged to `main`. No code changes.
+
 ## [3.15.0] - 2026-08-01
 
 ### Added

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -16,7 +16,9 @@
 > shipped in 3.13.0, and CI lint wiring (`.github/workflows/manifest-lint.yml`,
 > running `wp-ops manifest lint` on push/PR to `main`) landed right after —
 > M2 is now fully done bar the 2 out-of-scope `mcp-server/*` commands. See
-> "Phase A implementation" below.
+> "Phase A implementation" below. M3 (Go CLI skeleton) is also done, merged
+> to `main` in PR #140 — see `docs/m3-go-skeleton.md`. M4 is next; see
+> `docs/m4-go-cli-completion.md`.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -395,8 +397,8 @@ purely additive distribution.
 |---|---|---|---|
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
 | M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **Done** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); guided prompts shipped in 3.13.0; CI lint wiring landed after. Only `mcp-server/*` (2, out of scope) remains unannotated |
-| M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | **Implemented**, on `feature/cli-manifest-m3-go-skeleton` (not yet merged) — see `docs/m3-go-skeleton.md` for the full breakdown; all acceptance criteria met, parity script passing 8/8 |
-| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started |
+| M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | **Done**, merged to `main` (PR #140) — see `docs/m3-go-skeleton.md` for the full breakdown; all acceptance criteria met, parity script passing 8/8 |
+| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started — see `docs/m4-go-cli-completion.md` |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |
 | M6 | `trellis-wpops` symlink | 4.1.0 | Not started |
 

--- a/docs/m3-go-skeleton.md
+++ b/docs/m3-go-skeleton.md
@@ -1,7 +1,7 @@
 # M3: Go CLI Skeleton — Implementation Tracker
 
-> **Status (2026-08-01):** Implemented on `feature/cli-manifest-m3-go-skeleton`,
-> not yet merged. All nine task groups below are done: `go build ./...` from
+> **Status (2026-08-01):** Merged to `main` (PR #140). All nine task groups
+> below are done: `go build ./...` from
 > `go/` produces a working `wp-ops` binary; the embedded catalog matches
 > bash's 66-command set field-for-field (`go/scripts/parity-check.sh` passes
 > 8/8 checks, including a strict `--json list` diff); a `scripts/**/*.sh`
@@ -275,7 +275,7 @@ table:
 
 ## Acceptance criteria for M3 done
 
-All met, on `feature/cli-manifest-m3-go-skeleton` (not yet merged):
+All met, merged to `main` (PR #140):
 
 - [x] `go build ./...` produces a working binary from `go/`
 - [x] `catalog.json` is generated at build time from all 66 discoverable
@@ -292,8 +292,10 @@ All met, on `feature/cli-manifest-m3-go-skeleton` (not yet merged):
   — exercised by a real PR: **#140**, both `Go Build` and `Manifest Lint`
   passing
 
-**Remaining before merge:** nothing — all three items are done. The branch is
-pushed with PR #140 open and CI green; `go/internal/catalog/gen` has direct
+**Remaining before merge:** nothing — all three items were done before merge.
+PR #140 merged to `main` with CI green; `go/internal/catalog/gen` has direct
 unit tests (`gen/main_test.go`) rather than only transitive coverage via
-`catalog_test.go` + the parity script; and the server-side guard is now a
-full port rather than a documented gap (`go/cmd/serverside.go`, see task 7).
+`catalog_test.go` + the parity script; and the server-side guard is a full
+port rather than a documented gap (`go/cmd/serverside.go`, see task 7). Next
+up: M4 — see `docs/cli-ux-plan.md`'s milestone table and
+`docs/m4-go-cli-completion.md` for the task breakdown.

--- a/docs/m4-go-cli-completion.md
+++ b/docs/m4-go-cli-completion.md
@@ -1,0 +1,196 @@
+# M4: Go CLI Completion — Implementation Tracker
+
+> **Status (2026-08-01):** Not started. Scoped out of M3
+> (`docs/m3-go-skeleton.md`, "Explicitly out of scope for M3") now that M3
+> is merged to `main` (PR #140). Parent plan: `docs/cli-ux-plan.md` (Phase
+> C, milestone M4, target **4.0.0**).
+
+## Goal
+
+> Remaining executors, Bubble Tea picker, completions, goreleaser + tap.
+
+M3 shipped the Go skeleton with two of four executors (`shell.go` for
+`.sh`/`.js`/`.py`, `ansible.go` for `.yml`) and non-interactive parity on
+`list`/`search`/`doctor`/`--json`. The bash CLI (`wp-ops`) is still the
+only way to run a `wp-cli/**` `.php` command or a `wordpress-utilities/**`
+snippet, and the only way to get an interactive picker or shell
+completions — the Go binary currently tells the user to fall back to bash
+for those (`go/cmd/dispatch.go:132-140`). M4 closes that gap and makes the
+Go binary the complete, installable replacement.
+
+The bash CLI keeps working untouched throughout M4, same as M3 — it is
+deleted only at 4.0.0 once the Go binary has full parity. See "Risks —
+Dual maintenance during M3–M4" in the parent plan.
+
+## Open decisions (resolve before/while implementing)
+
+1. **Script distribution: embed vs. locate.** Parent plan's Phase C section
+   already frames this and recommends **(a) embed** (`go:embed` the script
+   tree, extract to a cache dir on first run, `WP_OPS_ROOT` as a dev
+   override) over **(b) locate the checkout** (resolve a repo root as
+   today). This decision gates the goreleaser/tap task below — a
+   `brew install wp-ops` user has no checkout to locate. Confirm (a) before
+   starting that task; `internal/detect` (M3) already ports the checkout
+   -location path for the `WP_OPS_ROOT` dev-override case either way.
+2. **`docs` search command.** Deferred from M3 (open decision #3 there)
+   with a note that it's likely cheap to add alongside `search` since both
+   walk the same catalog. Confirm it's still in scope for M4 — the
+   milestone table's M4 row doesn't explicitly list it, but the parent
+   plan's general "Carried over from the bash CLI" list does
+   (`docs` search at `wp-ops:1235-1346`). **Recommendation:** include it;
+   low incremental cost once `internal/catalog`'s search API exists.
+3. **Bubble Tea picker scope.** Bash's interactive surface is actually two
+   things: `fzf_menu()` (delegates to the `fzf` binary when present) and
+   `interactive_command_menu()` (a plain-bash fallback picker when `fzf`
+   isn't installed), both feeding into the shared
+   `prompt_manifest_args()` guided per-argument prompting from M2. Decide
+   whether the Bubble Tea picker replaces both paths with one
+   implementation (recommended — that's the whole point of dropping the
+   `fzf` dependency) or only replaces the `fzf` path and keeps a bare
+   fallback. **Recommendation:** one Bubble Tea implementation, no `fzf`
+   dependency at all post-M4.
+4. **Typed flags vs. `DisableFlagParsing`.** M3's task 7 note flags this
+   explicitly: per-entry Cobra commands currently use
+   `DisableFlagParsing: true` and pass args through raw. If the Bubble Tea
+   picker wants to render per-`@flag` prompts the way `prompt_manifest_args`
+   does in bash, decide whether it reads `catalog.Entry.Flags` directly
+   (no Cobra flag involvement, recommended — keeps the raw passthrough
+   M3 chose) or whether picker-driven runs need real typed flags after all.
+
+## Task breakdown
+
+Ordered by dependency — each task assumes the ones above it exist. Unlike
+M3, these four are largely independent of each other (no shared
+foundation task like `internal/manifest`/`internal/catalog`); order here is
+by how directly each blocks "the Go binary can replace bash," not by a
+hard technical dependency.
+
+### 1. `internal/exec/wpcli.go`
+Port of `execute_php_command()` (`wp-ops:1146`).
+- [ ] Detect `extends WP_CLI_Command` in the script source; if present,
+  resolve the registered command name (port of
+  `get_registered_wp_command()`, `wp-ops:1140`) and invoke via
+  `wp --require=<script> <registered-command> [args...]`; otherwise
+  `wp eval-file <script> [args...]`
+- [ ] Run from `$WP_SITE_DIR` (port of `require_wp_site_dir()`,
+  `wp-ops:1109`, reusing `internal/detect.WPSiteDir()` from M3) — fail
+  clearly if unset/undetected, same as bash
+- [ ] Fail clearly if `wp` isn't on `PATH` before attempting anything
+- [ ] `--help` renders from the manifest (`internal/exec/help.go`'s shared
+  renderer, extended with the "Runs via WP-CLI against..." / "Runs as:
+  wp ..." lines bash prints), no probe — same manifest-first-by-construction
+  property ansible.go already has, so there's no short-circuit bug class to
+  worry about here
+- [ ] Wire into `go/cmd/dispatch.go`: replace the `ext == ".php"` early
+  return (currently prints "isn't runnable through the Go CLI yet") with a
+  real call
+- [ ] Unit tests mirroring `internal/exec/ansible_test.go`'s shape: help
+  rendering, the `WP_CLI_Command` detection branch, missing-`wp`/missing-
+  `WP_SITE_DIR` failure paths
+
+### 2. `internal/exec/snippet.go`
+Port of `execute_snippet()` (`wp-ops:1232`) — covers `wordpress-utilities/**`.
+- [ ] Default (no args): print to stdout. Match bash's TTY-aware
+  formatting (dimmed filename header + trailing reference-snippet notice
+  on a terminal; raw file content only when piped/redirected, so
+  `wp-ops ... > footer.php` still works)
+- [ ] `--path`: print only the resolved file path
+- [ ] `--copy`: copy to clipboard. Port `find_clipboard_cmd()`
+  (`wp-ops:1220`) — `pbcopy` (macOS) → `xclip`/`xsel` (Linux) →
+  `clip.exe` (WSL/Windows) — fail with the same "no clipboard tool found,
+  try --path instead" message if none are on `PATH`
+- [ ] `--help` renders from the manifest, plus the fixed "this is a
+  reference snippet, not run directly" explanation and the three-line
+  usage block bash prints (`wp-ops <key>`, `--copy`, `--path`)
+- [ ] Wire into `go/cmd/dispatch.go`: replace the
+  `strings.HasPrefix(e.Key, "wordpress-utilities/")` early return
+- [ ] Unit tests: `--path`/`--copy`/default branches, clipboard-tool
+  fallback chain (mock `exec.LookPath`), TTY vs. piped output shape
+
+### 3. `internal/ui` — Bubble Tea interactive picker
+Replaces the `fzf`-dependent `fzf_menu()` (`wp-ops:1477`) and its
+no-`fzf` fallback `interactive_command_menu()` (`wp-ops:1563`), per open
+decision #3.
+- [ ] Category → command list navigation, filterable by typing (the `fzf`
+  UX bash currently shells out for)
+- [ ] Curated preview pane per M1/Phase A: manifest-rendered usage/args
+  /examples (`internal/exec/help.go`'s body renderer already produces
+  this text — reuse it verbatim, don't re-derive)
+- [ ] Guided per-`@arg`/`@flag` prompting on selection, port of
+  `prompt_manifest_args()` (`wp-ops:1477`-area helper added in M2/3.13.0):
+  one prompt per declared arg/flag showing description + choices/default
+  inline, reprompt on blank required field, "Additional arguments"
+  catch-all at the end for anything not expressible as a single manifest
+  line (repeatable flags, etc. — same limitation bash's version has)
+- [ ] No-manifest commands keep a plain free-text prompt, same fallback
+  bash uses
+- [ ] Launches when `wp-ops` runs with no args on an interactive terminal
+  (`main()`'s `[[ -t 0 && -t 1 ]]` check, `wp-ops:2148`) — non-interactive
+  (piped/redirected) keeps printing `list`-equivalent output
+- [ ] Manual pass: run the picker end to end for one command per executor
+  type (`.sh`, `.yml`, `.php` post-task-1, snippet post-task-2), same
+  spirit as M3's task 8 manual pass
+
+### 4. Shell completions
+Replaces the hand-written `print_completion()` (`wp-ops:2098`, bash-only).
+- [ ] Wire Cobra's built-in `completion` command (bash/zsh/fish/PowerShell)
+  — largely free once the command tree is fully populated (it already is,
+  post-M3), but verify the dynamically-registered per-entry commands
+  (`DisableFlagParsing: true`, M3 task 7) complete correctly; Cobra's
+  default completion may need `ValidArgsFunction` hints since flag
+  parsing is disabled
+- [ ] Category → basename two-token completion (`wp-ops <category>
+  <TAB>` → basenames in that category), matching bash's actual grammar
+  ported in M3 task 7, not the flatter completion bash's
+  `print_completion()` implements today
+- [ ] Manual pass: source the generated completion script in bash and zsh,
+  confirm category and basename completion both work
+
+### 5. `docs` search command
+Deferred from M3 per open decision #2 above; port of `docs` search
+(`wp-ops:1235-1346`) if decision #2 confirms it's in scope.
+- [ ] Walk `@doc` references from the catalog (already populated by M3's
+  `internal/catalog`) plus a full-text search fallback over doc files,
+  matching bash's behavior
+- [ ] `wp-ops docs <term>` prints matching doc paths/excerpts
+
+### 6. `goreleaser` + Homebrew tap distribution
+Gated on open decision #1 (embed vs. locate).
+- [ ] If embed: `go:embed` the script tree (everything under the category
+  directories in `catalog.Categories`), extract to a cache dir
+  (`~/.cache/wp-ops` or platform equivalent) on first run;
+  `internal/detect`'s `WP_OPS_ROOT` env var overrides for development,
+  pointing at a live checkout instead of the extracted copy
+- [ ] `.goreleaser.yml`: build matrix (darwin/linux, amd64/arm64 at
+  minimum), archive naming, checksums
+- [ ] Homebrew tap: `imagewize/tap` formula, `brew install
+  imagewize/tap/wp-ops`
+- [ ] Update `install.sh` or superseded by `brew install` instructions —
+  decide whether `install.sh`'s PATH-append approach stays as a
+  no-Homebrew fallback or is retired
+- [ ] CI: goreleaser run on tag push, separate from `go-build.yml`
+
+## Explicitly out of scope for M4
+
+Don't let these creep in — they're later phases per the parent plan's
+milestone table:
+
+- `internal/registry` / shared site registry / `--on <env>` SSH dispatch
+  (Phase D, M5)
+- `trellis-wpops` symlink (Phase E, M6)
+- Deleting the bash CLI — stays authoritative and untouched until 4.0.0
+  ships with full Go parity
+
+## Acceptance criteria for M4 done
+
+- [ ] `wp-cli/**` `.php` commands and `wordpress-utilities/**` snippets run
+  end to end through the Go binary (one of each, minimum)
+- [ ] Interactive picker launches on a bare `wp-ops` invocation with no
+  `fzf` binary required, with guided per-argument prompting matching M2's
+  bash UX
+- [ ] Generated completions work in at least bash and zsh
+- [ ] `brew install imagewize/tap/wp-ops` (or the chosen distribution path
+  per open decision #1) produces a working, self-contained binary
+- [ ] `docs` search, if in scope per open decision #2, matches bash output
+- [ ] CI green on all of the above (`go-build.yml` plus any new
+  goreleaser workflow)


### PR DESCRIPTION
## Summary
- Adds `docs/m4-go-cli-completion.md`: an ordered task breakdown for M4 (remaining Go executors — `wpcli.go`/`snippet.go` — the Bubble Tea picker, shell completions, `docs` search, and goreleaser/Homebrew tap distribution), four flagged open decisions, and explicit done criteria, following the same format as `docs/m3-go-skeleton.md`.
- Corrects `docs/cli-ux-plan.md` and `docs/m3-go-skeleton.md`, both of which still described M3 as "implemented, not yet merged" on a feature branch after PR #140 had already merged M3 to `main`.
- No code changes.

## Test plan
- [x] Docs-only change; no build/test impact