### PR TITLE
mcp-server: implement recommendations items 1-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.24.0] - 2026-08-03
+
+### Added
+
+- **mcp-server** - `mcp-server/src/server.ts`: `site`/`env` tool parameters are now `z.enum(...)` built from the site registry at server start (`buildSiteEnvSchemas()`) instead of free-form `z.string()`, so an invalid site/env key is rejected before the call is made rather than costing a full round trip. Falls back to plain `z.string()` if the registry can't be loaded yet or is empty, so a fresh install without `config/sites.json` still starts.
+- **mcp-server** - `mcp-server/src/tools/wpCli.ts`: expanded the read-only allowlist. `SAFE_READ_VERBS` gained `size`/`tables`/`verify-checksums`/`pluck` (covers `wp db size`, `wp db tables`, `wp core verify-checksums`, `wp option pluck`); a new `NESTED_RESOURCE_VERBS` allowlist covers commands where the verb is the third token because the second names a sub-resource (`wp cron event list`), without blindly trusting `args[2]` for every command — `wp option update list <value>` still correctly requires `confirm: true`.
 
 ### Changed
 
 - **mcp-server** - `mcp-server/README.md`: recommend user-scoped MCP server registration in `~/.claude.json`; add Permissions section with pre-approval config for read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `wp_cli`); add Usage Tips covering multi-site registry and CLAUDE.md integration guidance.
-- **docs** - `docs/mcp-server-recommendations.md`: mark items 1-4 as documented with references to the updated README sections.
+- **docs** - `docs/mcp-server-recommendations.md`: mark items 1-8 as done. Items 5-6 (`wpBin`/`phpBin` override, `url` field + `site`/`env` on audits) turned out to already be implemented (predating this pass); items 7-8 are the new schema-enum and allowlist work above.
 
 ## [3.23.2] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **mcp-server** - `mcp-server/README.md`: recommend user-scoped MCP server registration in `~/.claude.json`; add Permissions section with pre-approval config for read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `wp_cli`); add Usage Tips covering multi-site registry and CLAUDE.md integration guidance.
+- **docs** - `docs/mcp-server-recommendations.md`: mark items 1-4 as documented with references to the updated README sections.
+
 ## [3.23.2] - 2026-08-01
 
 ### Changed

--- a/docs/mcp-server-recommendations.md
+++ b/docs/mcp-server-recommendations.md
@@ -38,28 +38,37 @@ Observed setup gaps:
 
 ## Quick wins — no code changes
 
-1. **Register the server user-scoped.**
+1. **Register the server user-scoped.** ✅ *Documented*
    `claude mcp add --scope user wp-ops ...` or add the `mcpServers` block to
    `~/.claude.json`. The registry is central, so the tools shouldn't only exist
    inside the example.com project. Any session — including in wp-ops itself —
    can then run audits or WP-CLI against any registered site.
+   
+   *Updated `mcp-server/README.md` to recommend user-scoped as the default.*
 
-2. **Add more sites to `sites.json`.**
+2. **Add more sites to `sites.json`.** ✅ *Template ready*
    Plain WordPress installs (e.g. `client`) work today via `localPath` —
    nothing in `wpCli.ts` assumes Bedrock; `--path` is arbitrary. Remote non-Trellis
    hosts work too as long as `wp` is on the remote PATH.
+   
+   *`config/sites.example.json` already includes `client.nl` (shared hosting with
+   custom `wpBin`/`phpBin`) and `static-site` (URL-only) examples.*
 
-3. **Mention the MCP tools in each site's CLAUDE.md.**
+3. **Mention the MCP tools in each site's CLAUDE.md.** ✅ *Template provided*
    Without that, Claude keeps reaching for raw `wp` / `trellis vm shell` bash
    commands — more permission prompts, more trial-and-error tokens. One line like
    "prefer the `wp-ops` MCP tools (`wp_cli`, `security_scan`, …) with site key
    `example.com`" changes the default behavior.
+   
+   *Added CLAUDE.md integration template to `mcp-server/README.md` Usage Tips.*
 
-4. **Pre-approve the read-only tools** in `~/.claude/settings.json` permissions:
+4. **Pre-approve the read-only tools** in `~/.claude/settings.json` permissions: ✅ *Documented*
    `mcp__wp-ops__redirect_audit`, `mcp__wp-ops__schema_audit`,
    `mcp__wp-ops__security_scan`, `mcp__wp-ops__wp_cli`. The write-guard already
    lives server-side (`confirm: true`), so prompting again client-side for reads is
    pure friction.
+   
+   *Added Permissions section to `mcp-server/README.md` with the exact config.*
 
 ## Server improvements for non-Bedrock / non-WordPress sites
 

--- a/docs/mcp-server-recommendations.md
+++ b/docs/mcp-server-recommendations.md
@@ -5,7 +5,7 @@ all sites — example.com, other WordPress installs (Bedrock/Trellis or plain), 
 non-WordPress sites — with a focus on saving time and tokens. Also covers the
 longer-term question of tighter coupling with the Go CLI binary.
 
-> **Status:** Up to date as of v3.23.2 (2026-08-01)
+> **Status:** Up to date as of v3.24.0 (2026-08-03) — items 1-8 done.
 
 ## Current state
 
@@ -72,38 +72,53 @@ Observed setup gaps:
 
 ## Server improvements for non-Bedrock / non-WordPress sites
 
-5. **Per-entry `wpBin`/`phpBin` override in the registry schema.**
+5. **Per-entry `wpBin`/`phpBin` override in the registry schema.** ✅ *Already implemented*
    The security docs (`wp-cli/security/README.md`) call out cPanel/Plesk hosts
    where the binary is `/opt/plesk/php/8.2/bin/php` and WP-CLI may be
-   `~/wp-cli.phar`. Right now `runRemote` hardcodes `wp`, so shared-hosting sites
-   can't be registered. This is the single change that opens the MCP up to every
-   non-Trellis client site.
+   `~/wp-cli.phar`.
 
-6. **Add a `url` field per site/env; let audits accept `site`/`env`.**
+   *`registry.ts`'s `envEntrySchema` already has `wpBin`/`phpBin`, and
+   `resolveWpBin`/`resolvePhpBin` are threaded through `runLocal`/`runRemote`/`runVm`
+   in `tools/wpCli.ts` — this landed in `c665424`, before this doc's items 1-4 pass.
+   `config/sites.example.json`'s `client.nl` entry demonstrates it.*
+
+6. **Add a `url` field per site/env; let audits accept `site`/`env`.** ✅ *Already implemented*
    `redirect_audit` and `schema_audit` are platform-agnostic (pure curl), making
-   them the entry point for Jekyll and static sites — but today full URLs must be
-   retyped. With `"url": "https://client.nl"` in the registry, "run a
-   redirect audit on client production" becomes one unambiguous call. Static
-   sites would register with *only* a `url` (the schema's refine currently requires
-   a path/host — relax it for URL-only entries).
+   them the entry point for Jekyll and static sites.
+
+   *`registry.ts`'s schema already has `url` and its `refine` accepts a URL-only
+   entry (also from `c665424`). `server.ts`'s `redirect_audit`/`schema_audit` tools
+   already accept `site`+`env` and resolve the URL from the registry entry, falling
+   back to the raw `urls`/`siteUrl` params. `config/sites.example.json`'s
+   `static-site` entry demonstrates a URL-only registration.*
 
 ## Token and time savings
 
-7. **Put the site keys in the tool schema.**
+7. **Put the site keys in the tool schema.** ✅ *Done*
    `site`/`env` are free-form `z.string()`, so a wrong guess costs a failed round
-   trip (the error lists known sites, but that's a full extra tool call). Since
-   `loadRegistry()` is cheap, build the schema at server start with
-   `z.enum(Object.keys(registry))` — valid keys land in the tool definition the
-   model sees, and mistakes drop to near zero. Trade-off: registry edits need a
-   server restart, which is already true in practice for stdio.
+   trip (the error lists known sites, but that's a full extra tool call).
 
-8. **Expand the read-only allowlist — every miss costs two tool calls.**
-   `isReadOnlyWpCommand` only checks `args[1]`, so genuinely read-only commands
-   like `wp cron event list` (`args[1] === "event"`), `wp config get`,
-   `wp db size`, `wp db tables`, `wp core verify-checksums`, `wp option pluck`
-   all fail, get re-sent with `confirm: true`, and burn a round trip plus a user
-   approval each time. Either check the verb at position 1 *or* 2, or allowlist
-   known read-only `command + subcommand` pairs.
+   *`server.ts`'s new `buildSiteEnvSchemas()` builds `z.enum(...)` for both `site`
+   (from the registry's top-level keys) and `env` (the union of env keys across all
+   sites) once at server start, and every tool's `site`/`env` params use it. Falls
+   back to plain `z.string()` if the registry can't be loaded yet or is empty, so a
+   fresh install without `sites.json` still starts. Trade-off: registry edits need a
+   server restart, as expected for stdio.*
+
+8. **Expand the read-only allowlist — every miss costs two tool calls.** ✅ *Done*
+   `isReadOnlyWpCommand` only checked `args[1]`, so genuinely read-only commands
+   like `wp cron event list` (`args[1] === "event"`), `wp db size`, `wp db tables`,
+   `wp core verify-checksums`, `wp option pluck` all failed, got re-sent with
+   `confirm: true`, and burned a round trip plus a user approval each time.
+
+   *`tools/wpCli.ts`: `SAFE_READ_VERBS` gained `size`/`tables`/`verify-checksums`/`pluck`.
+   For the `wp cron event list` shape — where the verb is the *third* token because
+   the second names a sub-resource, not an action — a new `NESTED_RESOURCE_VERBS`
+   allowlist (currently just `cron: [event, schedule]`) checks the third token
+   instead. Deliberately not a blind "check args[1] OR args[2]": args[2] is often an
+   arbitrary caller-supplied value (an option name, a post ID) that could
+   coincidentally collide with a safe verb — e.g. `wp option update list <value>`
+   must stay gated even though its third token is `list`.*
 
 9. **Cap and compact tool output.**
    `wp_cli` returns stdout verbatim — `wp post list` on a big site can dump tens
@@ -132,10 +147,10 @@ Observed setup gaps:
 
 ## Suggested order of work
 
-1. Items 1–4: config-only, doable immediately.
-2. Items 5–6: opens up all non-Trellis and static sites.
-3. Items 7–8: biggest recurring token savers.
-4. Items 9–11: output compaction and new tools.
+1. ✅ Items 1–4: config-only, doable immediately.
+2. ✅ Items 5–6: opens up all non-Trellis and static sites (turned out to already be implemented).
+3. ✅ Items 7–8: biggest recurring token savers.
+4. Items 9–11: output compaction and new tools — remaining.
 
 ---
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -73,7 +73,11 @@ npm run build
 
 ## Register with Claude Code
 
-Add to your `.mcp.json` (project-scoped) or `~/.claude.json` (user-scoped):
+**Recommended:** Register the server **user-scoped** in `~/.claude.json` so the tools
+are available in every project and session. Project-scoped (`.mcp.json`) works but
+limits the tools to only that project directory.
+
+Add to your `~/.claude.json` (user-scoped) or `.mcp.json` (project-scoped):
 
 ```json
 {
@@ -87,6 +91,43 @@ Add to your `.mcp.json` (project-scoped) or `~/.claude.json` (user-scoped):
 ```
 
 Or add the same block under `mcpServers` in Claude Desktop's config file.
+
+> **Why user-scoped?** The site registry is central and multi-site. Registering
+> user-scoped lets any session — including in the wp-ops repo itself — run audits
+> or WP-CLI against any registered site without project-specific config.
+
+## Permissions (pre-approve read-only tools)
+
+The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, and
+read-only `wp_cli` commands) are safe to run without confirmation. Pre-approve
+them in `~/.claude/settings.json` to avoid repeated permission prompts:
+
+```json
+{
+  "mcp": {
+    "permissions": {
+      "mcp__wp-ops__redirect_audit": { "allowed": true },
+      "mcp__wp-ops__schema_audit": { "allowed": true },
+      "mcp__wp-ops__security_scan": { "allowed": true },
+      "mcp__wp-ops__wp_cli": { "allowed": true }
+    }
+  }
+}
+```
+
+Write operations (e.g., `wp_cli` with `search-replace`, `post delete`, `plugin install`)
+still require `confirm: true` and will prompt for approval.
+
+## Usage Tips
+
+- **Multi-site registry:** `config/sites.example.json` shows the full schema.
+  Add all your sites (Bedrock, plain WordPress, static sites) — the same tools
+  work across all of them. URL-only entries enable `redirect_audit` and
+  `schema_audit` for static/Jekyll sites.
+- **CLAUDE.md integration:** In each project that uses these tools, add a note
+  in `CLAUDE.md` like: "Prefer the wp-ops MCP tools (`wp_cli`, `security_scan`,
+  `redirect_audit`, `schema_audit`, `db_backup`) with the site key from
+  `mcp-server/config/sites.json`."
 
 ## Running as a network service (Streamable HTTP)
 

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { z, type ZodTypeAny } from "zod";
 import { loadRegistry, resolveSiteEnv } from "./registry.js";
 import { runDbBackup } from "./tools/dbBackup.js";
 import { runSecurityScan } from "./tools/securityScan.js";
@@ -7,11 +7,37 @@ import { isReadOnlyWpCommand, runWpCli } from "./tools/wpCli.js";
 import { runRedirectAudit } from "./tools/redirectAudit.js";
 import { runSchemaAudit } from "./tools/schemaAudit.js";
 
+// Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
+// by the client/model before the call is ever made, instead of costing a full round trip
+// (loadRegistry() is cheap, so doing this once at server start is fine). Falls back to
+// plain z.string() if the registry can't be loaded yet (e.g. sites.json not created) or
+// is empty — the real, more informative error still surfaces from resolveSiteEnv() at
+// call time either way. Trade-off: registry edits need a server restart to pick up new
+// keys, same as for stdio transport in general.
+function buildSiteEnvSchemas(): { site: ZodTypeAny; env: ZodTypeAny } {
+  try {
+    const registry = loadRegistry();
+    const siteKeys = Object.keys(registry);
+    if (siteKeys.length === 0) {
+      return { site: z.string(), env: z.string() };
+    }
+    const envKeys = Array.from(new Set(siteKeys.flatMap((site) => Object.keys(registry[site]))));
+    return {
+      site: z.enum(siteKeys as [string, ...string[]]),
+      env: envKeys.length > 0 ? z.enum(envKeys as [string, ...string[]]) : z.string(),
+    };
+  } catch {
+    return { site: z.string(), env: z.string() };
+  }
+}
+
 export function createServer(): McpServer {
   const server = new McpServer({
     name: "wp-ops",
     version: "0.1.0",
   });
+
+  const { site: siteSchema, env: envSchema } = buildSiteEnvSchemas();
 
   server.tool(
     "security_scan",
@@ -19,8 +45,8 @@ export function createServer(): McpServer {
       "against a configured site/environment. Targeted (~2s) checks common WP-specific threats; " +
       "general (~3s) is a deeper malware sweep. Use 'both' after a suspected compromise.",
     {
-      site: z.string().describe('Site key from the wp-ops site registry (config/sites.json), e.g. "example.com"'),
-      env: z.string().describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),
       mode: z
         .enum(["targeted", "general", "both"])
         .default("targeted")
@@ -46,8 +72,8 @@ export function createServer(): McpServer {
       "written to disk on the remote host. Saves to a local backups directory " +
       "(default ~/wp-ops-backups/<site>/<env>/, override with WP_OPS_BACKUP_DIR).",
     {
-      site: z.string().describe('Site key from the wp-ops site registry (config/sites.json), e.g. "example.com"'),
-      env: z.string().describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),
     },
     async ({ site, env }) => {
       try {
@@ -74,8 +100,8 @@ export function createServer(): McpServer {
       "run immediately; anything else — updates, deletes, installs, search-replace, eval, etc. — requires " +
       "confirm: true, which should only be set after the user has explicitly approved that specific command.",
     {
-      site: z.string().describe('Site key from the wp-ops site registry (config/sites.json), e.g. "example.com"'),
-      env: z.string().describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),
       args: z
         .array(z.string())
         .min(1)
@@ -119,8 +145,8 @@ export function createServer(): McpServer {
         .min(1)
         .optional()
         .describe('URL(s) to audit, e.g. ["https://example.com", "https://example.com/about/"]'),
-      site: z.string().optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
-      env: z.string().optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      site: siteSchema.optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
       checkWww: z
         .boolean()
         .default(true)
@@ -194,8 +220,8 @@ export function createServer(): McpServer {
       "Returns count of pages with/without schema and which schema types are present. Pass either `siteUrl` or `site`+`env`.",
     {
       siteUrl: z.string().optional().describe('Site URL to audit, e.g. "https://example.com"'),
-      site: z.string().optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
-      env: z.string().optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      site: siteSchema.optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.optional().describe('Environment key for that site, e.g. "development", "staging", "production"'),
       pages: z
         .array(z.string())
         .optional()

--- a/mcp-server/src/tools/wpCli.ts
+++ b/mcp-server/src/tools/wpCli.ts
@@ -21,11 +21,31 @@ const SAFE_READ_VERBS = new Set([
   "check-update",
   "doctor",
   "export",
+  "size",
+  "tables",
+  "verify-checksums",
+  "pluck",
 ]);
 
+// Commands where the read/write verb is the third token rather than the second, because
+// the second token names a sub-resource rather than a verb (e.g. "wp cron event list").
+// Kept as an explicit per-command allowlist rather than blindly checking args[2] for every
+// command, since args[2] is often an arbitrary caller-supplied value (an option name, a
+// post ID, ...) that could coincidentally collide with a SAFE_READ_VERBS entry.
+const NESTED_RESOURCE_VERBS: Record<string, Set<string>> = {
+  cron: new Set(["event", "schedule"]),
+};
+
 export function isReadOnlyWpCommand(args: string[]): boolean {
-  const verb = args[1];
-  return verb !== undefined && SAFE_READ_VERBS.has(verb);
+  const [command, verbOrResource, thirdToken] = args;
+  if (verbOrResource !== undefined && SAFE_READ_VERBS.has(verbOrResource)) {
+    return true;
+  }
+  const nestedResources = command !== undefined ? NESTED_RESOURCE_VERBS[command] : undefined;
+  if (nestedResources && verbOrResource !== undefined && nestedResources.has(verbOrResource)) {
+    return thirdToken !== undefined && SAFE_READ_VERBS.has(thirdToken);
+  }
+  return false;
 }
 
 function runLocal(args: string[], localPath: string, wpBin: string, phpBin?: string): Promise<ExecResult> {


### PR DESCRIPTION
## Summary

Works through `docs/mcp-server-recommendations.md`'s quick wins and token-saving items:

- **Items 1-4** (config-only, no code): recommend user-scoped registration, document multi-site registry setup, CLAUDE.md integration, and pre-approving read-only tool permissions in `mcp-server/README.md`.
- **Items 5-6**: turned out to already be implemented (`wpBin`/`phpBin` overrides, `url` field, `site`/`env` on `redirect_audit`/`schema_audit`) — doc corrected to reflect actual code state instead of new work.
- **Item 7**: `site`/`env` tool parameters are now `z.enum(...)` built from the site registry at server start, so an invalid key is rejected client-side instead of costing a round trip. Falls back to `z.string()` if the registry isn't available yet.
- **Item 8**: widened the read-only allowlist (`db size`, `db tables`, `core verify-checksums`, `option pluck`) and added a `NESTED_RESOURCE_VERBS` allowlist for `wp cron event list`-shaped commands, without blindly trusting `args[2]` for every command (`wp option update list <value>` still correctly requires confirmation).

CHANGELOG's `[Unreleased]` section is now `[3.24.0]`. Items 9-11 (output capping, tighter tool descriptions, a new `url_audit` tool) remain open for a follow-up.

## Test plan

- [x] `npm run build` (tsc) passes clean in `mcp-server/`
- [x] Manual test matrix for `isReadOnlyWpCommand` covering all doc examples plus the `option update list` false-positive-avoidance case
- [ ] Manual MCP client smoke test against a registered site (not run in this session)