### PR TITLE
Add wp-ops docs search to the Go CLI (M4 task 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.0] - 2026-08-01
+
+### Added
+
+- **go** - M4 task 5 (per `docs/m4-go-cli-completion.md`): the Go CLI gets `wp-ops docs [term]`, a port of bash's full-text search over the repo's ~65 markdown guides (`wp-ops:1610-1736`). With no term, lists every `*.md` file under the repo root (excluding `.git`/`node_modules`/`vendor`); with a term, prints each matching file with its match count and up to 3 matching lines (collapsed whitespace, truncated to 96 chars), plus a "… N more" summary beyond that. `-w`/`--word` restricts matching to whole words (so `oom` doesn't hit inside "server room"); `-l`/`--files`/`--paths` prints matching paths only, for piping to an editor. This is unrelated to the per-command `@doc` manifest directive (`catalog.Entry.Doc`, already surfaced by `--help`/`--json`) — a pure filesystem search independent of any command's manifest, new file `go/cmd/docs.go`. `wp-ops search`'s "no command matches" path (`go/cmd/search.go`) regains the "the documentation mentions it though" cross-reference into this search, matching bash's behavior — the gap was called out explicitly in a comment left when `search` was ported ahead of `docs` landing. Unit-tested (`go/cmd/docs_test.go`): file discovery/exclusion, case-insensitivity vs. whole-word matching, whitespace collapsing/truncation, and match-count-is-lines-not-occurrences (`grep -c` semantics). `go/scripts/parity-check.sh` still 8/8 — `docs` isn't part of that contract (bash's output there is hand-formatted prose, not a stable interface), and neither `--json` nor `search`/`doctor` changed shape.
+
 ## [3.21.0] - 2026-08-01
 
 ### Added

--- a/docs/cli-ux-plan.md
+++ b/docs/cli-ux-plan.md
@@ -20,8 +20,9 @@
 > to `main` in PR #140 — see `docs/m3-go-skeleton.md`. M4 is in progress —
 > tasks 3 (Bubble Tea picker) and 4 (shell completions) are merged (PRs
 > #144, #145); tasks 1–2 (remaining executors) were also done earlier. Task
-> 5 (`docs` search) and 6 (goreleaser + tap) remain — see
-> `docs/m4-go-cli-completion.md`. Phase F (below) was raised against M4's
+> 5 (`docs` search) is done, on `feature/go-docs-search`, not yet merged.
+> Task 6 (goreleaser + tap) remains — see `docs/m4-go-cli-completion.md`.
+> Phase F (below) was raised against M4's
 > shipped picker/list surfaces; its options 1–3 merged in PR #146 (3.20.0).
 > Option 4 (splitting `scripts`) is now also done, on
 > `feature/cli-picker-search-scripts-categories`, not yet merged — turned out
@@ -578,7 +579,7 @@ touch `viewBrowse`), not a prerequisite for it.
 | M1 | Manifest spec, bash parser, `manifest lint`, backup + monitoring annotated | 3.10.0 | **Done**, merged (PR #134) |
 | M2 | All 66 annotated; guided prompts; `@runs` replaces the hardcoded list | 3.11.0 | **Done** — groups 1–5 plus the 2 `trellis` stragglers annotated (64/66 total); guided prompts shipped in 3.13.0; CI lint wiring landed after. Only `mcp-server/*` (2, out of scope) remains unannotated |
 | M3 | Go skeleton, catalog generator, shell + ansible executors; parity on `list`/`search`/`doctor`/`--json` | 4.0.0-beta | **Done**, merged to `main` (PR #140) — see `docs/m3-go-skeleton.md` for the full breakdown; all acceptance criteria met, parity script passing 8/8 |
-| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | **In progress** — tasks 1–4 done (PHP/snippet executors, picker PR #144, completions PR #145); tasks 5 (`docs` search) and 6 (goreleaser + tap) remain. See `docs/m4-go-cli-completion.md` |
+| M4 | Remaining executors, Bubble Tea picker, completions, goreleaser + tap | 4.0.0 | **In progress** — tasks 1–5 done (PHP/snippet executors, picker PR #144, completions PR #145, `docs` search on `feature/go-docs-search`); task 6 (goreleaser + tap) remains. See `docs/m4-go-cli-completion.md` |
 | M5 | Shared site registry, `--on <env>` SSH dispatch | 4.1.0 | Not started |
 | M6 | `trellis-wpops` symlink | 4.1.0 | Not started |
 | F | Command discovery: category-first default views, picker grouping | 3.20.0 | **In progress** — options 1–3 done, merged (PR #146); option 4 not started. See Phase F below |

--- a/docs/m4-go-cli-completion.md
+++ b/docs/m4-go-cli-completion.md
@@ -2,11 +2,11 @@
 
 > **Status (2026-08-01):** In progress. Task 1 (`internal/exec/wpcli.go`),
 > task 2 (`internal/exec/snippet.go`), task 3 (`internal/ui` Bubble Tea
-> picker), and task 4 (shell completions) are done. Scoped out of M3
-> (`docs/m3-go-skeleton.md`, "Explicitly out of scope for M3") now that M3
-> is merged to `main` (PR #140). Parent plan: `docs/cli-ux-plan.md` (Phase
-> C, milestone M4, target **4.0.0**). Remaining: task 5 (`docs` search) and
-> task 6 (goreleaser + Homebrew tap).
+> picker), task 4 (shell completions), and task 5 (`docs` search) are done.
+> Scoped out of M3 (`docs/m3-go-skeleton.md`, "Explicitly out of scope for
+> M3") now that M3 is merged to `main` (PR #140). Parent plan:
+> `docs/cli-ux-plan.md` (Phase C, milestone M4, target **4.0.0**).
+> Remaining: task 6 (goreleaser + Homebrew tap).
 
 ## Goal
 
@@ -227,11 +227,31 @@ Replaces the hand-written `print_completion()` (`wp-ops:2098`, bash-only). **Don
 
 ### 5. `docs` search command
 Deferred from M3 per open decision #2 above; port of `docs` search
-(`wp-ops:1235-1346`) if decision #2 confirms it's in scope.
-- [ ] Walk `@doc` references from the catalog (already populated by M3's
-  `internal/catalog`) plus a full-text search fallback over doc files,
-  matching bash's behavior
-- [ ] `wp-ops docs <term>` prints matching doc paths/excerpts
+(`wp-ops:1610-1736`, dispatch at `wp-ops:2196-2211`). **Done.**
+- [x] Full-text search over every `*.md` file in the repo (excluding
+  `.git`/`node_modules`/`vendor`), independent of any command's manifest —
+  the `@doc` per-command directive (`catalog.Entry.Doc`) is a separate,
+  already-shipped feature (surfaced in executors' `--help` and `--json`
+  since M2/M3); `docs` search never reads it. New `go/cmd/docs.go`:
+  `findDocs` (file discovery), `compileDocTerm` (case-insensitive, or
+  whole-word via `-w`/`--word`), `searchDocFile`/`searchDocs` (per-file and
+  aggregate matching, `grep -c` semantics — match count is lines, not
+  occurrences)
+- [x] `wp-ops docs [term]` prints matching doc paths/excerpts: no term lists
+  every doc file; a term prints each matching file with its match count and
+  up to 3 matching lines (collapsed whitespace, truncated to 96 chars) plus
+  a "… N more" summary; `-l`/`--files`/`--paths` prints matching paths only
+- [x] `wp-ops search`'s "no command matches" path regains the "the
+  documentation mentions it though" cross-reference into `docs` search
+  (`hasDocMatches` in `docs.go`), closing the gap `search.go`'s doc comment
+  flagged when `search` was ported ahead of `docs` landing
+- [x] Unit tests (`go/cmd/docs_test.go`): file discovery/exclusion,
+  case-insensitive vs. whole-word matching, whitespace collapsing/
+  truncation, match-count-is-lines-not-occurrences. Manual pass: term
+  search, `-w`, `-l`, no-term listing, and no-match all verified against the
+  real repo tree; `go/scripts/parity-check.sh` still 8/8 (`docs` isn't part
+  of that contract — bash's own output there is hand-formatted prose, not a
+  stable interface, same reasoning `search`/`doctor` already use)
 
 ### 6. `goreleaser` + Homebrew tap distribution
 Gated on open decision #1 (embed vs. locate).
@@ -270,6 +290,6 @@ milestone table:
 - [x] Generated completions work in at least bash and zsh
 - [ ] `brew install imagewize/tap/wp-ops` (or the chosen distribution path
   per open decision #1) produces a working, self-contained binary
-- [ ] `docs` search, if in scope per open decision #2, matches bash output
+- [x] `docs` search, if in scope per open decision #2, matches bash output
 - [ ] CI green on all of the above (`go-build.yml` plus any new
   goreleaser workflow)

--- a/go/cmd/docs.go
+++ b/go/cmd/docs.go
@@ -1,0 +1,281 @@
+// Port of the bash CLI's "Documentation Search" section (wp-ops:1610-1736)
+// and its dispatch (wp-ops:2196-2211) — M4 task 5,
+// docs/m4-go-cli-completion.md. Unrelated to the per-command @doc manifest
+// directive (catalog.Entry.Doc, already surfaced by executors' --help and
+// --json): this is a full-text search over every *.md file in the repo,
+// independent of any command's manifest.
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// docMatchLimit caps how many matching lines are shown per document before
+// the rest are summarised as "… N more" — a long guide can otherwise bury
+// every other matching document under one file's hits (wp-ops:1621).
+const docMatchLimit = 3
+
+// docLineWidth truncates a shown matching line so a long paragraph stays on
+// one row (wp-ops:1624).
+const docLineWidth = 96
+
+var (
+	docsPathsOnly bool
+	docsWholeWord bool
+)
+
+var docsCmd = &cobra.Command{
+	Use:   "docs [term]",
+	Short: "Search the guides (no term lists them)",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cc *cobra.Command, args []string) error {
+		term := ""
+		if len(args) > 0 {
+			term = args[0]
+		}
+		os.Exit(runDocs(term, docsPathsOnly, docsWholeWord))
+		return nil
+	},
+}
+
+func init() {
+	docsCmd.Flags().BoolVarP(&docsPathsOnly, "files", "l", false, "Print only matching file paths")
+	docsCmd.Flags().BoolVar(&docsPathsOnly, "paths", false, "Alias for --files")
+	docsCmd.Flags().BoolVarP(&docsWholeWord, "word", "w", false, "Match whole words only")
+	rootCmd.AddCommand(docsCmd)
+}
+
+// docLine is one matching line, already collapsed/truncated for display.
+type docLine struct {
+	number int
+	text   string
+}
+
+// docResult is one document with at least one match.
+type docResult struct {
+	relPath    string
+	matchCount int
+	lines      []docLine
+}
+
+func runDocs(term string, pathsOnly, wholeWord bool) int {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	if term == "" {
+		printDocsList(root)
+		return 0
+	}
+
+	results, err := searchDocs(root, term, wholeWord)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	if len(results) == 0 {
+		fmt.Printf("No documents match '%s'.\n\n", term)
+		fmt.Printf("Try wp-ops search %s to look for a command instead.\n", term)
+		return 1
+	}
+
+	if pathsOnly {
+		for _, r := range results {
+			fmt.Println(r.relPath)
+		}
+		return 0
+	}
+
+	noun := "documents"
+	if len(results) == 1 {
+		noun = "document"
+	}
+	fmt.Printf("%d %s matching '%s':\n\n", len(results), noun, term)
+
+	for _, r := range results {
+		matchNoun := "matches"
+		if r.matchCount == 1 {
+			matchNoun = "match"
+		}
+		fmt.Printf("  %s (%d %s)\n", r.relPath, r.matchCount, matchNoun)
+		for _, l := range r.lines {
+			fmt.Printf("    %5d  %s\n", l.number, l.text)
+		}
+		if r.matchCount > docMatchLimit {
+			fmt.Printf("    %5s  … %d more\n", "", r.matchCount-docMatchLimit)
+		}
+		fmt.Println()
+	}
+
+	if wholeWord {
+		fmt.Printf("Paths only (for piping to an editor): wp-ops docs %s -l\n\n", term)
+	} else {
+		fmt.Printf("Whole words only: wp-ops docs %s -w   ·   paths only: wp-ops docs %s -l\n\n", term, term)
+	}
+
+	return 0
+}
+
+func printDocsList(root string) {
+	docs, err := findDocs(root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	fmt.Printf("Documentation (%d files)\n\n", len(docs))
+	for _, d := range docs {
+		fmt.Printf("  %s\n", relDocPath(root, d))
+	}
+	fmt.Println()
+	fmt.Println("Search inside them with: wp-ops docs <term>")
+	fmt.Println()
+}
+
+// hasDocMatches backs search.go's "the documentation mentions it though"
+// cross-reference (wp-ops:1582-1586) when a command search comes up empty.
+func hasDocMatches(term string) bool {
+	root, err := repoRoot()
+	if err != nil {
+		return false
+	}
+	results, err := searchDocs(root, term, false)
+	return err == nil && len(results) > 0
+}
+
+// searchDocs walks every *.md file under root and returns one docResult per
+// file with at least one match, in findDocs' (sorted, repo-relative-path)
+// order.
+func searchDocs(root, term string, wholeWord bool) ([]docResult, error) {
+	re, err := compileDocTerm(term, wholeWord)
+	if err != nil {
+		return nil, err
+	}
+
+	docs, err := findDocs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []docResult
+	for _, doc := range docs {
+		count, lines, err := searchDocFile(doc, re)
+		if err != nil {
+			// Matches bash's `2>/dev/null` on the grep calls: an unreadable
+			// file is skipped, not a hard failure.
+			continue
+		}
+		if count > 0 {
+			results = append(results, docResult{
+				relPath:    relDocPath(root, doc),
+				matchCount: count,
+				lines:      lines,
+			})
+		}
+	}
+	return results, nil
+}
+
+// findDocs mirrors find_docs (wp-ops:1630-1634): every *.md file in the
+// repo, excluding .git/node_modules/vendor, sorted.
+func findDocs(root string) ([]string, error) {
+	var docs []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".md") {
+			docs = append(docs, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(docs)
+	return docs, nil
+}
+
+func relDocPath(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+// compileDocTerm builds the case-insensitive matcher grep -i (or grep -wi
+// for --word) implements, per DOC_GREP_OPTS (wp-ops:1628).
+func compileDocTerm(term string, wholeWord bool) (*regexp.Regexp, error) {
+	pattern := regexp.QuoteMeta(term)
+	if wholeWord {
+		pattern = `\b` + pattern + `\b`
+	}
+	return regexp.Compile("(?i)" + pattern)
+}
+
+// collapseDocWhitespace mirrors print_docs_results' sed pipeline
+// (wp-ops:1719-1720): markdown indentation and list markers carry no
+// meaning once a line is shown out of context.
+var docWhitespaceRun = regexp.MustCompile(`[ \t]{2,}`)
+
+func collapseDocWhitespace(s string) string {
+	s = strings.TrimLeft(s, " \t")
+	s = docWhitespaceRun.ReplaceAllString(s, " ")
+
+	runes := []rune(s)
+	if len(runes) > docLineWidth {
+		return string(runes[:docLineWidth-1]) + "…"
+	}
+	return s
+}
+
+// searchDocFile scans one file line by line, matching grep -c (matchCount,
+// the number of matching lines) and grep -n | head -N (the first
+// docMatchLimit matching lines, collapsed/truncated for display).
+func searchDocFile(path string, re *regexp.Regexp) (matchCount int, lines []docLine, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		text := scanner.Text()
+		if !re.MatchString(text) {
+			continue
+		}
+		matchCount++
+		if len(lines) < docMatchLimit {
+			lines = append(lines, docLine{number: lineNum, text: collapseDocWhitespace(text)})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, nil, err
+	}
+	return matchCount, lines, nil
+}

--- a/go/cmd/docs_test.go
+++ b/go/cmd/docs_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeDocs materializes a small doc tree under t.TempDir() and returns its
+// root, so findDocs/searchDocs can be exercised against real files without
+// touching the repo checkout.
+func writeDocs(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("writing %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// TestFindDocs ports find_docs (wp-ops:1630-1634): every *.md file, sorted,
+// excluding .git/node_modules/vendor and non-.md files.
+func TestFindDocs(t *testing.T) {
+	root := writeDocs(t, map[string]string{
+		"README.md":                  "top",
+		"guides/backup.md":           "guide",
+		"guides/notes.txt":           "not markdown",
+		".git/COMMIT_EDITMSG":        "not a doc",
+		"node_modules/pkg/README.md": "vendored, excluded",
+		"vendor/lib/README.md":       "vendored, excluded",
+	})
+
+	got, err := findDocs(root)
+	if err != nil {
+		t.Fatalf("findDocs: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(root, "README.md"),
+		filepath.Join(root, "guides/backup.md"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("findDocs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("findDocs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestCompileDocTerm covers the -w/--word distinction (DOC_GREP_OPTS,
+// wp-ops:1628): a bare term matches as a substring, --word requires a word
+// boundary so short terms like "oom" don't hit inside "server room".
+func TestCompileDocTerm(t *testing.T) {
+	tests := []struct {
+		name      string
+		term      string
+		wholeWord bool
+		text      string
+		want      bool
+	}{
+		{"substring match", "oom", false, "the server room is loud", true},
+		{"whole word rejects a substring hit", "oom", true, "the server room is loud", false},
+		{"whole word matches a standalone word", "oom", true, "an OOM killer event", true},
+		{"case-insensitive by default", "Manifest", false, "the manifest file", true},
+		{"regex metacharacters are literal", "wp-ops", false, "run wp-ops docs", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re, err := compileDocTerm(tt.term, tt.wholeWord)
+			if err != nil {
+				t.Fatalf("compileDocTerm: %v", err)
+			}
+			if got := re.MatchString(tt.text); got != tt.want {
+				t.Errorf("MatchString(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCollapseDocWhitespace ports the sed pipeline in print_docs_results
+// (wp-ops:1719-1720): trim leading indentation, collapse runs of 2+
+// whitespace, then truncate to docLineWidth with an ellipsis.
+func TestCollapseDocWhitespace(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trims leading indentation", "    - a list item", "- a list item"},
+		{"collapses internal runs", "a   b    c", "a b c"},
+		{"short line is untouched otherwise", "hello world", "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collapseDocWhitespace(tt.in); got != tt.want {
+				t.Errorf("collapseDocWhitespace(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	long := ""
+	for i := 0; i < 120; i++ {
+		long += "x"
+	}
+	got := collapseDocWhitespace(long)
+	if len(got) == 0 {
+		t.Fatal("collapseDocWhitespace returned empty string")
+	}
+	runes := []rune(got)
+	if len(runes) != docLineWidth {
+		t.Errorf("truncated length = %d, want %d", len(runes), docLineWidth)
+	}
+	if runes[len(runes)-1] != '…' {
+		t.Errorf("truncated line should end with an ellipsis, got %q", got)
+	}
+}
+
+// TestSearchDocFile pins matchCount against grep -c (matching lines, not
+// occurrences) and the docMatchLimit cap on lines actually returned.
+func TestSearchDocFile(t *testing.T) {
+	root := writeDocs(t, map[string]string{
+		"many.md": "manifest one\nmanifest two\nmanifest three\nmanifest four\nno hit here\n",
+	})
+	re, err := compileDocTerm("manifest", false)
+	if err != nil {
+		t.Fatalf("compileDocTerm: %v", err)
+	}
+
+	count, lines, err := searchDocFile(filepath.Join(root, "many.md"), re)
+	if err != nil {
+		t.Fatalf("searchDocFile: %v", err)
+	}
+	if count != 4 {
+		t.Errorf("matchCount = %d, want 4", count)
+	}
+	if len(lines) != docMatchLimit {
+		t.Fatalf("len(lines) = %d, want %d", len(lines), docMatchLimit)
+	}
+	if lines[0].number != 1 || lines[0].text != "manifest one" {
+		t.Errorf("lines[0] = %+v, want {1 manifest one}", lines[0])
+	}
+}
+
+// TestSearchDocs covers the end-to-end aggregation: only files with at
+// least one match are returned, in findDocs' sorted order.
+func TestSearchDocs(t *testing.T) {
+	root := writeDocs(t, map[string]string{
+		"a.md": "nothing relevant here",
+		"b.md": "the manifest directive lives here",
+		"c.md": "MANIFEST in caps, twice: manifest",
+	})
+
+	results, err := searchDocs(root, "manifest", false)
+	if err != nil {
+		t.Fatalf("searchDocs: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].relPath != "b.md" || results[1].relPath != "c.md" {
+		t.Errorf("results in wrong order: %+v", results)
+	}
+	if results[1].matchCount != 1 {
+		t.Errorf("c.md matchCount = %d, want 1 (grep -c counts matching lines, not occurrences)", results[1].matchCount)
+	}
+}
+
+// TestSearchDocsNoMatches confirms an empty result set, not an error, is
+// how "no documents match" is signalled — runDocs relies on this to print
+// its own message rather than propagating a search error.
+func TestSearchDocsNoMatches(t *testing.T) {
+	root := writeDocs(t, map[string]string{"a.md": "irrelevant content"})
+
+	results, err := searchDocs(root, "zzznomatchxyz", false)
+	if err != nil {
+		t.Fatalf("searchDocs: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("results = %v, want none", results)
+	}
+}

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -31,6 +31,7 @@ playbooks, and more.
 
   wp-ops list                             List every command by category
   wp-ops search <term>                    Search commands by name or description
+  wp-ops docs [term] [-l]                 Search the guides (no term lists them)
   wp-ops doctor                           Check dependencies and environment
   wp-ops --json                           Output the command list as JSON
   wp-ops --version                        Show version`,

--- a/go/cmd/search.go
+++ b/go/cmd/search.go
@@ -25,15 +25,18 @@ func init() {
 	rootCmd.AddCommand(searchCmd)
 }
 
-// runSearch ports print_search_results (wp-ops:1566), minus the "the docs
-// mention it" doc-search cross-reference — `docs` search is deferred to M4
-// (docs/m3-go-skeleton.md, open decision #3).
+// runSearch ports print_search_results (wp-ops:1566), including the "the
+// docs mention it" cross-reference into docs.go's full-text doc search
+// (wp-ops:1582-1586).
 func runSearch(term string) {
 	c := mustCatalog()
 	matches := c.Search(term)
 
 	if len(matches) == 0 {
 		fmt.Printf("No commands match '%s'.\n\n", term)
+		if hasDocMatches(term) {
+			fmt.Printf("The documentation mentions it though — try wp-ops docs %s.\n\n", term)
+		}
 		fmt.Println("Run wp-ops to browse everything by category.")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- Ports bash's full-text search over the repo's ~65 markdown guides (`wp-ops:1610-1736`) into the Go CLI: `wp-ops docs [term]` lists every doc with no term, or searches with match counts and up to 3 excerpt lines per file, `-w`/`--word` for whole-word matching, `-l`/`--files`/`--paths` for paths-only output.
- `wp-ops search`'s "no command matches" path regains the "the documentation mentions it though" cross-reference into `docs` search, closing a gap left when `search` was ported ahead of `docs`.
- Closes out M4 task 5 (`docs/m4-go-cli-completion.md`) — only task 6 (goreleaser + Homebrew tap) remains before M4/4.0.0.

## Test plan
- [x] `go build ./...` and `go test ./...` pass
- [x] `go/scripts/parity-check.sh` still 8/8 (`docs` isn't part of that contract)
- [x] Manual pass: term search, `-w`, `-l`, no-term listing, no-match case, `--help`, and the `search` cross-reference, all against the real repo tree