### PR TITLE
Implement M4 task 1: the WP-CLI/.php executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0] - 2026-08-01
+
+### Added
+
+- **go** - M4 task 1 (`internal/exec/wpcli.go`, per `docs/m4-go-cli-completion.md`): the Go CLI can now run `wp-cli/**` and `bedrock/**` `.php` commands, closing one of the two remaining executor gaps from M3. Port of `execute_php_command()` (`wp-ops:1146`) — detects a registered `WP_CLI_Command` subclass via `get_registered_wp_command()`'s Go equivalent and invokes `wp --require=<script> <command> [args...]`, falling back to `wp eval-file <script> [args...]` otherwise. `resolveWPSiteDir()` (`go/cmd/wpsite.go`) ports `require_wp_site_dir()`, mirroring `resolveTrellisDir()`'s detect-then-confirm flow via `internal/detect.WPSiteDir()`. `--help` renders from the manifest with no probe, same manifest-first-by-construction property `ansible.go` already has. `go/cmd/dispatch.go`'s `.php` branch now dispatches for real instead of printing the M4 stub message; `wordpress-utilities/*` snippets still hit that stub pending task 2.
+
 ## [3.15.1] - 2026-08-01
 
 ### Added

--- a/docs/m4-go-cli-completion.md
+++ b/docs/m4-go-cli-completion.md
@@ -1,9 +1,9 @@
 # M4: Go CLI Completion — Implementation Tracker
 
-> **Status (2026-08-01):** Not started. Scoped out of M3
-> (`docs/m3-go-skeleton.md`, "Explicitly out of scope for M3") now that M3
-> is merged to `main` (PR #140). Parent plan: `docs/cli-ux-plan.md` (Phase
-> C, milestone M4, target **4.0.0**).
+> **Status (2026-08-01):** In progress. Task 1 (`internal/exec/wpcli.go`)
+> is done. Scoped out of M3 (`docs/m3-go-skeleton.md`, "Explicitly out of
+> scope for M3") now that M3 is merged to `main` (PR #140). Parent plan:
+> `docs/cli-ux-plan.md` (Phase C, milestone M4, target **4.0.0**).
 
 ## Goal
 
@@ -66,27 +66,34 @@ by how directly each blocks "the Go binary can replace bash," not by a
 hard technical dependency.
 
 ### 1. `internal/exec/wpcli.go`
-Port of `execute_php_command()` (`wp-ops:1146`).
-- [ ] Detect `extends WP_CLI_Command` in the script source; if present,
+Port of `execute_php_command()` (`wp-ops:1146`). **Done.**
+- [x] Detect `extends WP_CLI_Command` in the script source; if present,
   resolve the registered command name (port of
   `get_registered_wp_command()`, `wp-ops:1140`) and invoke via
   `wp --require=<script> <registered-command> [args...]`; otherwise
-  `wp eval-file <script> [args...]`
-- [ ] Run from `$WP_SITE_DIR` (port of `require_wp_site_dir()`,
-  `wp-ops:1109`, reusing `internal/detect.WPSiteDir()` from M3) — fail
-  clearly if unset/undetected, same as bash
-- [ ] Fail clearly if `wp` isn't on `PATH` before attempting anything
-- [ ] `--help` renders from the manifest (`internal/exec/help.go`'s shared
+  `wp eval-file <script> [args...]` — `RegisteredWPCommand()` /
+  `RunWPCLI()` in `wpcli.go`
+- [x] Run from `$WP_SITE_DIR` (port of `require_wp_site_dir()`,
+  `wp-ops:1109`) — fail clearly if unset/undetected, same as bash.
+  `resolveWPSiteDir()` in `go/cmd/wpsite.go` mirrors `resolveTrellisDir()`
+  (M3), reusing `internal/detect.WPSiteDir()` and `detect.Confirm()`
+- [x] Fail clearly if `wp` isn't on `PATH` before attempting anything —
+  `WPAvailable()`, checked in `executeWPCLI()` before site-dir resolution
+- [x] `--help` renders from the manifest (`internal/exec/help.go`'s shared
   renderer, extended with the "Runs via WP-CLI against..." / "Runs as:
   wp ..." lines bash prints), no probe — same manifest-first-by-construction
   property ansible.go already has, so there's no short-circuit bug class to
-  worry about here
-- [ ] Wire into `go/cmd/dispatch.go`: replace the `ext == ".php"` early
-  return (currently prints "isn't runnable through the Go CLI yet") with a
-  real call
-- [ ] Unit tests mirroring `internal/exec/ansible_test.go`'s shape: help
-  rendering, the `WP_CLI_Command` detection branch, missing-`wp`/missing-
-  `WP_SITE_DIR` failure paths
+  worry about here. `FormatWPCLIHelp()`
+- [x] Wire into `go/cmd/dispatch.go`: `ext == ".php"` now dispatches to
+  `executeWPCLI()` instead of the M4 stub message (the stub remains for
+  `wordpress-utilities/*` pending task 2)
+- [x] Unit tests mirroring `internal/exec/ansible_test.go`'s shape:
+  `wpcli_test.go` covers `RegisteredWPCommand` (WP_CLI_Command subclass,
+  plain script, missing file) and `FormatWPCLIHelp` (eval-file form,
+  --require form, site-dir-not-set). Manual pass: both `--help` forms
+  rendered correctly end to end (`wp-cli/security/scanner-targeted`,
+  `bedrock/wp-cli-config/wp-cli-pattern-validate`), and the
+  `WP_SITE_DIR`-not-a-directory failure path was exercised
 
 ### 2. `internal/exec/snippet.go`
 Port of `execute_snippet()` (`wp-ops:1232`) — covers `wordpress-utilities/**`.

--- a/go/cmd/dispatch.go
+++ b/go/cmd/dispatch.go
@@ -128,12 +128,15 @@ func executeEntry(e catalog.Entry, args []string) int {
 		return executeAnsible(e, args, isHelp)
 	}
 
-	// wp-cli/*.php and wordpress-utilities/* snippets don't have Go
-	// executors yet — internal/exec/wpcli.go and snippet.go are explicitly
-	// M4 scope (docs/m3-go-skeleton.md, "Explicitly out of scope for M3").
-	// They're still in the catalog (list/search/doctor/--json need them for
-	// parity), just not runnable through this binary yet.
-	if ext == ".php" || strings.HasPrefix(e.Key, "wordpress-utilities/") {
+	if ext == ".php" {
+		return executeWPCLI(e, args, isHelp)
+	}
+
+	// wordpress-utilities/* snippets don't have a Go executor yet —
+	// internal/exec/snippet.go is M4 task 2 (docs/m4-go-cli-completion.md).
+	// Still in the catalog (list/search/doctor/--json need it for parity),
+	// just not runnable through this binary yet.
+	if strings.HasPrefix(e.Key, "wordpress-utilities/") {
 		if isHelp {
 			fmt.Print(wpexec.FormatGenericHelp(e))
 			return 0
@@ -194,6 +197,39 @@ func executeAnsible(e catalog.Entry, args []string, isHelp bool) int {
 	}
 
 	code, err := wpexec.RunPlaybook(trellisDir, filepath.Join(root, e.ScriptPath), args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	printCompletionBanner(e.Key, code)
+	return code
+}
+
+func executeWPCLI(e catalog.Entry, args []string, isHelp bool) int {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	scriptPath := filepath.Join(root, e.ScriptPath)
+	wpCommand := wpexec.RegisteredWPCommand(scriptPath)
+
+	if isHelp {
+		fmt.Print(wpexec.FormatWPCLIHelp(e, os.Getenv("WP_SITE_DIR"), wpCommand))
+		return 0
+	}
+
+	if !wpexec.WPAvailable() {
+		fmt.Fprintln(os.Stderr, "wp (WP-CLI) not found on PATH. Install WP-CLI first.")
+		return 1
+	}
+
+	wpSiteDir, ok := resolveWPSiteDir()
+	if !ok {
+		return 1
+	}
+
+	code, err := wpexec.RunWPCLI(wpSiteDir, scriptPath, wpCommand, args)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/go/cmd/wpsite.go
+++ b/go/cmd/wpsite.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/imagewize/wp-ops/go/internal/detect"
+)
+
+// resolveWPSiteDir ports require_wp_site_dir() (wp-ops:1109): trust
+// $WP_SITE_DIR if it's set and exists; otherwise try to detect a Bedrock
+// site from the working directory and confirm interactively before using
+// it, same as resolveTrellisDir does for Ansible commands.
+func resolveWPSiteDir() (string, bool) {
+	if dir := os.Getenv("WP_SITE_DIR"); dir != "" {
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			fmt.Fprintf(os.Stderr, "WP_SITE_DIR (%s) is not a directory.\n", dir)
+			return "", false
+		}
+		return dir, true
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return "", false
+	}
+	home, _ := os.UserHomeDir()
+
+	detected, ok := detect.WPSiteDir(cwd, home)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "WP_SITE_DIR is not set.")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "WP-CLI script commands run against a real WordPress/Bedrock site, so")
+		fmt.Fprintln(os.Stderr, "wp-ops needs to know where that project lives (the directory you'd")
+		fmt.Fprintln(os.Stderr, "normally cd into before running 'wp ...'). Either run this from inside")
+		fmt.Fprintln(os.Stderr, "the site, or:")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "  export WP_SITE_DIR=/path/to/your/bedrock-site")
+		return "", false
+	}
+
+	interactive := detect.IsTerminal(os.Stdin) && detect.IsTerminal(os.Stdout)
+	if !detect.Confirm("WP_SITE_DIR", detected, os.Stdin, os.Stdout, interactive) {
+		return "", false
+	}
+	return detected, true
+}

--- a/go/internal/exec/wpcli.go
+++ b/go/internal/exec/wpcli.go
@@ -1,0 +1,109 @@
+package exec
+
+import (
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+// WPAvailable reports whether wp (WP-CLI) is on PATH — port of
+// execute_php_command()'s `command -v wp` check (wp-ops:1189).
+func WPAvailable() bool {
+	_, err := osexec.LookPath("wp")
+	return err == nil
+}
+
+var addCommandRe = regexp.MustCompile(`add_command\(\s*['"]([^'"]+)['"]`)
+
+// RegisteredWPCommand extracts the name a WP-CLI command file registers via
+// WP_CLI::add_command(), e.g. "pattern validate" from
+// wp-cli-pattern-validate.php. Returns "" if the file doesn't register one
+// (either it's not a WP_CLI_Command subclass, or grep found nothing). Port
+// of get_registered_wp_command() (wp-ops:1140).
+func RegisteredWPCommand(scriptPath string) string {
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return ""
+	}
+	if !strings.Contains(string(data), "extends WP_CLI_Command") {
+		return ""
+	}
+	m := addCommandRe.FindStringSubmatch(string(data))
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// RunWPCLI runs a wp-cli/*.php or bedrock/*.php command against wpSiteDir,
+// with stdio inherited. When wpCommand is set (the script registers a
+// WP_CLI_Command), it runs as `wp --require=<scriptPath> <wpCommand>
+// <args...>`; otherwise as `wp eval-file <scriptPath> <args...>`. Port of
+// execute_php_command()'s execution path (wp-ops:1194-1203).
+func RunWPCLI(wpSiteDir, scriptPath, wpCommand string, args []string) (exitCode int, err error) {
+	var cmdArgs []string
+	if wpCommand != "" {
+		// wpCommand intentionally split on spaces and appended as separate
+		// argv entries: a registered name like "pattern validate" is two
+		// CLI words, not one argument — same as bash's unquoted expansion.
+		cmdArgs = append([]string{"--require=" + scriptPath}, strings.Fields(wpCommand)...)
+	} else {
+		cmdArgs = []string{"eval-file", scriptPath}
+	}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := osexec.Command("wp", cmdArgs...)
+	cmd.Dir = wpSiteDir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*osexec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, err
+	}
+	return 0, nil
+}
+
+// FormatWPCLIHelp renders --help for a wp-cli/bedrock .php command from its
+// catalog entry — manifest-first by construction, same as FormatHelp
+// (ansible.go). Port of print_manifest_help plus execute_php_command()'s
+// --help branch (wp-ops:1160-1186).
+func FormatWPCLIHelp(e catalog.Entry, wpSiteDir, wpCommand string) string {
+	current := wpSiteDir
+	if current == "" {
+		current = "not set"
+	}
+
+	runsLine := fmt.Sprintf("Runs via WP-CLI against the site at $WP_SITE_DIR (currently: %s)", current)
+	var runsAs string
+	if wpCommand != "" {
+		runsAs = fmt.Sprintf("Runs as: wp --require=%s %s [args...]", path.Base(e.ScriptPath), wpCommand)
+	} else {
+		runsAs = fmt.Sprintf("Runs as: wp eval-file %s [args...]", path.Base(e.ScriptPath))
+	}
+
+	if !e.Annotated {
+		var b strings.Builder
+		fmt.Fprintf(&b, "Description: %s\n\n", e.Description)
+		fmt.Fprintf(&b, "Script: %s\n", e.ScriptPath)
+		fmt.Fprintln(&b, runsLine)
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, runsAs)
+		return b.String()
+	}
+
+	var b strings.Builder
+	writeManifestHelpBody(&b, e)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, runsLine)
+	fmt.Fprintln(&b, runsAs)
+	return b.String()
+}

--- a/go/internal/exec/wpcli_test.go
+++ b/go/internal/exec/wpcli_test.go
@@ -1,0 +1,105 @@
+package exec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+func TestRegisteredWPCommand_WPCLICommandClass(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wp-cli-pattern-validate.php")
+	writeFile(t, path, `<?php
+class Pattern_Validate_Command extends WP_CLI_Command {
+	public function validate( $args, $assoc_args ) {}
+}
+WP_CLI::add_command( 'pattern validate', array( $_cmd, 'validate' ) );
+`)
+
+	if got := RegisteredWPCommand(path); got != "pattern validate" {
+		t.Errorf("RegisteredWPCommand = %q, want %q", got, "pattern validate")
+	}
+}
+
+func TestRegisteredWPCommand_PlainScript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scanner-targeted.php")
+	writeFile(t, path, `<?php
+// A plain top-to-bottom script, no WP_CLI_Command subclass.
+echo "scanning...";
+`)
+
+	if got := RegisteredWPCommand(path); got != "" {
+		t.Errorf("RegisteredWPCommand = %q, want empty", got)
+	}
+}
+
+func TestRegisteredWPCommand_MissingFile(t *testing.T) {
+	if got := RegisteredWPCommand(filepath.Join(t.TempDir(), "does-not-exist.php")); got != "" {
+		t.Errorf("RegisteredWPCommand = %q, want empty", got)
+	}
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+}
+
+func TestFormatWPCLIHelp_EvalFile(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	e, ok := c.Lookup("wp-cli/security/scanner-targeted")
+	if !ok {
+		t.Fatal("wp-cli/security/scanner-targeted not found in catalog")
+	}
+
+	help := FormatWPCLIHelp(e, "/srv/www/example.com/current", "")
+
+	for _, want := range []string{
+		"Usage: wp-ops wp-cli/security/scanner-targeted [args...]",
+		e.Description,
+		"Arguments:",
+		"Requires: wp",
+		"Runs via WP-CLI against the site at $WP_SITE_DIR (currently: /srv/www/example.com/current)",
+		"Runs as: wp eval-file scanner-targeted.php [args...]",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("FormatWPCLIHelp output missing %q:\n%s", want, help)
+		}
+	}
+}
+
+func TestFormatWPCLIHelp_RequireCommand(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	e, ok := c.Lookup("bedrock/wp-cli-config/wp-cli-pattern-validate")
+	if !ok {
+		t.Fatal("bedrock/wp-cli-config/wp-cli-pattern-validate not found in catalog")
+	}
+
+	help := FormatWPCLIHelp(e, "/srv/www/example.com/current", "pattern validate")
+
+	if !strings.Contains(help, "Runs as: wp --require=wp-cli-pattern-validate.php pattern validate [args...]") {
+		t.Errorf("FormatWPCLIHelp missing --require line:\n%s", help)
+	}
+}
+
+func TestFormatWPCLIHelp_SiteDirNotSet(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	e, _ := c.Lookup("wp-cli/security/scanner-targeted")
+
+	help := FormatWPCLIHelp(e, "", "")
+	if !strings.Contains(help, "(currently: not set)") {
+		t.Errorf("FormatWPCLIHelp with empty wpSiteDir missing 'not set':\n%s", help)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `go/internal/exec/wpcli.go`, porting bash's `execute_php_command()` (`wp-ops:1146`): runs `wp-cli/**` and `bedrock/**` `.php` commands via `wp --require=<script> <command> [args...]` when the script registers a `WP_CLI_Command` subclass, or `wp eval-file <script> [args...]` otherwise.
- Adds `go/cmd/wpsite.go` (`resolveWPSiteDir()`), porting `require_wp_site_dir()` and mirroring `resolveTrellisDir()`'s detect-then-confirm flow.
- `--help` renders from the manifest (no probe), manifest-first-by-construction like `ansible.go`.
- Wires the new executor into `go/cmd/dispatch.go`'s `.php` branch, replacing the M4 stub message. `wordpress-utilities/*` snippets still hit the stub, pending task 2 (`internal/exec/snippet.go`).
- Checks off task 1 in `docs/m4-go-cli-completion.md` with implementation notes.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] `go generate ./...` produces no catalog drift
- [x] Manual: `--help` verified for both the eval-file form (`wp-cli/security/scanner-targeted`) and the `--require` form (`bedrock/wp-cli-config/wp-cli-pattern-validate`)
- [x] Manual: `WP_SITE_DIR` pointing at a non-directory fails cleanly with the expected error