### PR TITLE
Implement M4 task 4: shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.0] - 2026-08-01
+
+### Added
+
+- **go** - M4 task 4 (shell completions, per `docs/m4-go-cli-completion.md`): the Go CLI now generates real bash/zsh/fish/PowerShell completion scripts via Cobra's built-in `completion` command — free once the command tree is fully populated, since `rootCmd` doesn't opt out of it. Added `categoryBasenameCompletions()` (`go/cmd/dispatch.go`) as each category command's `ValidArgsFunction`, porting bash's `print_completion()` (`wp-ops:2098`) two-token grammar: `wp-ops <category> <TAB>` offers every basename in that category (deduplicated), and anything past the basename returns no completions — the rest of argv belongs to the underlying script, not to wp-ops. The dynamically-registered per-entry (full-key, hidden) leaf commands from M3 task 7 complete without error despite `DisableFlagParsing: true`: positional args fall back to file completion (a reasonable default, since most scripts take paths) and `--<TAB>` correctly suppresses bogus flag suggestions instead of leaking them.
+- **go** - `wp-ops doctor` now reports whether `wp-ops completion bash`/`zsh` will actually work: zsh always does (its `compinit` ships with the shell, no extra package), but bash needs bash ≥4 — macOS ships bash 3.2, frozen since 2007 over the GPLv3 relicense, which can't run Cobra's generated script even with `bash-completion` installed — and the separate `bash-completion` package itself. Both are checked and reported with install guidance (`brew install bash`, `brew install bash-completion`) rather than failing silently on a clean Mac.
+- **docs** - Root `README.md`'s "wp-ops CLI" section gets a pointer note: a Go rewrite is in progress (`go/`), not yet distributed, so the documented bash CLI usage stays authoritative for now — links to `docs/cli-ux-plan.md` for the plan and milestone status.
+
 ## [3.18.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Tools, scripts, and guides for modern WordPress development & devops—optimized
 
 A single entry point for everything in this repo. Auto-discovers commands across every category and groups them by subdirectory.
 
+> A Go rewrite of this CLI is in progress (`go/`) — same manifest-driven commands, a real Cobra binary with generated shell completions, eventually a `brew install`. It isn't distributed yet, so the bash CLI below stays the way to install and run wp-ops for now. See [docs/cli-ux-plan.md](docs/cli-ux-plan.md) for the plan and current milestone status.
+
 ```bash
 ./install.sh                 # add wp-ops to your PATH (one-time)
 wp-ops                       # interactive picker (fuzzy, if fzf is installed)

--- a/docs/m4-go-cli-completion.md
+++ b/docs/m4-go-cli-completion.md
@@ -1,10 +1,12 @@
 # M4: Go CLI Completion — Implementation Tracker
 
 > **Status (2026-08-01):** In progress. Task 1 (`internal/exec/wpcli.go`),
-> task 2 (`internal/exec/snippet.go`), and task 3 (`internal/ui` Bubble Tea
-> picker) are done. Scoped out of M3 (`docs/m3-go-skeleton.md`, "Explicitly
-> out of scope for M3") now that M3 is merged to `main` (PR #140). Parent
-> plan: `docs/cli-ux-plan.md` (Phase C, milestone M4, target **4.0.0**).
+> task 2 (`internal/exec/snippet.go`), task 3 (`internal/ui` Bubble Tea
+> picker), and task 4 (shell completions) are done. Scoped out of M3
+> (`docs/m3-go-skeleton.md`, "Explicitly out of scope for M3") now that M3
+> is merged to `main` (PR #140). Parent plan: `docs/cli-ux-plan.md` (Phase
+> C, milestone M4, target **4.0.0**). Remaining: task 5 (`docs` search) and
+> task 6 (goreleaser + Homebrew tap).
 
 ## Goal
 
@@ -188,19 +190,40 @@ decision #3. **Done.**
   matches" state
 
 ### 4. Shell completions
-Replaces the hand-written `print_completion()` (`wp-ops:2098`, bash-only).
-- [ ] Wire Cobra's built-in `completion` command (bash/zsh/fish/PowerShell)
-  — largely free once the command tree is fully populated (it already is,
-  post-M3), but verify the dynamically-registered per-entry commands
-  (`DisableFlagParsing: true`, M3 task 7) complete correctly; Cobra's
-  default completion may need `ValidArgsFunction` hints since flag
-  parsing is disabled
-- [ ] Category → basename two-token completion (`wp-ops <category>
+Replaces the hand-written `print_completion()` (`wp-ops:2098`, bash-only). **Done.**
+- [x] Wire Cobra's built-in `completion` command (bash/zsh/fish/PowerShell)
+  — free once the command tree is fully populated (it already was, post-M3):
+  Cobra registers it automatically since `rootCmd` doesn't set
+  `CompletionOptions.DisableDefaultCmd`. Verified the dynamically-registered
+  per-entry (full-key, hidden) leaf commands complete without error despite
+  `DisableFlagParsing: true` — positional args fall back to
+  `ShellCompDirectiveDefault` (file completion, a reasonable default for
+  scripts that mostly take paths), and `--<TAB>` correctly returns
+  `ShellCompDirectiveNoFileComp` rather than leaking bogus flag suggestions.
+  No `ValidArgsFunction` needed for these; the open decision's concern
+  didn't end up applying in practice.
+- [x] Category → basename two-token completion (`wp-ops <category>
   <TAB>` → basenames in that category), matching bash's actual grammar
   ported in M3 task 7, not the flatter completion bash's
-  `print_completion()` implements today
-- [ ] Manual pass: source the generated completion script in bash and zsh,
-  confirm category and basename completion both work
+  `print_completion()` implements today — `categoryBasenameCompletions()`
+  in `dispatch.go`, wired as each category command's `ValidArgsFunction`:
+  returns every basename in the category (deduplicated) when completing the
+  first arg, `ShellCompDirectiveNoFileComp` with no candidates for anything
+  past that — matching bash's `cword >= 3` → `COMPREPLY=()`, since
+  everything after the basename belongs to the underlying script's own
+  argv, not to wp-ops. Unit-tested (`dispatch_test.go`).
+- [x] Manual pass: source the generated completion script in bash and zsh,
+  confirm category and basename completion both work — zsh verified with a
+  real `compinit` + sourced completion script driven via `expect` (TAB
+  against `wp-ops scripts <TAB>` and `wp-ops scripts db<TAB>`, confirming
+  both the full category list and prefix-filtered single-match
+  autocomplete); bash needed two things installed first that a stock macOS
+  shell lacks — Homebrew `bash` (macOS ships bash 3.2, frozen since 2007
+  over the GPLv3 relicense, which Cobra's generated script can't run even
+  with `bash-completion` installed) and the `bash-completion` package
+  itself — then verified the same way. `wp-ops doctor` now reports both
+  (see below) so this isn't a silent trap for the next person testing on a
+  clean Mac.
 
 ### 5. `docs` search command
 Deferred from M3 per open decision #2 above; port of `docs` search
@@ -244,7 +267,7 @@ milestone table:
 - [ ] Interactive picker launches on a bare `wp-ops` invocation with no
   `fzf` binary required, with guided per-argument prompting matching M2's
   bash UX
-- [ ] Generated completions work in at least bash and zsh
+- [x] Generated completions work in at least bash and zsh
 - [ ] `brew install imagewize/tap/wp-ops` (or the chosen distribution path
   per open decision #1) produces a working, self-contained binary
 - [ ] `docs` search, if in scope per open decision #2, matches bash output

--- a/go/cmd/dispatch.go
+++ b/go/cmd/dispatch.go
@@ -55,8 +55,36 @@ func registerCatalogCommands(c *catalog.Catalog) {
 				runCategory(mustCatalog(), cat, args)
 				return nil
 			},
+			ValidArgsFunction: categoryBasenameCompletions(cat),
 		}
 		rootCmd.AddCommand(catCmd)
+	}
+}
+
+// categoryBasenameCompletions backs `wp-ops <category> <TAB>` completion:
+// bash's actual completion grammar (print_completion, wp-ops:2098) is
+// exactly two tokens — category, then a basename within it — and stops
+// there (cword >= 3 gets no completions, since anything past the basename
+// belongs to the underlying script's own argv). ValidArgsFunction is called
+// once per positional slot regardless of DisableFlagParsing, so this only
+// needs to guard on "am I completing the first arg after the category".
+func categoryBasenameCompletions(cat string) func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		entries := mustCatalog().CommandsIn(cat)
+		seen := make(map[string]bool, len(entries))
+		basenames := make([]string, 0, len(entries))
+		for _, e := range entries {
+			b := filepath.Base(e.Key)
+			if seen[b] {
+				continue
+			}
+			seen[b] = true
+			basenames = append(basenames, b)
+		}
+		return basenames, cobra.ShellCompDirectiveNoFileComp
 	}
 }
 

--- a/go/cmd/dispatch_test.go
+++ b/go/cmd/dispatch_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+// TestCategoryBasenameCompletions ports the manual pass in
+// docs/m4-go-cli-completion.md task 4: `wp-ops <category> <TAB>` offers
+// every basename in that category, deduplicated, and stops completing once
+// a basename is already present (the rest of argv belongs to the
+// underlying script, not to wp-ops).
+func TestCategoryBasenameCompletions(t *testing.T) {
+	fn := categoryBasenameCompletions("scripts")
+
+	got, directive := fn(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+	}
+	if len(got) == 0 {
+		t.Fatal("want at least one basename completion for the scripts category")
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, b := range got {
+		if seen[b] {
+			t.Errorf("duplicate basename completion %q", b)
+		}
+		seen[b] = true
+	}
+
+	// db-backup is scripts/backup/db-backup.sh — a stable, unlikely-to-move
+	// entry to pin against, same choice serverside_test.go makes elsewhere.
+	if !seen["db-backup"] {
+		t.Errorf("want db-backup among scripts completions, got %v", got)
+	}
+
+	got2, directive2 := fn(nil, []string{"db-backup"}, "")
+	if directive2 != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive with a basename already chosen = %v, want ShellCompDirectiveNoFileComp", directive2)
+	}
+	if len(got2) != 0 {
+		t.Errorf("want no completions once a basename is already chosen, got %v", got2)
+	}
+}
+
+// TestCategoryBasenameCompletionsScoped checks that a category's
+// completions only ever contain basenames that actually live in that
+// category — the point of the two-token grammar
+// (docs/m4-go-cli-completion.md task 4).
+func TestCategoryBasenameCompletionsScoped(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("loading catalog: %v", err)
+	}
+
+	inScripts := make(map[string]bool)
+	for _, e := range c.CommandsIn("scripts") {
+		inScripts[filepath.Base(e.Key)] = true
+	}
+
+	fn := categoryBasenameCompletions("scripts")
+	got, _ := fn(nil, nil, "")
+	for _, b := range got {
+		if !inScripts[b] {
+			t.Errorf("scripts completions included %q, which isn't a scripts basename", b)
+		}
+	}
+}

--- a/go/cmd/doctor.go
+++ b/go/cmd/doctor.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	osexec "os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -81,6 +83,10 @@ func runDoctor() int {
 		fmt.Println()
 	}
 
+	fmt.Println("Shell completion (wp-ops completion --help for setup)")
+	checkShellCompletion()
+	fmt.Println()
+
 	fmt.Println("Server-side (not checked here — these run on the server)")
 	fmt.Println("  ·  gawk               time filtering in the Nginx log monitors")
 	fmt.Println("     Ubuntu ships mawk by default, so gawk may be absent:")
@@ -118,6 +124,73 @@ func checkBinary(bin, purpose string, required bool) bool {
 	}
 	fmt.Printf("  %s %-18s %s\n", mark, bin, purpose)
 	return ok
+}
+
+// bashCompletionPaths are the well-known install locations for the
+// bash-completion package across common package managers. Presence of any
+// one of them is treated as "installed" — good enough for doctor's
+// advisory purpose, not a hard guarantee it's sourced in every shell.
+var bashCompletionPaths = []string{
+	"/opt/homebrew/etc/profile.d/bash_completion.sh", // Homebrew, Apple Silicon
+	"/usr/local/etc/profile.d/bash_completion.sh",    // Homebrew, Intel
+	"/etc/profile.d/bash_completion.sh",
+	"/usr/share/bash-completion/bash_completion", // Debian/Ubuntu, Fedora
+	"/etc/bash_completion",                       // older distros
+}
+
+// checkShellCompletion reports whether `wp-ops completion <shell>` is
+// likely to work end to end. zsh's compinit ships with the shell itself, so
+// it always works once `source <(wp-ops completion zsh)` runs. bash needs
+// two things Cobra's generated script assumes are present: bash ≥4 (macOS
+// ships 3.2, frozen since 2007 over the GPLv3 relicense — Homebrew's `bash`
+// formula installs a current one) and the separate bash-completion package
+// (`brew install bash-completion` for that bash 3.2 case, or
+// `bash-completion@2` alongside a bash ≥4).
+func checkShellCompletion() {
+	fmt.Println("  ✓ zsh                works out of the box (compinit) — no extra package needed")
+
+	if _, err := osexec.LookPath("bash"); err != nil {
+		fmt.Println("  ! bash               not found on PATH")
+		return
+	}
+
+	if major, ok := bashMajorVersion(); ok && major < 4 {
+		fmt.Printf("  ! bash %-14s completions need bash ≥4 — install a current one: brew install bash\n", fmt.Sprintf("%d.x", major))
+	} else {
+		fmt.Println("  ✓ bash               version supports completions")
+	}
+
+	found := false
+	for _, p := range bashCompletionPaths {
+		if _, err := os.Stat(p); err == nil {
+			found = true
+			break
+		}
+	}
+	if found {
+		fmt.Println("  ✓ bash-completion    found")
+	} else {
+		fmt.Println("  ! bash-completion    not found — install it: brew install bash-completion (or your distro's bash-completion package)")
+	}
+}
+
+// bashMajorVersion shells out to whatever `bash` is on PATH and parses
+// $BASH_VERSION's leading integer (e.g. "5.3.15(1)-release" -> 5).
+func bashMajorVersion() (int, bool) {
+	out, err := osexec.Command("bash", "-c", "echo -n \"$BASH_VERSION\"").Output()
+	if err != nil {
+		return 0, false
+	}
+	version := strings.TrimSpace(string(out))
+	major, _, ok := strings.Cut(version, ".")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(major)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func checkEnvDir(varName, purpose string, detector func(startDir, stopAt string) (string, bool)) {


### PR DESCRIPTION
## Summary
- Wires Cobra's built-in `completion` command and adds `categoryBasenameCompletions()` as each category command's `ValidArgsFunction`, porting bash's `print_completion()` two-token grammar (`wp-ops <category> <TAB>` → basenames in that category, nothing past that).
- `wp-ops doctor` now reports whether bash completion will actually work — bash needs ≥4 plus the separate `bash-completion` package (macOS ships bash 3.2, which can't run Cobra's generated script even with the package installed); zsh works out of the box via `compinit`.
- Points `README.md`'s wp-ops CLI section at the in-progress Go rewrite without touching the still-accurate bash instructions.
- Updates `docs/m4-go-cli-completion.md` (task 4 done) and `CHANGELOG.md` (3.19.0).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] New unit tests (`go/cmd/dispatch_test.go`) cover category-scoped completion and the stop-after-basename behavior
- [x] Manually verified real TAB-completion in both zsh and bash via `expect`-driven sessions against the built binary (installed `bash` and `bash-completion` via Homebrew to test bash's path, since neither was present)
- [x] `wp-ops --version` still resolves from `CHANGELOG.md` correctly (3.19.0)