### PR TITLE
Implement M4 task 2: the wordpress-utilities snippet executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.17.0] - 2026-08-01
+
+### Added
+
+- **go** - M4 task 2 (`internal/exec/snippet.go`, per `docs/m4-go-cli-completion.md`): the Go CLI can now run `wordpress-utilities/**` reference snippets, closing the second of M4's two remaining executor gaps. Port of `execute_snippet()` (`wp-ops:1232`) — default (no args) prints the snippet to stdout, TTY-aware like bash (filename header plus trailing reference-snippet notice on a terminal, raw content only when piped/redirected so `wp-ops ... > footer.php` still works, minus bash's ANSI dimming to match the rest of the Go CLI's plain-text convention); `--path` prints only the resolved file path; `--copy` clipboard-copies via the same `pbcopy` → `xclip`/`xsel` → `clip.exe` fallback chain as `find_clipboard_cmd()` (`wp-ops:1220`), failing with the same "no clipboard tool found, try --path instead" message if none are on `PATH`. `--help` renders from the manifest plus the fixed "reference snippet, not run directly" explanation and three-line usage block bash prints. `go/cmd/dispatch.go`'s `wordpress-utilities/*` branch now dispatches for real instead of printing the M4 stub message.
+
+### Fixed
+
+- **go** - `go/cmd/dispatch.go`'s executor dispatch checked `ext == ".php"` before the `wordpress-utilities/` category prefix, a regression introduced when M4 task 1 split what had been a single combined condition. Since 3 of the 5 non-doc files under `wordpress-utilities/` are `.php`, they were silently executed via WP-CLI (`wp eval-file`) instead of being printed/copied as reference snippets — never shipped to a release, caught while wiring up task 2's executor. The category-prefix check now runs first.
+
 ## [3.16.0] - 2026-08-01
 
 ### Added

--- a/docs/m4-go-cli-completion.md
+++ b/docs/m4-go-cli-completion.md
@@ -1,9 +1,10 @@
 # M4: Go CLI Completion — Implementation Tracker
 
 > **Status (2026-08-01):** In progress. Task 1 (`internal/exec/wpcli.go`)
-> is done. Scoped out of M3 (`docs/m3-go-skeleton.md`, "Explicitly out of
-> scope for M3") now that M3 is merged to `main` (PR #140). Parent plan:
-> `docs/cli-ux-plan.md` (Phase C, milestone M4, target **4.0.0**).
+> and task 2 (`internal/exec/snippet.go`) are done. Scoped out of M3
+> (`docs/m3-go-skeleton.md`, "Explicitly out of scope for M3") now that M3
+> is merged to `main` (PR #140). Parent plan: `docs/cli-ux-plan.md`
+> (Phase C, milestone M4, target **4.0.0**).
 
 ## Goal
 
@@ -96,23 +97,38 @@ Port of `execute_php_command()` (`wp-ops:1146`). **Done.**
   `WP_SITE_DIR`-not-a-directory failure path was exercised
 
 ### 2. `internal/exec/snippet.go`
-Port of `execute_snippet()` (`wp-ops:1232`) — covers `wordpress-utilities/**`.
-- [ ] Default (no args): print to stdout. Match bash's TTY-aware
-  formatting (dimmed filename header + trailing reference-snippet notice
+Port of `execute_snippet()` (`wp-ops:1232`) — covers `wordpress-utilities/**`. **Done.**
+- [x] Default (no args): print to stdout. Match bash's TTY-aware
+  formatting (filename header + trailing reference-snippet notice
   on a terminal; raw file content only when piped/redirected, so
-  `wp-ops ... > footer.php` still works)
-- [ ] `--path`: print only the resolved file path
-- [ ] `--copy`: copy to clipboard. Port `find_clipboard_cmd()`
+  `wp-ops ... > footer.php` still works) — `PrintSnippet()` in
+  `snippet.go`. Go port drops bash's ANSI dimming, matching the rest of
+  the Go CLI's plain-text convention (`printCompletionBanner` etc.)
+- [x] `--path`: print only the resolved file path
+- [x] `--copy`: copy to clipboard. Port `find_clipboard_cmd()`
   (`wp-ops:1220`) — `pbcopy` (macOS) → `xclip`/`xsel` (Linux) →
   `clip.exe` (WSL/Windows) — fail with the same "no clipboard tool found,
-  try --path instead" message if none are on `PATH`
-- [ ] `--help` renders from the manifest, plus the fixed "this is a
+  try --path instead" message if none are on `PATH` — `clipboardCmd()` /
+  `CopySnippet()`
+- [x] `--help` renders from the manifest, plus the fixed "this is a
   reference snippet, not run directly" explanation and the three-line
-  usage block bash prints (`wp-ops <key>`, `--copy`, `--path`)
-- [ ] Wire into `go/cmd/dispatch.go`: replace the
-  `strings.HasPrefix(e.Key, "wordpress-utilities/")` early return
-- [ ] Unit tests: `--path`/`--copy`/default branches, clipboard-tool
-  fallback chain (mock `exec.LookPath`), TTY vs. piped output shape
+  usage block bash prints (`wp-ops <key>`, `--copy`, `--path`) —
+  `FormatSnippetHelp()`
+- [x] Wire into `go/cmd/dispatch.go`: replaced the
+  `strings.HasPrefix(e.Key, "wordpress-utilities/")` early return with
+  `executeSnippet()`. Also fixed an ordering bug found while wiring this
+  up: the `ext == ".php"` check ran before the `wordpress-utilities/`
+  prefix check, so `wordpress-utilities/**.php` snippets (3 of the 5
+  non-doc files in that tree) were silently executed via WP-CLI instead
+  of printed/copied. The category-prefix check now runs first.
+- [x] Unit tests: `--path`/`--copy`/default branches, clipboard-tool
+  fallback chain (mock `exec.LookPath`), TTY vs. piped output shape —
+  `snippet_test.go`. Manual pass: `--help`/`--path`/default/`--copy` all
+  exercised end to end against a real annotated `.php` snippet
+  (`wordpress-utilities/snippets/post-expiry-noindex`), a non-`.php`
+  snippet pair (`.css`/`.js` in `wordpress-utilities/age-verification/`),
+  and a plain-file `.php` snippet (`age-verification/footer`) to confirm
+  the ordering fix
 
 ### 3. `internal/ui` — Bubble Tea interactive picker
 Replaces the `fzf`-dependent `fzf_menu()` (`wp-ops:1477`) and its

--- a/go/cmd/dispatch.go
+++ b/go/cmd/dispatch.go
@@ -128,22 +128,16 @@ func executeEntry(e catalog.Entry, args []string) int {
 		return executeAnsible(e, args, isHelp)
 	}
 
-	if ext == ".php" {
-		return executeWPCLI(e, args, isHelp)
+	// Checked before the .php branch below: wordpress-utilities/* snippets
+	// are reference files, several of them .php, so the category prefix
+	// must win over the extension or they'd be run through WP-CLI instead
+	// of printed/copied.
+	if strings.HasPrefix(e.Key, "wordpress-utilities/") {
+		return executeSnippet(e, args, isHelp)
 	}
 
-	// wordpress-utilities/* snippets don't have a Go executor yet —
-	// internal/exec/snippet.go is M4 task 2 (docs/m4-go-cli-completion.md).
-	// Still in the catalog (list/search/doctor/--json need it for parity),
-	// just not runnable through this binary yet.
-	if strings.HasPrefix(e.Key, "wordpress-utilities/") {
-		if isHelp {
-			fmt.Print(wpexec.FormatGenericHelp(e))
-			return 0
-		}
-		fmt.Fprintf(os.Stderr, "%s isn't runnable through the Go CLI yet — its executor lands in M4.\n", e.Key)
-		fmt.Fprintf(os.Stderr, "Run it via the bash CLI instead: wp-ops %s %s\n", e.Key, strings.Join(args, " "))
-		return 1
+	if ext == ".php" {
+		return executeWPCLI(e, args, isHelp)
 	}
 
 	if isHelp {
@@ -236,6 +230,23 @@ func executeWPCLI(e catalog.Entry, args []string, isHelp bool) int {
 	}
 	printCompletionBanner(e.Key, code)
 	return code
+}
+
+func executeSnippet(e catalog.Entry, args []string, isHelp bool) int {
+	if isHelp {
+		fmt.Print(wpexec.FormatSnippetHelp(e))
+		return 0
+	}
+
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	scriptPath := filepath.Join(root, e.ScriptPath)
+	tty := detect.IsTerminal(os.Stdout)
+
+	return wpexec.RunSnippet(os.Stdout, os.Stderr, e, scriptPath, args, tty)
 }
 
 func printCompletionBanner(key string, code int) {

--- a/go/internal/exec/snippet.go
+++ b/go/internal/exec/snippet.go
@@ -1,0 +1,145 @@
+package exec
+
+import (
+	"fmt"
+	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+// wordpress-utilities files are copy-paste-into-a-theme reference snippets
+// (PHP includes, CSS, browser JS) with no meaningful "run" behavior of their
+// own, so instead of executing them, wp-ops prints or clipboard-copies them.
+// Port of execute_snippet() (wp-ops:1232).
+
+// clipboardCmd resolves the first available clipboard tool, returning its
+// argv (command plus any fixed args). Port of find_clipboard_cmd()
+// (wp-ops:1220): pbcopy (macOS) -> xclip/xsel (Linux) -> clip.exe
+// (WSL/Windows). Returns nil if none are on PATH.
+func clipboardCmd(lookPath func(string) (string, error)) []string {
+	for _, candidate := range [][]string{
+		{"pbcopy"},
+		{"xclip", "-selection", "clipboard"},
+		{"xsel", "--clipboard", "--input"},
+		{"clip.exe"},
+	} {
+		if _, err := lookPath(candidate[0]); err == nil {
+			return candidate
+		}
+	}
+	return nil
+}
+
+// CopySnippet copies scriptPath's contents to the clipboard via the first
+// available clipboard tool. Returns ok=false with no error when no clipboard
+// tool is found on PATH — the caller prints the "try --path instead"
+// guidance, matching bash's messaging split (wp-ops:1267-1271).
+func CopySnippet(scriptPath string) (ok bool, err error) {
+	argv := clipboardCmd(osexec.LookPath)
+	if argv == nil {
+		return false, nil
+	}
+
+	f, err := os.Open(scriptPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	cmd := osexec.Command(argv[0], argv[1:]...)
+	cmd.Stdin = f
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// PrintSnippet writes scriptPath's contents to w. When tty is true it adds
+// the dimmed-in-bash filename header and trailing reference-snippet notice
+// bash prints on a terminal (wp-ops:1280-1285); when false (piped/redirected)
+// it writes the raw file content only, so `wp-ops ... > footer.php` still
+// works (wp-ops:1286-1288). wp-ops's Go port drops bash's ANSI dimming —
+// see printCompletionBanner (dispatch.go) for the same plain-text convention.
+func PrintSnippet(w io.Writer, scriptPath string, tty bool) error {
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return err
+	}
+
+	if !tty {
+		_, err := w.Write(data)
+		return err
+	}
+
+	fmt.Fprintf(w, "# %s\n\n", scriptPath)
+	w.Write(data)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Reference snippet — copy it into your project (wp-ops does not run it). Try --copy or --path.")
+	return nil
+}
+
+// FormatSnippetHelp renders --help for a wordpress-utilities/* snippet from
+// its catalog entry, plus the fixed "this is a reference snippet, not run
+// directly" explanation and three-line usage block bash prints. Port of
+// print_manifest_help plus execute_snippet()'s --help branch
+// (wp-ops:1237-1256).
+func FormatSnippetHelp(e catalog.Entry) string {
+	var b strings.Builder
+
+	if !e.Annotated {
+		fmt.Fprintf(&b, "Description: %s\n\n", e.Description)
+		fmt.Fprintf(&b, "File: %s\n\n", e.ScriptPath)
+	} else {
+		writeManifestHelpBody(&b, e)
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintln(&b, "This is a reference snippet meant to be copied into a WordPress")
+	fmt.Fprintln(&b, "theme or plugin, not run directly — wp-ops just prints it.")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Usage: wp-ops %s            Print the snippet\n", e.Key)
+	fmt.Fprintf(&b, "       wp-ops %s --copy      Copy it to the clipboard\n", e.Key)
+	fmt.Fprintf(&b, "       wp-ops %s --path      Print only the file path\n", e.Key)
+	return b.String()
+}
+
+// RunSnippet dispatches a wordpress-utilities/* command's non-help args:
+// --path prints the resolved file path, --copy copies to the clipboard
+// (falling back to a "try --path" error when no clipboard tool is found),
+// and anything else prints the snippet (TTY-aware, see PrintSnippet). Port
+// of execute_snippet()'s body (wp-ops:1258-1290) minus the --help branch,
+// which the caller handles via FormatSnippetHelp same as the other
+// executors.
+func RunSnippet(w io.Writer, errw io.Writer, e catalog.Entry, scriptPath string, args []string, tty bool) int {
+	if len(args) > 0 && args[0] == "--path" {
+		fmt.Fprintln(w, scriptPath)
+		return 0
+	}
+
+	if len(args) > 0 && args[0] == "--copy" {
+		ok, err := CopySnippet(scriptPath)
+		if err != nil {
+			fmt.Fprintln(errw, err)
+			return 1
+		}
+		if !ok {
+			fmt.Fprintln(errw, "No clipboard tool found (tried pbcopy, xclip, xsel, clip.exe).")
+			fmt.Fprintf(errw, "Use 'wp-ops %s --path' to get the file path instead.\n", e.Key)
+			return 1
+		}
+		if tty {
+			fmt.Fprintf(w, "Copied %s to clipboard\n", filepath.Base(scriptPath))
+		}
+		return 0
+	}
+
+	if err := PrintSnippet(w, scriptPath, tty); err != nil {
+		fmt.Fprintln(errw, err)
+		return 1
+	}
+	return 0
+}

--- a/go/internal/exec/snippet_test.go
+++ b/go/internal/exec/snippet_test.go
@@ -1,0 +1,173 @@
+package exec
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+func writeSnippet(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "footer.php")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func lookupSnippetEntry(t *testing.T) catalog.Entry {
+	t.Helper()
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	e, ok := c.Lookup("wordpress-utilities/snippets/post-expiry-noindex")
+	if !ok {
+		t.Fatal("wordpress-utilities/snippets/post-expiry-noindex not found in catalog")
+	}
+	return e
+}
+
+func TestPrintSnippet_TTY(t *testing.T) {
+	path := writeSnippet(t, "<?php echo 'hi'; ?>")
+	var buf bytes.Buffer
+	if err := PrintSnippet(&buf, path, true); err != nil {
+		t.Fatalf("PrintSnippet: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, path) {
+		t.Errorf("output missing file path header:\n%s", out)
+	}
+	if !strings.Contains(out, "<?php echo 'hi'; ?>") {
+		t.Errorf("output missing file content:\n%s", out)
+	}
+	if !strings.Contains(out, "Reference snippet") {
+		t.Errorf("output missing reference-snippet notice:\n%s", out)
+	}
+}
+
+func TestPrintSnippet_Piped(t *testing.T) {
+	body := "<?php echo 'hi'; ?>"
+	path := writeSnippet(t, body)
+	var buf bytes.Buffer
+	if err := PrintSnippet(&buf, path, false); err != nil {
+		t.Fatalf("PrintSnippet: %v", err)
+	}
+	if buf.String() != body {
+		t.Errorf("piped output = %q, want raw content %q", buf.String(), body)
+	}
+}
+
+func TestRunSnippet_Path(t *testing.T) {
+	path := writeSnippet(t, "content")
+	e := catalog.Entry{Key: "wordpress-utilities/snippets/footer"}
+	var out, errOut bytes.Buffer
+
+	code := RunSnippet(&out, &errOut, e, path, []string{"--path"}, false)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if strings.TrimSpace(out.String()) != path {
+		t.Errorf("output = %q, want %q", out.String(), path)
+	}
+}
+
+func TestRunSnippet_DefaultPrintsContent(t *testing.T) {
+	body := "raw content"
+	path := writeSnippet(t, body)
+	e := catalog.Entry{Key: "wordpress-utilities/snippets/footer"}
+	var out, errOut bytes.Buffer
+
+	code := RunSnippet(&out, &errOut, e, path, nil, false)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if out.String() != body {
+		t.Errorf("output = %q, want %q", out.String(), body)
+	}
+}
+
+func TestClipboardCmd_FallbackChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		available map[string]bool
+		want      []string
+	}{
+		{"pbcopy preferred", map[string]bool{"pbcopy": true, "xclip": true}, []string{"pbcopy"}},
+		{"xclip when no pbcopy", map[string]bool{"xclip": true}, []string{"xclip", "-selection", "clipboard"}},
+		{"xsel when no pbcopy or xclip", map[string]bool{"xsel": true}, []string{"xsel", "--clipboard", "--input"}},
+		{"clip.exe last resort", map[string]bool{"clip.exe": true}, []string{"clip.exe"}},
+		{"none available", map[string]bool{}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookPath := func(name string) (string, error) {
+				if tt.available[name] {
+					return "/usr/bin/" + name, nil
+				}
+				return "", errors.New("not found")
+			}
+			got := clipboardCmd(lookPath)
+			if !equalSlices(got, tt.want) {
+				t.Errorf("clipboardCmd = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunSnippet_CopyNoClipboardTool(t *testing.T) {
+	// clipboardCmd relies on exec.LookPath directly inside CopySnippet, so on
+	// a machine with none of the four tools on PATH this exercises the real
+	// fallback message; skip if the test host happens to have one.
+	if clipboardCmd(osexec.LookPath) != nil {
+		t.Skip("a clipboard tool is present on this machine; can't exercise the no-tool path")
+	}
+
+	path := writeSnippet(t, "content")
+	e := catalog.Entry{Key: "wordpress-utilities/snippets/footer"}
+	var out, errOut bytes.Buffer
+
+	code := RunSnippet(&out, &errOut, e, path, []string{"--copy"}, false)
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "--path instead") {
+		t.Errorf("stderr missing --path fallback guidance:\n%s", errOut.String())
+	}
+}
+
+func TestFormatSnippetHelp_Annotated(t *testing.T) {
+	e := lookupSnippetEntry(t)
+	help := FormatSnippetHelp(e)
+
+	for _, want := range []string{
+		e.Description,
+		"reference snippet meant to be copied",
+		"Usage: wp-ops wordpress-utilities/snippets/post-expiry-noindex            Print the snippet",
+		"--copy      Copy it to the clipboard",
+		"--path      Print only the file path",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("FormatSnippetHelp output missing %q:\n%s", want, help)
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/go/internal/exec/snippet_test.go
+++ b/go/internal/exec/snippet_test.go
@@ -138,7 +138,8 @@ func TestRunSnippet_CopyNoClipboardTool(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
-	if !strings.Contains(errOut.String(), "--path instead") {
+	if !strings.Contains(errOut.String(), "No clipboard tool found") ||
+		!strings.Contains(errOut.String(), "wp-ops wordpress-utilities/snippets/footer --path") {
 		t.Errorf("stderr missing --path fallback guidance:\n%s", errOut.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `go/internal/exec/snippet.go`, porting bash's `execute_snippet()` (`wp-ops:1232`): prints, clipboard-copies (`--copy`), or path-resolves (`--path`) `wordpress-utilities/**` reference snippets instead of executing them.
- `--copy` uses the same `pbcopy` → `xclip`/`xsel` → `clip.exe` fallback chain as `find_clipboard_cmd()` (`wp-ops:1220`), failing with the same "no clipboard tool found, try --path instead" message if none are on `PATH`.
- Default print is TTY-aware like bash (filename header + trailing notice on a terminal, raw content only when piped/redirected), minus bash's ANSI dimming to match the rest of the Go CLI's plain-text convention.
- `--help` renders from the manifest plus the fixed "reference snippet, not run directly" explanation bash prints.
- Wires the new executor into `go/cmd/dispatch.go`'s `wordpress-utilities/*` branch, replacing the M4 stub message.
- **Fix**: while wiring this up, found that the `ext == ".php"` check ran before the `wordpress-utilities/` prefix check — a regression from M4 task 1 splitting what had been one combined condition. 3 of the 5 non-doc files under `wordpress-utilities/` are `.php`, so they were silently executed via WP-CLI instead of printed/copied. Reordered so the category prefix wins.
- Checks off task 2 in `docs/m4-go-cli-completion.md` with implementation notes.
- Bumps CHANGELOG.md to 3.17.0.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New unit tests: `--path`/`--copy`/default branches, clipboard-tool fallback chain (mocked `exec.LookPath`), TTY vs. piped output shape
- [x] Manual: `--help`/`--path`/default/`--copy` exercised end to end against a real annotated `.php` snippet (`wordpress-utilities/snippets/post-expiry-noindex`)
- [x] Manual: non-`.php` snippet pair (`.css`/`.js` in `wordpress-utilities/age-verification/`) and a plain-file `.php` snippet (`age-verification/footer`) confirm the ordering fix