### PR TITLE
Phase F: category-first command discovery (options 1-3)

### DIFF
--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -17,8 +17,12 @@
 > running `wp-ops manifest lint` on push/PR to `main`) landed right after —
 > M2 is now fully done bar the 2 out-of-scope `mcp-server/*` commands. See
 > "Phase A implementation" below. M3 (Go CLI skeleton) is also done, merged
-> to `main` in PR #140 — see `docs/m3-go-skeleton.md`. M4 is next; see
-> `docs/m4-go-cli-completion.md`.
+> to `main` in PR #140 — see `docs/m3-go-skeleton.md`. M4 is in progress —
+> tasks 3 (Bubble Tea picker) and 4 (shell completions) are merged (PRs
+> #144, #145); tasks 1–2 (remaining executors) were also done earlier. Task
+> 5 (`docs` search) and 6 (goreleaser + tap) remain — see
+> `docs/m4-go-cli-completion.md`. Phase F (below) is a new, unscheduled
+> proposal raised against M4's shipped picker/list surfaces.
 
 A plan to take the `wp-ops` CLI from "auto-discovered shell scripts" to a
 declarative, self-documenting tool with the ergonomics of
@@ -391,6 +395,126 @@ purely additive distribution.
 
 ---
 
+# Phase F — Command discovery: default views and picker density
+
+**Status (2026-08-01):** Options 1, 2, and 3 done, on
+`feature/cli-manifest-phase-f-discovery`. Option 4 not started.
+Raised against the M4 Go CLI (`docs/m4-go-cli-completion.md`), after M4
+tasks 3 (Bubble Tea picker) and 4 (shell completions) shipped — the
+manifest work in Phase A gave every command good metadata, but the three
+surfaces that render the *list* of commands still show too much at once, or
+too little structure, to act as a landing page.
+
+## The problem
+
+Three views, three different symptoms:
+
+1. **`wp-ops list` / piped bare `wp-ops`** (`go/cmd/list.go:34`,
+   `printCategorizedList`) — flattens all ~66 commands under category
+   headers, one full-sentence description per line. Correctly organized,
+   just long: it's a wall of text that requires scrolling, not a landing
+   page.
+2. **The Bubble Tea picker on bare `wp-ops`** (`go/internal/ui/model.go`) —
+   the opposite problem. `New()` (`model.go:80-89`) loads `c.Entries` as one
+   flat, alphabetically-sorted list with no category grouping at all,
+   filterable by typing. Compact, but directionless: nothing distinguishes
+   a backup command from an image-conversion command except reading each
+   line.
+3. **`trellis` with no arguments** — short (~22 lines) because it's a
+   **two-level** structure: top-level verbs, some of which (`db`, `server`,
+   `key`, `vm`) fan out to subcommands only shown after typing
+   `trellis db`.
+
+## Key finding: the two-level structure already exists
+
+`wp-ops <category>` (e.g. `wp-ops trellis`) is already a real command —
+`registerCatalogCommands` (`go/cmd/dispatch.go:47-61`) registers one Cobra
+command per active category, whose bare-args `RunE` calls `runCategory` →
+`printCategoryCommands` (`list.go:49`), printing just that category's
+commands. Nothing needs to be built to get trellis-style drill-down; it's
+wired but not the *default* landing view — `wp-ops list` and bare `wp-ops`
+both still call `printCategorizedList`, which shows everything at once
+instead of pointing at the category commands that already exist.
+
+## Options
+
+| # | Change | Effort | Effect |
+|---|---|---|---|
+| 1 | Rewrite `printCategorizedList` to print **category names + counts + one blurb only** (~8 lines), pointing at `wp-ops <category>` for the existing full per-category view | Small — one function, no new plumbing | Matches `trellis`'s brevity directly |
+| 2 | Picker: insert **dim, non-selectable category header rows** into the browse list — group `filterEntries`'s output by category before rendering (`model.go`'s `viewBrowse`, `filterEntries`) | Small–medium — a grouping pass plus header rows in `viewBrowse` | Same item count, but scannable instead of a flat name wall |
+| 3 | Picker: add a **category-select stage before the command list** (browse categories → then that category's commands), mirroring `trellis`'s two-level nav | Medium — a new `stage` in the picker's state machine (`model.go:17-24`) | Biggest ergonomic win, closest match to `trellis`, but adds a keystroke to drill into a category |
+| 4 | Split the oversized `scripts` category (35 commands, no subgrouping — the largest of the 6 active categories) into subcategories matching its existing directories (`backup`, `monitoring`, `git`, `images`, `release`, `sync`, `woocommerce`, `misc`, `patterns`) | Larger — touches `@category` manifest values across ~25 files plus catalog grouping logic | Fixes the one category still too big even after #1 |
+
+**Done (1):** `printCategorizedList` (`list.go`) now prints an 8-line
+category summary (name, count, one blurb from a new `catalog.CategoryBlurbs`
+map); the original full per-command listing moved to `printAllCommands`,
+exposed as `wp-ops list --all`. Bare `wp-ops` (piped) and `wp-ops --help`
+both pick up the shorter view for free since they already called
+`printCategorizedList` (`root.go:71,83`).
+
+**Done (2):** `filterEntries` (`model.go`) now sorts by category rank
+(`catalog.Categories`' curated order, matching option 1's summary order)
+then key, instead of plain alphabetical-by-key — categories were already
+contiguous as a side effect of key-prefix sorting, but not in curated
+order. `viewBrowse` tracks the previous row's category while iterating the
+visible window and renders a `categoryHeaderStyle`-styled header line
+whenever it changes, including at the top of the window after a scroll (so
+a mid-scroll view still tells you what category you're looking at). Headers
+aren't part of `m.filtered`, so cursor movement and selection indices are
+unaffected — only rendering changed.
+
+**Done (3):** added `stageCategory` as the picker's new outermost stage
+(`model.go`'s `stage` enum), shown first on launch: "All categories" (cursor
+default, scoped to nothing — the full catalog, same reach as before this
+option) followed by each active category with its count and
+`catalog.CategoryBlurbs` text, reusing the same list `cmd`'s compact `list`
+view (option 1) shows. Selecting a category sets `browseCategory` and
+re-filters into `stageBrowse` scoped to just that category (`applyFilter` /
+new `filterByCategory`); the browse header grows a breadcrumb
+(`wp-ops > Trellis > `) and, once scoped, the option-2 per-row category
+headers stop repeating themselves since the breadcrumb already says which
+category. Esc now means "go up one level" everywhere (stageBrowse → back to
+stageCategory; stageFields/stageFreeText → back to stageBrowse, unchanged
+from before); Ctrl+C is the only "quit entirely" key past stageCategory.
+`catalog.CategoryBlurbs` moved from `cmd/list.go` into `internal/catalog`
+so both `cmd` and `internal/ui` read the same map without either package
+importing the other.
+
+**Recommendation:** 1–3 done; 4 (splitting the oversized `scripts`
+category) is a bigger, separable change worth sequencing on its own.
+
+## Picker visual density vs. upstream Bubble Tea examples
+
+Bubble Tea's own README demo (a `./demo` todo-list picker: `[ ] Plant
+carrots`, `[x] See friends`, four items, generous blank lines between
+sections, no borders, a single faint hint line) reads as calmer than
+`wp-ops`'s picker, which wraps both the list and the preview in
+`lipgloss.RoundedBorder()` panes (`model.go:43`) side by side inside an
+alt-screen, with rows packed tightly.
+
+Worth naming explicitly: **this is not an apples-to-apples comparison.**
+The README demo is a 4-item toy built to be legible in a screenshot; the
+`wp-ops` picker is rendering up to 66 filterable rows *and* a live
+multi-section preview pane (usage/args/examples — `wpexec.PreviewBody`),
+which is closer to real dense Bubble Tea tools (`gh dash`, `glow`) than to
+the README's todo list. A literal style match isn't the goal.
+
+What *is* borrowable regardless of density:
+
+- More vertical whitespace around the header/footer (the demo never
+  crowds text against the pane edge).
+- Lighter chrome on the list pane specifically — a single outer border
+  around the whole app, rather than two nested bordered boxes
+  (`borderedPane` applied twice in `viewBrowse`), reads as less boxed-in.
+- The footer hint style (`j/k, up/down: select • enter: choose • q, esc:
+  quit`) is already close to what `wp-ops` does (`viewBrowse`'s footer
+  string) — no change needed there.
+
+This is a secondary polish item, best done alongside option #2 above (both
+touch `viewBrowse`), not a prerequisite for it.
+
+---
+
 # Milestones
 
 | # | Scope | Version | Status |
@@ -398,9 +522,10 @@ purely additive distribution.
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
 | M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **Done** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); guided prompts shipped in 3.13.0; CI lint wiring landed after. Only `mcp-server/*` (2, out of scope) remains unannotated |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | **Done**, merged to `main` (PR #140) — see `docs/m3-go-skeleton.md` for the full breakdown; all acceptance criteria met, parity script passing 8/8 |
-| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | Not started — see `docs/m4-go-cli-completion.md` |
+| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | **In progress** — tasks 1–4 done (PHP/snippet executors, picker PR #144, completions PR #145); tasks 5 (`docs` search) and 6 (goreleaser + tap) remain. See `docs/m4-go-cli-completion.md` |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |
 | M6 | `trellis-wpops` symlink | 4.1.0 | Not started |
+| F | Command discovery: category-first default views, picker grouping | unscheduled | **In progress** — options 1–3 done (`feature/cli-manifest-phase-f-discovery`), option 4 not started. See Phase F below |
 
 ## Immediate fixes (do now, independent of the plan)
 

--- a/go/cmd/list.go
+++ b/go/cmd/list.go
@@ -12,27 +12,59 @@ import (
 	"github.com/imagewize/wp-ops/go/internal/catalog"
 )
 
+var allFlag bool
+
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List every command by category",
 	RunE: func(cc *cobra.Command, args []string) error {
 		c := mustCatalog()
-		if jsonFlag {
+		switch {
+		case jsonFlag:
 			printJSON(c)
-			return nil
+		case allFlag:
+			printAllCommands(c)
+		default:
+			printCategorizedList(c)
 		}
-		printCategorizedList(c)
 		return nil
 	},
 }
 
 func init() {
 	listCmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
+	listCmd.Flags().BoolVar(&allFlag, "all", false, "List every command in every category, with descriptions")
 	rootCmd.AddCommand(listCmd)
 }
 
+// printCategorizedList renders the compact, category-only default view —
+// what bare `wp-ops` and `wp-ops list` show. Full per-command output moved
+// to printAllCommands (`--all`); a single category's commands are already
+// available via `wp-ops <category>` (dispatch.go's per-category Cobra
+// commands), so this view doesn't need to duplicate that.
 func printCategorizedList(c *catalog.Catalog) {
 	fmt.Println("wp-ops — WordPress Operations Tools")
+	fmt.Println()
+
+	for _, category := range c.Categories() {
+		entries := c.CommandsIn(category)
+		fmt.Printf("  %-22s (%2d)  %s\n", catalog.CategoryDisplayNames[category], len(entries), catalog.CategoryBlurbs[category])
+	}
+
+	fmt.Println()
+	fmt.Println("Run 'wp-ops <category>' to see a category's commands (e.g. 'wp-ops trellis')")
+	fmt.Println("Run 'wp-ops list --all' to see every command with its description")
+	fmt.Println("Run 'wp-ops search <term>' to find a command")
+	fmt.Println("Run 'wp-ops doctor' to check dependencies and environment")
+	fmt.Println("Run 'wp-ops --json' for machine-readable command list")
+}
+
+// printAllCommands is the original full listing: every command in every
+// category, one line each with its description. Kept behind `list --all`
+// since it's still the only single-command way to see the whole catalog at
+// once (e.g. for grepping).
+func printAllCommands(c *catalog.Catalog) {
+	fmt.Println("wp-ops — WordPress Operations Tools (full list)")
 	fmt.Println()
 
 	for _, category := range c.Categories() {
@@ -41,6 +73,7 @@ func printCategorizedList(c *catalog.Catalog) {
 		fmt.Println()
 	}
 
+	fmt.Println("Run 'wp-ops list' for a compact category summary")
 	fmt.Println("Run 'wp-ops search <term>' to find a command")
 	fmt.Println("Run 'wp-ops doctor' to check dependencies and environment")
 	fmt.Println("Run 'wp-ops --json' for machine-readable command list")

--- a/go/internal/catalog/catalog.go
+++ b/go/internal/catalog/catalog.go
@@ -182,3 +182,17 @@ var CategoryDisplayNames = map[string]string{
 	"troubleshooting":     "Troubleshooting",
 	"mcp-server":          "MCP Server",
 }
+
+// CategoryBlurbs is a one-line summary per category — shown alongside its
+// command count in cmd's compact `list` view and ui's picker category-select
+// stage. Phase F, docs/cli-ux-plan.md. Lives here (not in cmd) so both `cmd`
+// and `internal/ui` can use the same text without either importing the
+// other.
+var CategoryBlurbs = map[string]string{
+	"scripts":             "Backup, monitoring, release, git, image, and sync utilities",
+	"trellis":             "Trellis provisioning, backups, and Ansible playbook commands",
+	"wp-cli":              "WordPress diagnostics, audits, and WP-CLI-driven tools",
+	"bedrock":             "Bedrock/Composer pattern validation",
+	"wordpress-utilities": "Reusable snippets copied into WordPress projects",
+	"mcp-server":          "MCP server dev/start commands",
+}

--- a/go/internal/ui/model.go
+++ b/go/internal/ui/model.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -17,7 +18,8 @@ import (
 type stage int
 
 const (
-	stageBrowse stage = iota
+	stageCategory stage = iota
+	stageBrowse
 	stageFields
 	stageFreeText
 	stageDone
@@ -25,31 +27,66 @@ const (
 
 // Result is what RunPicker returns: either a command to run with its
 // assembled argv, or Quit if the user backed out without selecting
-// anything (Esc/Ctrl+C from the browse list, port of fzf_menu returning
-// non-zero on Esc, wp-ops:1982).
+// anything (Ctrl+C from any stage, or Esc from the outermost
+// category-select stage — port of fzf_menu returning non-zero on Esc,
+// wp-ops:1982).
 type Result struct {
 	Key  string
 	Args []string
 	Quit bool
 }
 
+// categoryOption is one row in the category-select stage (stageCategory).
+// key is "" for the "All categories" pseudo-entry, which scopes browsing to
+// nothing (i.e. the full catalog) — the one-Enter-keystroke equivalent of
+// the picker's pre-Phase-F behavior, kept as the default cursor position so
+// a user who wants to search across everything isn't worse off than before.
+type categoryOption struct {
+	key   string
+	label string
+	count int
+	blurb string
+}
+
+// buildCategoryOptions lists "All categories" followed by every active
+// category in catalog.Categories' curated order — the same set and order
+// cmd's compact `list` view uses (Phase F, docs/cli-ux-plan.md, option 3).
+func buildCategoryOptions(c *catalog.Catalog) []categoryOption {
+	opts := []categoryOption{{
+		label: "All categories",
+		count: len(c.Entries),
+		blurb: "Search or browse the whole catalog",
+	}}
+	for _, cat := range c.Categories() {
+		opts = append(opts, categoryOption{
+			key:   cat,
+			label: catalog.CategoryDisplayNames[cat],
+			count: len(c.CommandsIn(cat)),
+			blurb: catalog.CategoryBlurbs[cat],
+		})
+	}
+	return opts
+}
+
 var (
-	headerStyle   = lipgloss.NewStyle().Bold(true)
-	dimStyle      = lipgloss.NewStyle().Faint(true)
-	cursorStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
-	serverTag     = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	noteStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	borderedPane  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
-	footerStyle   = dimStyle
-	minListWidth  = 34
-	minPaneHeight = 10
+	headerStyle         = lipgloss.NewStyle().Bold(true)
+	dimStyle            = lipgloss.NewStyle().Faint(true)
+	cursorStyle         = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
+	serverTag           = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	errorStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	noteStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	borderedPane        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+	footerStyle         = dimStyle
+	categoryHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("245"))
+	minListWidth        = 34
+	minPaneHeight       = 10
 )
 
 // Model is the Bubble Tea model backing the interactive picker. It replaces
 // both fzf_menu() and interactive_command_menu() (open decision #3 in
-// docs/m4-go-cli-completion.md): a single filterable, scrollable list with
-// a live preview pane, followed by guided per-field prompting on selection.
+// docs/m4-go-cli-completion.md): a category-select stage (Phase F, option 3)
+// leading into a filterable, scrollable list with a live preview pane,
+// followed by guided per-field prompting on selection.
 type Model struct {
 	all      []catalog.Entry
 	filtered []catalog.Entry
@@ -57,6 +94,13 @@ type Model struct {
 	listTop  int // first visible row, for scrolling a long filtered list
 
 	filterQuery []rune
+
+	categories []categoryOption
+	catCursor  int
+	// browseCategory is the category key stageBrowse is scoped to ("" means
+	// unscoped — the "All categories" choice), set when the user selects a
+	// row in stageCategory.
+	browseCategory string
 
 	preview viewport.Model
 
@@ -74,14 +118,19 @@ type Model struct {
 	result        Result
 }
 
-// New builds the initial model from a catalog, sorted the same way
-// catalog.Search would return an unfiltered search (by key) — see
-// filterEntries.
+// New builds the initial model from a catalog. Entries are grouped by
+// category (in catalog.Categories' curated order, same order list.go's
+// summary view uses) and alphabetically by key within a category — see
+// filterEntries. Phase F, docs/cli-ux-plan.md: grouping (rather than a flat
+// alphabetical-by-key list) is what lets viewBrowse print a category header
+// above each run of entries instead of an undifferentiated name wall.
 func New(c *catalog.Catalog) Model {
 	m := Model{
-		all:     c.Entries,
-		preview: viewport.New(40, minPaneHeight),
-		input:   textinput.New(),
+		all:        c.Entries,
+		categories: buildCategoryOptions(c),
+		stage:      stageCategory,
+		preview:    viewport.New(40, minPaneHeight),
+		input:      textinput.New(),
 	}
 	m.input.Prompt = "> "
 	m.filtered = filterEntries(m.all, "")
@@ -93,7 +142,27 @@ func filterEntries(all []catalog.Entry, query string) []catalog.Entry {
 	// Search only needs Entries populated — it doesn't touch the lookup
 	// indexes built by Load(), so a bare literal here is fine and avoids
 	// duplicating catalog's case-insensitive substring-match logic.
-	return c.Search(query)
+	entries := c.Search(query)
+	sort.SliceStable(entries, func(i, j int) bool {
+		ri, rj := categoryRank(entries[i].Category), categoryRank(entries[j].Category)
+		if ri != rj {
+			return ri < rj
+		}
+		return entries[i].Key < entries[j].Key
+	})
+	return entries
+}
+
+// categoryRank orders by position in catalog.Categories (the curated,
+// most-used-first order), falling back to the end of the list for any
+// category that isn't in it — defensive only, every real category is.
+func categoryRank(category string) int {
+	for i, cat := range catalog.Categories {
+		if cat == category {
+			return i
+		}
+	}
+	return len(catalog.Categories)
 }
 
 func (m Model) Init() tea.Cmd {
@@ -109,6 +178,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		switch m.stage {
+		case stageCategory:
+			return m.updateCategory(msg)
 		case stageBrowse:
 			return m.updateBrowse(msg)
 		case stageFields, stageFreeText:
@@ -156,12 +227,59 @@ func (m *Model) cursorEntry() int {
 	return m.cursor
 }
 
-func (m Model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+// updateCategory handles input for stageCategory, the outermost stage: pick
+// "All categories" or one specific category, then drill into stageBrowse
+// scoped to that choice. Port of trellis-cli's two-level nav (Phase F,
+// docs/cli-ux-plan.md, option 3) — mirrored here rather than replacing
+// stageBrowse so the flat, cross-category filter/search from option 2 stays
+// available as the default (cursor starts on "All categories").
+func (m Model) updateCategory(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC, tea.KeyEsc:
 		m.result = Result{Quit: true}
 		m.stage = stageDone
 		return m, tea.Quit
+
+	case tea.KeyEnter:
+		if len(m.categories) == 0 {
+			return m, nil
+		}
+		m.browseCategory = m.categories[m.catCursor].key
+		m.filterQuery = nil
+		m.applyFilter()
+		m.stage = stageBrowse
+		return m, nil
+
+	case tea.KeyUp, tea.KeyCtrlP:
+		if m.catCursor > 0 {
+			m.catCursor--
+		}
+		return m, nil
+
+	case tea.KeyDown, tea.KeyCtrlN:
+		if m.catCursor < len(m.categories)-1 {
+			m.catCursor++
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		m.result = Result{Quit: true}
+		m.stage = stageDone
+		return m, tea.Quit
+
+	case tea.KeyEsc:
+		// Back out one level to category-select rather than quitting — Esc
+		// is "go up a level" everywhere in this picker (also true of
+		// stageFields/stageFreeText below); Ctrl+C is the only "quit
+		// entirely" key once past stageCategory.
+		m.stage = stageCategory
+		m.filterQuery = nil
+		return m, nil
 
 	case tea.KeyEnter:
 		if len(m.filtered) == 0 {
@@ -212,10 +330,24 @@ func (m Model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) applyFilter() {
-	m.filtered = filterEntries(m.all, string(m.filterQuery))
+	pool := m.all
+	if m.browseCategory != "" {
+		pool = filterByCategory(m.all, m.browseCategory)
+	}
+	m.filtered = filterEntries(pool, string(m.filterQuery))
 	m.cursor = 0
 	m.listTop = 0
 	m.syncPreview()
+}
+
+func filterByCategory(all []catalog.Entry, category string) []catalog.Entry {
+	var out []catalog.Entry
+	for _, e := range all {
+		if e.Category == category {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // beginPrompting transitions from the browse list into guided per-field
@@ -305,18 +437,44 @@ func (m Model) submitPrompt() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-	if m.stage == stageDone {
+	switch m.stage {
+	case stageDone:
 		return ""
-	}
-	if m.stage == stageFields || m.stage == stageFreeText {
+	case stageCategory:
+		return m.viewCategory()
+	case stageFields, stageFreeText:
 		return m.viewPrompt()
+	default:
+		return m.viewBrowse()
 	}
-	return m.viewBrowse()
+}
+
+func (m Model) viewCategory() string {
+	var b strings.Builder
+	b.WriteString(headerStyle.Render("wp-ops — interactive picker"))
+	b.WriteString("\n\n")
+
+	for i, opt := range m.categories {
+		line := fmt.Sprintf("%-22s (%2d)  %s", opt.label, opt.count, opt.blurb)
+		if i == m.catCursor {
+			b.WriteString(cursorStyle.Render("> " + line))
+		} else {
+			b.WriteString("  " + line)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n" + footerStyle.Render("↑/↓ move · enter select · esc quit"))
+	return b.String()
 }
 
 func (m Model) viewBrowse() string {
 	var list strings.Builder
-	fmt.Fprintf(&list, "wp-ops > %s\n\n", string(m.filterQuery))
+	crumb := "All categories"
+	if m.browseCategory != "" {
+		crumb = catalog.CategoryDisplayNames[m.browseCategory]
+	}
+	fmt.Fprintf(&list, "wp-ops > %s > %s\n\n", crumb, string(m.filterQuery))
 
 	listWidth := minListWidth
 	if m.width > 0 {
@@ -335,8 +493,19 @@ func (m Model) viewBrowse() string {
 	if len(m.filtered) == 0 {
 		list.WriteString(dimStyle.Render("No matches."))
 	}
+	// lastCat starts empty so the window's first visible row always gets a
+	// header, even mid-scroll — reorients the user after paging rather than
+	// assuming they remember which category they scrolled into. Skipped
+	// entirely when stageBrowse is already scoped to one category (the
+	// breadcrumb above already says which).
+	lastCat := ""
 	for i := start; i < end; i++ {
 		e := m.filtered[i]
+		if m.browseCategory == "" && e.Category != lastCat {
+			list.WriteString(categoryHeaderStyle.Render(catalog.CategoryDisplayNames[e.Category]))
+			list.WriteString("\n")
+			lastCat = e.Category
+		}
 		line := fmt.Sprintf("%-28s", truncate(filepath.Base(e.Key), 28))
 		if e.RunsOn == "server" {
 			line += " " + serverTag.Render("(server)")
@@ -353,7 +522,7 @@ func (m Model) viewBrowse() string {
 	previewPane := borderedPane.Render(m.preview.View())
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane)
-	footer := footerStyle.Render("type to filter · ↑/↓ move · pgup/pgdn scroll preview · enter run · esc quit")
+	footer := footerStyle.Render("type to filter · ↑/↓ move · pgup/pgdn scroll preview · enter run · esc back · ctrl+c quit")
 
 	return headerStyle.Render("wp-ops — interactive picker") + "\n" + body + "\n" + footer
 }


### PR DESCRIPTION
## Summary
- `wp-ops list` / bare `wp-ops` now show a compact 8-line category summary (name, count, blurb) instead of every command's full description; the old full listing moves to `wp-ops list --all`
- The interactive picker's browse list now groups entries by category with header rows, sorted in the same curated order as the list view
- The picker gains a category-select stage on launch (mirroring `trellis-cli`'s top-level verb list), with "All categories" as the default choice so existing cross-category search stays one keystroke away
- Documents the above as Phase F in `docs/cli-ux-plan.md`, including the options considered and why option 4 (splitting the oversized `scripts` category) is deferred

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` pass
- [x] Each commit builds independently in an isolated worktree (bisectability)
- [x] Manually rendered `wp-ops list` and `wp-ops list --all`
- [x] Off-screen rendered the picker's category stage, a scoped browse (category selected), cross-category filtering, and Esc back-navigation