### PR TITLE
Fix Homebrew tap distribution: repo name and Gatekeeper quarantine

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,6 +70,19 @@ homebrew_casks:
     directory: Casks
     homepage: "https://github.com/imagewize/wp-ops"
     description: "Unified CLI for WordPress operations, Trellis, and Bedrock workflows"
+    # The binary isn't code-signed/notarized (no Apple Developer ID), so
+    # macOS quarantines it on download and Gatekeeper kills it outright on
+    # first run (exit 137) rather than showing the usual "open anyway"
+    # prompt a signed-but-unnotarized app would get. Stripping the
+    # quarantine bit post-install is the standard goreleaser fix for
+    # distributing an unsigned CLI binary via a cask — found by an actual
+    # `brew install imagewize/tap/wp-ops` failing this way.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/wp-ops"]
+          end
 
 release:
   github:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.23.1] - 2026-08-01
+
+### Fixed
+
+- **go** - The Homebrew tap's real repo name is `imagewize/homebrew-tap`, not `imagewize/tap` — Homebrew's tap-naming convention maps the short `imagewize/tap` form used in `brew tap`/`brew install` commands to a repo literally prefixed `homebrew-`. `.goreleaser.yml`'s `repository.name` pointed at the wrong one, so the first real release's cask push landed nowhere; caught by an actual `brew install imagewize/tap/wp-ops` run. Also: the installed binary isn't code-signed or notarized (no Apple Developer ID), so macOS quarantines it on download and Gatekeeper killed it outright on first run (`exit 137`) instead of showing the usual "open anyway" prompt — a `homebrew_casks` `hooks.post.install` now strips `com.apple.quarantine` from the staged binary, the standard goreleaser fix for distributing an unsigned CLI tool via a cask. `brew install imagewize/tap/wp-ops` followed by `wp-ops --version`/`wp-ops search` verified working end to end after both fixes.
+
 ## [3.23.0] - 2026-08-01
 
 ### Added


### PR DESCRIPTION
## Summary

Two bugs found by actually running `brew install imagewize/tap/wp-ops` after PR #150 merged and v3.23.0 was tagged:

1. **Wrong tap repo name.** Homebrew's naming convention maps `imagewize/tap` (the short form used in `brew tap`/`brew install`) to a GitHub repo literally named `imagewize/homebrew-tap`, not `imagewize/tap`. The repo was created as `imagewize/tap`; renamed to `imagewize/homebrew-tap` and `.goreleaser.yml`'s `repository.name` updated to match.
2. **Gatekeeper kills the binary on first run.** The `wp-ops` binary isn't code-signed or notarized (no Apple Developer ID), so macOS quarantines it on download; Gatekeeper then kills it outright (`exit 137`) on first run instead of prompting to allow it. Added the standard goreleaser fix: a `homebrew_casks` `hooks.post.install` that strips `com.apple.quarantine` from the staged binary.

Also bumps to 3.23.1 (patch, distribution-only fixes — no CLI behavior changed).

## Test plan

- [x] `goreleaser check` validates the updated config
- [x] Re-tagged v3.23.0 twice while iterating on these fixes (tag/release deleted and recreated each time — no public consumers yet)
- [x] `brew install imagewize/tap/wp-ops` succeeds end to end against the corrected repo name
- [x] Post this PR's fix, once tagged as v3.23.1: `wp-ops --version` and `wp-ops search webp` both work from a fresh `brew install`, confirming the quarantine strip resolves the Gatekeeper kill