### PR TITLE
Add db-pull.sh: positional-arg wrapper for pulling remote DBs into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.26.0] - 2026-08-03
+
+### Added
+
+- **scripts/backup** - `db-pull.sh`: positional-argument wrapper (`wp-ops db-pull example.com production`) that pulls a remote site's database into local development over SSH, adapted from `imagewize.com/scripts/pull-db.sh` and generalized — no hardcoded site table. Runs via `trellis vm shell` and reads both the remote and local `siteurl` at run time through WP-CLI instead of guessing URL suffixes, so it isn't tied to any one site's naming convention. Backs up the current development database before overwriting it, prompts for confirmation (`--yes`/`-y` to skip), and supports multisite via `--multisite` (scopes `search-replace` with `--url` and fixes `wp_blogs` domains). Complements the existing `trellis/backup/database-pull.yml` playbook, which stays the better fit for automated/scheduled pulls; `trellis/backup/README.md` now points at the script instead of its old hand-copied inline-bash template. Addresses Gap 2 of `docs/wp-ops-recommendations.md`.
+
 ## [3.25.1] - 2026-08-03
 
 ### Fixed

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -75,7 +75,7 @@ practice.
 
 ---
 
-## Gap 2: `db-pull` ergonomics
+## Gap 2: `db-pull` ergonomics — done (`scripts/backup/db-pull.sh`, 2026-08-03)
 
 The capability exists — `trellis/backup/database-pull.yml` pulls a remote database
 into development with URL search-replace, and resolves as `wp-ops database-pull`.
@@ -178,7 +178,7 @@ generalized to arguments, as was done for `run-monitoring.sh`.
 
 1. **Gap 3** — delete the stale seo-strategy monitoring fork. Costs nothing, stops
    the divergence that produced the false "missing tools" list.
-2. **Gap 2** — `scripts/backup/db-pull.sh`. Highest daily value.
+2. **Gap 2** — `scripts/backup/db-pull.sh`. Highest daily value. **Done.**
 3. **Gap 5 "Take" rows** — four scripts, mechanical work.
 4. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap.
 5. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to.

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -41,6 +41,70 @@
   },
   {
     "category": "scripts",
+    "key": "scripts/backup/db-pull",
+    "description": "Pull a remote site's database into development via SSH, with URL search-replace",
+    "script_path": "scripts/backup/db-pull.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "trellis"
+    ],
+    "doc": "trellis/backup/README.md",
+    "args": [
+      {
+        "name": "site-name",
+        "required_raw": "optional",
+        "required": false,
+        "default": "example.com",
+        "description": "Site name as in wordpress_sites.yml",
+        "raw": "site-name    optional  {example.com}  Site name as in wordpress_sites.yml"
+      },
+      {
+        "name": "environment",
+        "required_raw": "optional",
+        "required": false,
+        "choices": [
+          "production",
+          "staging"
+        ],
+        "description": "Remote environment to pull from",
+        "raw": "environment  optional  {production|staging}  Remote environment to pull from"
+      }
+    ],
+    "flags": [
+      {
+        "name": "--host",
+        "required_raw": "optional",
+        "required": false,
+        "default": "example.com",
+        "description": "SSH host to pull from (default: site-name)",
+        "raw": "--host       optional  {example.com}  SSH host to pull from (default: site-name)"
+      },
+      {
+        "name": "--multisite",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Also fix wp_blogs domains and scope search-replace with --url",
+        "raw": "--multisite  optional  {}  Also fix wp_blogs domains and scope search-replace with --url"
+      },
+      {
+        "name": "--yes",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Skip the confirmation prompt",
+        "raw": "--yes        optional  {}  Skip the confirmation prompt"
+      }
+    ],
+    "examples": [
+      "wp-ops db-pull example.com production",
+      "wp-ops db-pull network.example.com production --multisite --yes"
+    ],
+    "manifest_category": "backup",
+    "display_category": "scripts",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
     "key": "scripts/backup/site-backup",
     "description": "Full backup of a Trellis site: database, uploads, config, and plugins/themes",
     "script_path": "scripts/backup/site-backup.sh",

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -10,8 +10,8 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(c.Entries) != 67 {
-		t.Errorf("len(Entries) = %d, want 67 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0)", len(c.Entries))
+	if len(c.Entries) != 68 {
+		t.Errorf("len(Entries) = %d, want 68 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0, +1 for scripts/backup/db-pull added in 3.26.0)", len(c.Entries))
 	}
 }
 
@@ -124,8 +124,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	scriptsRaw := c.CommandsIn("scripts")
-	if len(scriptsRaw) != 35 {
-		t.Errorf("CommandsIn(scripts) = %d entries, want 35 (directory-based grouping must be unaffected by the display split)", len(scriptsRaw))
+	if len(scriptsRaw) != 36 {
+		t.Errorf("CommandsIn(scripts) = %d entries, want 36 (directory-based grouping must be unaffected by the display split)", len(scriptsRaw))
 	}
 	for _, e := range scriptsRaw {
 		if e.Category != "scripts" {
@@ -134,8 +134,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	scriptsDisplay := c.CommandsInDisplay("scripts")
-	if len(scriptsDisplay) != 11 {
-		t.Errorf("CommandsInDisplay(scripts) = %d entries, want 11 (backup, git, misc, sync, woocommerce)", len(scriptsDisplay))
+	if len(scriptsDisplay) != 12 {
+		t.Errorf("CommandsInDisplay(scripts) = %d entries, want 12 (backup, git, misc, sync, woocommerce)", len(scriptsDisplay))
 	}
 
 	monitoring := c.CommandsInDisplay("monitoring")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,7 @@ This directory contains utility scripts organized into functional areas:
 scripts/
 ├── backup/                      # Backup automation scripts
 │   ├── db-backup.sh            # Database-only backup with URL replacement
+│   ├── db-pull.sh              # Pull a remote database into development via SSH
 │   └── site-backup.sh          # Complete site backup (DB + files + config)
 ├── git/                         # Git/GitHub utilities
 │   ├── create-pr.sh            # AI-powered GitHub PR creation
@@ -1221,6 +1222,39 @@ Trellis-aware database backup with optional URL replacement for staging/developm
     ├── {env}_db_with_urls_{timestamp}.sql.gz  # staging/dev only
     └── backup_info_{timestamp}.txt
 ```
+
+---
+
+### db-pull.sh
+
+Pulls a remote site's database into local development over SSH, with URL search-replace. Runs on your machine — uses `trellis vm shell` to reach the local dev VM, and SSHes from inside it straight to the remote host, so the dump streams through with no intermediate file on either end.
+
+#### Features
+
+- **No remote temp file**: streams `wp db export` over SSH directly into `wp db import`
+- **Dynamic URL detection**: reads both the remote and local `siteurl` at run time via WP-CLI — no hardcoded per-site URL table
+- **Safety backup**: exports the current development database before overwriting it
+- **Multisite support** (`--multisite`): scopes `search-replace` with `--url` and fixes `wp_blogs` domains
+- **Confirmation prompt**: skip with `--yes`/`-y`
+
+#### Usage
+
+```bash
+export TRELLIS_DIR=/path/to/trellis
+
+# Pull production into development
+./db-pull.sh example.com production
+
+# Pull from a host that differs from the site key, skip the prompt
+./db-pull.sh example.com staging --host staging.example.com --yes
+
+# Multisite network
+./db-pull.sh network.example.com production --multisite
+```
+
+Via wp-ops: `wp-ops db-pull example.com production`.
+
+For automated/repeatable pulls instead, use `trellis/backup/database-pull.yml` (`wp-ops trellis database-pull -e site=example.com -e env=production`) — it has no `trellis vm shell` dependency and is the better fit for CI/scheduled jobs. See [trellis/backup/README.md](../trellis/backup/README.md) for the tradeoffs.
 
 ---
 

--- a/scripts/backup/db-pull.sh
+++ b/scripts/backup/db-pull.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+
+# Trellis Database Pull Script
+# Pull a remote site's database into local development via SSH, with URL
+# search-replace and optional multisite domain fixup.
+#
+# Runs on your machine, inside a Trellis project. Uses `trellis vm shell` to
+# reach the local development VM, and SSHes from inside it straight to the
+# remote host — the dump streams over that pipe with no intermediate file on
+# either end.
+#
+# Usage:
+#   TRELLIS_DIR=/path/to/trellis ./db-pull.sh [site-name] [environment] [options]
+#   wp-ops db-pull example.com production
+#
+# Options:
+#   --host HOST    SSH host to pull from (default: site-name)
+#   --multisite    Also fix wp_blogs domains and scope search-replace with --url
+#   --yes, -y      Skip the confirmation prompt
+#
+# For a from-scratch look at each underlying step, or the Ansible-playbook
+# alternative, see trellis/backup/README.md.
+#
+# @desc     Pull a remote site's database into development via SSH, with URL search-replace
+# @category backup
+# @runs     local
+# @requires trellis
+# @arg      site-name    optional  {example.com}  Site name as in wordpress_sites.yml
+# @arg      environment  optional  {production|staging}  Remote environment to pull from
+# @flag     --host       optional  {example.com}  SSH host to pull from (default: site-name)
+# @flag     --multisite  optional  {}  Also fix wp_blogs domains and scope search-replace with --url
+# @flag     --yes        optional  {}  Skip the confirmation prompt
+# @example  wp-ops db-pull example.com production
+# @example  wp-ops db-pull network.example.com production --multisite --yes
+# @doc      trellis/backup/README.md
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") [site-name] [environment] [options]"
+    echo ""
+    echo "Pull a remote site's database into local development via SSH, with"
+    echo "URL search-replace. Streams the dump straight from the remote host"
+    echo "into the local VM's database — no intermediate file either side."
+    echo ""
+    echo "Arguments:"
+    echo "  site-name    Site name under /srv/www, as in wordpress_sites.yml (default: example.com)"
+    echo "  environment  production | staging (default: production) — used for messaging only"
+    echo ""
+    echo "Options:"
+    echo "  --host HOST  SSH host to pull from (default: site-name)"
+    echo "  --multisite  Also fix wp_blogs domains and scope search-replace with --url"
+    echo "  --yes, -y    Skip the confirmation prompt"
+    echo ""
+    echo "Requires TRELLIS_DIR set to your Trellis project (used to run"
+    echo "'trellis vm shell'):"
+    echo "  TRELLIS_DIR=/path/to/trellis $(basename "$0") example.com production"
+    echo ""
+    echo "For automated/repeatable pulls instead, use the Ansible playbook:"
+    echo "  wp-ops trellis database-pull -e site=example.com -e env=production"
+}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" >&2; }
+warning() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+
+# Parse arguments
+POSITIONAL=()
+REMOTE_HOST=""
+MULTISITE=false
+SKIP_CONFIRM=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --host)
+            REMOTE_HOST="${2:-}"
+            shift 2
+            ;;
+        --multisite)
+            MULTISITE=true
+            shift
+            ;;
+        --yes|-y)
+            SKIP_CONFIRM=true
+            shift
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+SITE_NAME="${POSITIONAL[0]:-example.com}"
+ENVIRONMENT="${POSITIONAL[1]:-production}"
+REMOTE_HOST="${REMOTE_HOST:-$SITE_NAME}"
+
+if [[ "$ENVIRONMENT" == "development" ]]; then
+    error "development is not a valid source environment (can't pull development into itself)."
+    exit 1
+fi
+
+TRELLIS_DIR="${TRELLIS_DIR:-}"
+if [[ -z "$TRELLIS_DIR" ]]; then
+    error "TRELLIS_DIR is not set. Point it at your Trellis project:"
+    echo "  export TRELLIS_DIR=/path/to/trellis" >&2
+    exit 1
+fi
+
+if [[ ! -f "$TRELLIS_DIR/ansible.cfg" ]]; then
+    error "TRELLIS_DIR ($TRELLIS_DIR) doesn't look like a Trellis project (no ansible.cfg found)."
+    exit 1
+fi
+
+if ! command -v trellis &> /dev/null; then
+    error "trellis CLI not found. Install it: https://github.com/roots/trellis-cli"
+    exit 1
+fi
+
+REMOTE_PATH="/srv/www/${SITE_NAME}/current"
+WORKDIR="/srv/www/${SITE_NAME}/current"
+WP_PATH="web/wp"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Database Pull: ${SITE_NAME} (${ENVIRONMENT})${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "${YELLOW}WARNING: This will replace your local development database.${NC}"
+echo -e "  Remote: web@${REMOTE_HOST}:${REMOTE_PATH}"
+echo -e "  Local:  ${TRELLIS_DIR} (${WORKDIR})"
+[[ "$MULTISITE" == true ]] && echo -e "  Multisite domain fixup: enabled"
+echo ""
+
+if [[ "$SKIP_CONFIRM" == true ]]; then
+    log "Skipping confirmation (--yes)."
+else
+    read -p "Continue? (y/N) " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log "Aborted."
+        exit 0
+    fi
+fi
+
+SEARCH_REPLACE_CMD="wp search-replace \"\$PROD_URL\" \"\$DEV_URL\" --all-tables --precise --path=${WP_PATH}"
+MULTISITE_STEPS=""
+FLUSH_STEP_NUM=6
+if [[ "$MULTISITE" == true ]]; then
+    SEARCH_REPLACE_CMD="${SEARCH_REPLACE_CMD} --url=\"\$PROD_URL\""
+    FLUSH_STEP_NUM=7
+    MULTISITE_STEPS="
+echo ''
+echo '=== Step 6: Fixing multisite blog domains ==='
+PROD_HOST=\$(echo \"\$PROD_URL\" | sed -E 's#^https?://##; s#/.*##')
+DEV_HOST=\$(echo \"\$DEV_URL\" | sed -E 's#^https?://##; s#/.*##')
+wp db query \"UPDATE wp_blogs SET domain = REPLACE(domain, '\${PROD_HOST}', '\${DEV_HOST}');\" --path=${WP_PATH}
+"
+fi
+
+PULL_COMMAND="
+set -e
+mkdir -p database_backup
+
+echo '=== Step 1: Reading current development URL ==='
+DEV_URL=\$(wp option get siteurl --path=${WP_PATH})
+echo \"  Development: \$DEV_URL\"
+
+echo ''
+echo '=== Step 2: Backing up current development database ==='
+wp db export database_backup/dev_backup_\$(date +%Y%m%d_%H%M%S).sql.gz --path=${WP_PATH} && echo '✓ Backup created'
+
+echo ''
+echo '=== Step 3: Pulling ${ENVIRONMENT} database from ${REMOTE_HOST} ==='
+PROD_URL=\$(ssh -o StrictHostKeyChecking=no web@${REMOTE_HOST} 'cd ${REMOTE_PATH} && wp option get siteurl --path=${WP_PATH}')
+echo \"  ${ENVIRONMENT}: \$PROD_URL\"
+ssh -o StrictHostKeyChecking=no web@${REMOTE_HOST} 'cd ${REMOTE_PATH} && wp db export - --path=${WP_PATH}' | gzip > /tmp/${SITE_NAME//./_}_import.sql.gz && echo '✓ Downloaded'
+
+echo ''
+echo '=== Step 4: Importing into development ==='
+gunzip < /tmp/${SITE_NAME//./_}_import.sql.gz | wp db import - --path=${WP_PATH} && echo '✓ Imported'
+rm -f /tmp/${SITE_NAME//./_}_import.sql.gz
+
+echo ''
+echo '=== Step 5: Running search-replace for URLs ==='
+${SEARCH_REPLACE_CMD}
+${MULTISITE_STEPS}
+echo ''
+echo '=== Step ${FLUSH_STEP_NUM}: Flushing cache ==='
+wp cache flush --path=${WP_PATH} && echo '✓ Cache flushed'
+
+echo ''
+echo '=== Database pull complete! ==='
+echo \"Your local site (\$DEV_URL) now has the ${ENVIRONMENT} database.\"
+"
+
+(cd "$TRELLIS_DIR" && trellis vm shell --workdir "$WORKDIR" -- bash -c "$PULL_COMMAND")
+
+echo ""
+echo -e "${GREEN}Database pull complete.${NC}"
+echo ""
+echo -e "Next steps:"
+echo -e "  1. Visit your local site in the browser"
+echo -e "  2. Check that URLs are correct"
+echo -e "  3. Test site functionality"
+
+exit 0

--- a/trellis/backup/README.md
+++ b/trellis/backup/README.md
@@ -123,6 +123,8 @@ ansible-playbook database-pull.yml -e site=example.com -e env=staging
 
 For interactive development work, you can use a direct shell script approach that runs inside the Trellis VM. This method is **simpler and faster** than the Ansible playbook, using SSH pipes to stream the database directly without intermediate files.
 
+**Prefer [`scripts/backup/db-pull.sh`](../../scripts/backup/db-pull.sh)** (`wp-ops db-pull example.com production`) over hand-copying the inline command below — it's this same approach, generalized: it reads the production and development URLs at run time via WP-CLI instead of hardcoding them, backs up the current development database first, prompts for confirmation (`--yes` to skip), and supports multisite via `--multisite`. The raw steps are kept below for reference and for cases where you want to run/adapt them by hand.
+
 **Standard site example:**
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `scripts/backup/db-pull.sh` (`wp-ops db-pull example.com production`), a positional-argument wrapper around the manual "trellis vm shell + SSH pipe" database pull currently only documented as a copy-paste template in `trellis/backup/README.md`
- Adapted from `imagewize.com/scripts/pull-db.sh` and generalized: reads the remote and local `siteurl` at run time via WP-CLI instead of a hardcoded per-site URL table, backs up the current dev database before overwriting it, prompts for confirmation (`--yes`/`-y` to skip), and supports multisite via `--multisite` (scopes `search-replace` with `--url` and fixes `wp_blogs` domains)
- Complements, doesn't replace, `trellis/backup/database-pull.yml` — the playbook stays the right tool for automated/scheduled pulls; this script is for interactive dev work
- Updates `trellis/backup/README.md` and `scripts/README.md` to point at the new script, regenerates the Go catalog, bumps its hardcoded entry-count test assertions, and adds a CHANGELOG entry (3.26.0)
- Addresses Gap 2 of `docs/wp-ops-recommendations.md` ("highest-value single script" in that doc), which is marked done

## Test plan
- [x] `bash -n scripts/backup/db-pull.sh` — syntax check
- [x] Dry-run against a fake `trellis` binary that syntax-checks the generated inner command instead of running it against a real VM, for both the single-site and `--multisite` code paths
- [x] `--help`, missing-`TRELLIS_DIR`, and `environment=development` error paths exercised manually
- [x] `wp-ops manifest lint` — clean
- [x] `./go/scripts/parity-check.sh` — 8/8 passed, bash and Go catalogs agree field-for-field
- [x] `go test ./...` — all green after bumping the catalog entry-count assertions