### PR TITLE
Upstream Gap 5 scripts: TTFB testing, page-draft import, deny-list auditing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.0] - 2026-08-03
+
+### Added
+
+- **scripts/monitoring** - `ttfb-test.sh`: runs `curl` against a URL 5 times, averages TTFB/DNS/connect/SSL timings, rates the result against Google's Core Web Vitals TTFB benchmarks, and writes a detailed report with optimization recommendations to `audits/`. Adapted from `seo-strategy/tools/scripts/ttfb-test.sh`, generalized off the hardcoded `imagewize.com` default URL — the URL is now a required argument.
+- **scripts/monitoring** - `remote-ttfb-ua.sh`: runs `curl` on the server itself over SSH (so local network distance doesn't skew the measurement), once per URL for each of the default, Googlebot, AhrefsBot, and Screaming Frog user agents. Adapted from `seo-strategy/tools/scripts/remote-ttfb-ua.sh`, generalized off the hardcoded `web@imagewize.com` SSH host and default URL list — both are now required arguments. Placed under `scripts/monitoring/` rather than `wordpress-utilities/speed-optimization/` (as `docs/wp-ops-recommendations.md` Gap 5 originally suggested) because the CLI treats every file under `wordpress-utilities/` as a copy-paste-into-a-theme reference snippet and never executes it; the speed-optimization README stays the docs home via `@doc`.
+- **wp-cli/content-creation** - `import-page-draft.sh`: updates an *existing* WordPress page's content from an HTML draft, locally and/or in production, stripping Blade `{{-- ... --}}` doc-comments before import. Complements `page-creation.sh`, which only creates new pages. Adapted from `seo-strategy/tools/scripts/import-page-draft.sh`, generalized off the hardcoded `imagewize.com` paths — site name is now a positional argument, and the local Trellis/Bedrock checkout dirs come from `TRELLIS_DIR`/`SITE_DIR` env vars, matching `db-pull.sh`'s convention.
+- **trellis/security** - `check-deny-ips.sh`: bulk-checks every individual IP already in a Trellis project's `deny-ips.conf.j2` against AbuseIPDB, so blocks that are no longer warranted (score dropped to 0, no recent reports) are easy to spot; CIDR subnet entries are skipped and reported as a count instead, since AbuseIPDB checks single IPs, not ranges. Adapted from `imagewize.com/scripts/check-deny-ips.sh`, generalized off the hardcoded conf path (now `TRELLIS_DIR`-relative) and dropped the original's hand-picked, site-specific hardcoded subnet IP list in favor of actually skipping subnets, matching what the script's own comment already claimed it did. Reuses `check-ips.sh`'s existing `trellis/security/.env` instead of introducing a second env file.
+
+All four address the "Take" rows of Gap 5 in `docs/wp-ops-recommendations.md`, and are manifest-annotated and resolve by basename in both the bash and Go CLIs (`go/scripts/parity-check.sh` passes 8/8; `catalog.json` regenerated).
+
 ## [3.26.0] - 2026-08-03
 
 ### Added

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -1083,6 +1083,42 @@
   },
   {
     "category": "scripts",
+    "key": "scripts/monitoring/remote-ttfb-ua",
+    "description": "Measure TTFB from the server itself, across multiple user agents (default, Googlebot, AhrefsBot, Screaming Frog)",
+    "script_path": "scripts/monitoring/remote-ttfb-ua.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "ssh"
+    ],
+    "doc": "wordpress-utilities/speed-optimization/README.md",
+    "args": [
+      {
+        "name": "ssh-host",
+        "required_raw": "required",
+        "required": true,
+        "default": "web@example.com",
+        "description": "SSH user@host to run curl from",
+        "raw": "ssh-host  required  {web@example.com}  SSH user@host to run curl from"
+      },
+      {
+        "name": "url",
+        "required_raw": "required",
+        "required": true,
+        "default": "https://example.com",
+        "description": "URL to test (repeatable)",
+        "raw": "url       required  {https://example.com}  URL to test (repeatable)"
+      }
+    ],
+    "examples": [
+      "wp-ops scripts/monitoring/remote-ttfb-ua web@example.com https://example.com/"
+    ],
+    "manifest_category": "monitoring",
+    "display_category": "monitoring",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
     "key": "scripts/monitoring/run-monitoring",
     "description": "Run traffic, security, AI-bot, and error monitoring together and save timestamped reports",
     "script_path": "scripts/monitoring/run-monitoring.sh",
@@ -1245,6 +1281,35 @@
     "examples": [
       "ssh web@example.com 'bash -s' \u003c traffic-monitor.sh",
       "ssh web@example.com 'bash -s' \u003c traffic-monitor.sh /srv/www/demo.example.com/logs/access.log 6"
+    ],
+    "manifest_category": "monitoring",
+    "display_category": "monitoring",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
+    "key": "scripts/monitoring/ttfb-test",
+    "description": "Measure TTFB for a URL over several requests and write a report with recommendations",
+    "script_path": "scripts/monitoring/ttfb-test.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "curl",
+      "bc"
+    ],
+    "doc": "wordpress-utilities/speed-optimization/README.md",
+    "args": [
+      {
+        "name": "url",
+        "required_raw": "required",
+        "required": true,
+        "default": "https://example.com",
+        "description": "URL to test",
+        "raw": "url  required  {https://example.com}  URL to test"
+      }
+    ],
+    "examples": [
+      "wp-ops scripts/monitoring/ttfb-test https://example.com"
     ],
     "manifest_category": "monitoring",
     "display_category": "monitoring",
@@ -2353,6 +2418,36 @@
   },
   {
     "category": "trellis",
+    "key": "trellis/security/check-deny-ips",
+    "description": "Check every individual IP in a Trellis deny-ips.conf.j2 against AbuseIPDB",
+    "script_path": "trellis/security/check-deny-ips.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "curl",
+      "jq",
+      "trellis"
+    ],
+    "doc": "trellis/security/README.md",
+    "flags": [
+      {
+        "name": "--full",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Full JSON output per IP via check-ips.sh, instead of the compact summary",
+        "raw": "--full  optional  {}  Full JSON output per IP via check-ips.sh, instead of the compact summary"
+      }
+    ],
+    "examples": [
+      "wp-ops trellis/security/check-deny-ips",
+      "wp-ops trellis/security/check-deny-ips --full"
+    ],
+    "manifest_category": "security",
+    "display_category": "trellis",
+    "annotated": true
+  },
+  {
+    "category": "trellis",
     "key": "trellis/security/check-ips",
     "description": "Check IP addresses against AbuseIPDB threat intelligence",
     "script_path": "trellis/security/check-ips.sh",
@@ -2395,6 +2490,71 @@
     ],
     "manifest_category": "updater",
     "display_category": "trellis",
+    "annotated": true
+  },
+  {
+    "category": "wp-cli",
+    "key": "wp-cli/content-creation/import-page-draft",
+    "description": "Update an existing WordPress page from an HTML draft, locally and/or in production",
+    "script_path": "wp-cli/content-creation/import-page-draft.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "ssh",
+      "trellis"
+    ],
+    "args": [
+      {
+        "name": "draft-file",
+        "required_raw": "required",
+        "required": true,
+        "default": "draft.html",
+        "description": "Local HTML draft with block markup",
+        "raw": "draft-file   required  {draft.html}  Local HTML draft with block markup"
+      },
+      {
+        "name": "page-id",
+        "required_raw": "required",
+        "required": true,
+        "default": "7673",
+        "description": "WordPress page ID to update",
+        "raw": "page-id      required  {7673}  WordPress page ID to update"
+      },
+      {
+        "name": "site-name",
+        "required_raw": "optional",
+        "required": false,
+        "default": "example.com",
+        "description": "Site name under /srv/www (default: example.com)",
+        "raw": "site-name    optional  {example.com}  Site name under /srv/www (default: example.com)"
+      },
+      {
+        "name": "environment",
+        "required_raw": "optional",
+        "required": false,
+        "choices": [
+          "local",
+          "production",
+          "both"
+        ],
+        "description": "Where to apply the update (default: local)",
+        "raw": "environment  optional  {local|production|both}  Where to apply the update (default: local)"
+      },
+      {
+        "name": "template",
+        "required_raw": "optional",
+        "required": false,
+        "default": "template-no-header.blade.php",
+        "description": "Optional _wp_page_template value to set",
+        "raw": "template     optional  {template-no-header.blade.php}  Optional _wp_page_template value to set"
+      }
+    ],
+    "examples": [
+      "wp-ops wp-cli/content-creation/import-page-draft draft.html 7673",
+      "wp-ops wp-cli/content-creation/import-page-draft draft.html 7673 example.com both template-no-header.blade.php"
+    ],
+    "manifest_category": "content-creation",
+    "display_category": "wp-cli",
     "annotated": true
   },
   {

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -10,8 +10,8 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(c.Entries) != 68 {
-		t.Errorf("len(Entries) = %d, want 68 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0, +1 for scripts/backup/db-pull added in 3.26.0)", len(c.Entries))
+	if len(c.Entries) != 72 {
+		t.Errorf("len(Entries) = %d, want 72 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0, +1 for scripts/backup/db-pull added in 3.26.0, +4 for ttfb-test/remote-ttfb-ua/import-page-draft/check-deny-ips added in 3.27.0)", len(c.Entries))
 	}
 }
 
@@ -124,8 +124,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	scriptsRaw := c.CommandsIn("scripts")
-	if len(scriptsRaw) != 36 {
-		t.Errorf("CommandsIn(scripts) = %d entries, want 36 (directory-based grouping must be unaffected by the display split)", len(scriptsRaw))
+	if len(scriptsRaw) != 38 {
+		t.Errorf("CommandsIn(scripts) = %d entries, want 38 (directory-based grouping must be unaffected by the display split; +2 for ttfb-test/remote-ttfb-ua added in 3.27.0)", len(scriptsRaw))
 	}
 	for _, e := range scriptsRaw {
 		if e.Category != "scripts" {
@@ -139,8 +139,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	monitoring := c.CommandsInDisplay("monitoring")
-	if len(monitoring) != 10 {
-		t.Errorf("CommandsInDisplay(monitoring) = %d entries, want 10", len(monitoring))
+	if len(monitoring) != 12 {
+		t.Errorf("CommandsInDisplay(monitoring) = %d entries, want 12 (+2 for ttfb-test/remote-ttfb-ua added in 3.27.0)", len(monitoring))
 	}
 	for _, e := range monitoring {
 		if e.Category != "scripts" {

--- a/scripts/monitoring/remote-ttfb-ua.sh
+++ b/scripts/monitoring/remote-ttfb-ua.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Remote TTFB test with multiple user agents. Runs curl on the server itself
+# (via SSH) rather than from your machine, so DNS/network distance to the
+# server doesn't skew the measurement — and tests how the server responds to
+# common crawler user agents (Googlebot, AhrefsBot, Screaming Frog) alongside
+# a default request, which matters when a WAF or caching layer treats bots
+# differently from regular visitors.
+#
+# Usage:
+#   ./remote-ttfb-ua.sh <ssh-host> <url1> [url2 ...]
+#   ./remote-ttfb-ua.sh web@example.com https://example.com/ https://example.com/blog/
+#
+# Requires: SSH access to the given host, with wp-ops not needed there — this
+# only shells out to curl on the remote side.
+#
+# @desc     Measure TTFB from the server itself, across multiple user agents (default, Googlebot, AhrefsBot, Screaming Frog)
+# @category monitoring
+# @runs     local
+# @requires ssh
+# @arg      ssh-host  required  {web@example.com}  SSH user@host to run curl from
+# @arg      url       required  {https://example.com}  URL to test (repeatable)
+# @example  wp-ops scripts/monitoring/remote-ttfb-ua web@example.com https://example.com/
+# @doc      wordpress-utilities/speed-optimization/README.md
+
+set -euo pipefail
+
+SSH_HOST="${1:-}"
+shift || true
+urls=("$@")
+
+if [ -z "$SSH_HOST" ] || [ "${#urls[@]}" -eq 0 ]; then
+  echo "Usage: $0 <ssh-host> <url1> [url2 ...]"
+  echo "Example: $0 web@example.com https://example.com/"
+  exit 1
+fi
+
+DATE=$(date +%Y-%m-%d_%H-%M-%S)
+OUT_DIR="audits"
+OUT_FILE="${OUT_DIR}/remote-ttfb-ua-${DATE}.txt"
+
+mkdir -p "${OUT_DIR}"
+
+ssh "${SSH_HOST}" "bash -s -- ${urls[@]}" <<'SH' > "${OUT_FILE}"
+set -euo pipefail
+
+urls=("$@")
+
+declare -A uas
+uas[default]=""
+uas[googlebot]="Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+uas[ahrefs]="Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)"
+uas[screamingfrog]="Mozilla/5.0 (compatible; Screaming Frog SEO Spider/20.0; +http://www.screamingfrog.co.uk/seo-spider/)"
+
+for label in "${!uas[@]}"; do
+  ua="${uas[$label]}"
+  echo "===== UA: ${label} ====="
+  for url in "${urls[@]}"; do
+    echo "URL: ${url}"
+    if [ -n "$ua" ]; then
+      curl -s -o /dev/null -D - -A "$ua" -w "ttfb=%{time_starttransfer} total=%{time_total} code=%{http_code}\n" "$url"
+    else
+      curl -s -o /dev/null -D - -w "ttfb=%{time_starttransfer} total=%{time_total} code=%{http_code}\n" "$url"
+    fi
+    echo ""
+  done
+  echo ""
+  echo ""
+done
+SH
+
+echo "Saved: ${OUT_FILE}"

--- a/scripts/monitoring/ttfb-test.sh
+++ b/scripts/monitoring/ttfb-test.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+#
+# Time to First Byte (TTFB) Test Script
+# Purpose: Measure server response time for a WordPress URL, averaged over
+#          several requests, and write a detailed report with optimization
+#          recommendations.
+#
+# Usage: ./ttfb-test.sh <url>
+#   Example: ./ttfb-test.sh https://example.com/blog/
+#
+# TTFB Benchmarks (Google Core Web Vitals):
+#   Good: < 800ms
+#   Needs Improvement: 800ms - 1800ms
+#   Poor: > 1800ms
+#
+# @desc     Measure TTFB for a URL over several requests and write a report with recommendations
+# @category monitoring
+# @runs     local
+# @requires curl bc
+# @arg      url  required  {https://example.com}  URL to test
+# @example  wp-ops scripts/monitoring/ttfb-test https://example.com
+# @doc      wordpress-utilities/speed-optimization/README.md
+
+set -e
+
+TEST_URL="$1"
+if [ -z "$TEST_URL" ]; then
+  echo "Usage: $0 <url>"
+  exit 1
+fi
+
+# Configuration
+OUTPUT_DIR="audits"
+DATE=$(date +%Y-%m-%d_%H-%M-%S)
+REPORT_FILE="${OUTPUT_DIR}/ttfb-test-${DATE}.txt"
+ITERATIONS=5  # Number of tests to run for averaging
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+echo "=========================================="
+echo "Time to First Byte (TTFB) Test"
+echo "URL: ${TEST_URL}"
+echo "Iterations: ${ITERATIONS}"
+echo "Date: ${DATE}"
+echo "=========================================="
+echo ""
+
+# Function to measure TTFB
+measure_ttfb() {
+  local url=$1
+
+  # Use curl with -w flag to get timing information
+  # Format: time_namelookup,time_connect,time_appconnect,time_pretransfer,time_starttransfer,time_total
+  curl -o /dev/null -s -w "%{time_namelookup},%{time_connect},%{time_appconnect},%{time_pretransfer},%{time_starttransfer},%{time_total},%{http_code}\n" "$url"
+}
+
+# Function to convert seconds to milliseconds
+to_ms() {
+  echo "scale=0; $1 * 1000 / 1" | bc
+}
+
+# Run multiple tests
+echo "Running ${ITERATIONS} TTFB measurements..."
+echo ""
+
+declare -a ttfb_values
+declare -a dns_values
+declare -a connect_values
+declare -a ssl_values
+
+for i in $(seq 1 $ITERATIONS); do
+  echo -n "Test $i/$ITERATIONS... "
+
+  # Get timing data
+  timing_data=$(measure_ttfb "$TEST_URL")
+
+  # Parse timing data
+  IFS=',' read -r dns_time connect_time ssl_time pretransfer_time ttfb total_time http_code <<< "$timing_data"
+
+  # Convert to milliseconds
+  dns_ms=$(to_ms "$dns_time")
+  connect_ms=$(to_ms "$connect_time")
+  ssl_ms=$(to_ms "$ssl_time")
+  ttfb_ms=$(to_ms "$ttfb")
+  total_ms=$(to_ms "$total_time")
+
+  # Store TTFB values for averaging
+  ttfb_values+=("$ttfb_ms")
+  dns_values+=("$dns_ms")
+  connect_values+=("$connect_ms")
+  ssl_values+=("$ssl_ms")
+
+  echo "TTFB: ${ttfb_ms}ms (HTTP ${http_code})"
+
+  # Small delay between tests
+  sleep 1
+done
+
+echo ""
+echo "=========================================="
+echo "Calculating Statistics..."
+echo "=========================================="
+echo ""
+
+# Calculate average TTFB
+sum=0
+for val in "${ttfb_values[@]}"; do
+  sum=$((sum + val))
+done
+avg_ttfb=$((sum / ITERATIONS))
+
+# Calculate min and max
+min_ttfb=${ttfb_values[0]}
+max_ttfb=${ttfb_values[0]}
+for val in "${ttfb_values[@]}"; do
+  if [ "$val" -lt "$min_ttfb" ]; then
+    min_ttfb=$val
+  fi
+  if [ "$val" -gt "$max_ttfb" ]; then
+    max_ttfb=$val
+  fi
+done
+
+# Calculate average DNS
+sum_dns=0
+for val in "${dns_values[@]}"; do
+  sum_dns=$((sum_dns + val))
+done
+avg_dns=$((sum_dns / ITERATIONS))
+
+# Calculate average Connect
+sum_connect=0
+for val in "${connect_values[@]}"; do
+  sum_connect=$((sum_connect + val))
+done
+avg_connect=$((sum_connect / ITERATIONS))
+
+# Calculate average SSL
+sum_ssl=0
+for val in "${ssl_values[@]}"; do
+  sum_ssl=$((sum_ssl + val))
+done
+avg_ssl=$((sum_ssl / ITERATIONS))
+
+# Determine performance rating
+if [ "$avg_ttfb" -lt 800 ]; then
+  rating="GOOD"
+  rating_color="${GREEN}"
+  rating_icon="✓"
+elif [ "$avg_ttfb" -lt 1800 ]; then
+  rating="NEEDS IMPROVEMENT"
+  rating_color="${YELLOW}"
+  rating_icon="⚠"
+else
+  rating="POOR"
+  rating_color="${RED}"
+  rating_icon="❌"
+fi
+
+# Display results
+echo "TTFB RESULTS"
+echo "------------"
+echo -e "Average TTFB: ${rating_color}${avg_ttfb}ms${NC} (${rating_icon} ${rating})"
+echo "Min TTFB: ${min_ttfb}ms"
+echo "Max TTFB: ${max_ttfb}ms"
+echo ""
+
+echo "TIMING BREAKDOWN (Average)"
+echo "--------------------------"
+echo "DNS Lookup: ${avg_dns}ms"
+echo "TCP Connect: ${avg_connect}ms"
+echo "SSL/TLS Handshake: ${avg_ssl}ms"
+echo ""
+
+echo "PERFORMANCE BENCHMARKS"
+echo "----------------------"
+echo "✓ Good: < 800ms"
+echo "⚠ Needs Improvement: 800ms - 1800ms"
+echo "❌ Poor: > 1800ms"
+echo ""
+
+# Generate detailed report
+cat > "${REPORT_FILE}" <<EOF
+========================================
+TIME TO FIRST BYTE (TTFB) TEST REPORT
+========================================
+
+TEST CONFIGURATION
+------------------
+URL: ${TEST_URL}
+Date: ${DATE}
+Iterations: ${ITERATIONS}
+
+TTFB RESULTS
+------------
+Average TTFB: ${avg_ttfb}ms
+Min TTFB: ${min_ttfb}ms
+Max TTFB: ${max_ttfb}ms
+Rating: ${rating}
+
+INDIVIDUAL MEASUREMENTS
+-----------------------
+EOF
+
+# Add individual test results
+for i in "${!ttfb_values[@]}"; do
+  test_num=$((i + 1))
+  echo "Test ${test_num}: ${ttfb_values[$i]}ms" >> "${REPORT_FILE}"
+done
+
+cat >> "${REPORT_FILE}" <<EOF
+
+TIMING BREAKDOWN (Average)
+--------------------------
+DNS Lookup: ${avg_dns}ms
+TCP Connect: ${avg_connect}ms
+SSL/TLS Handshake: ${avg_ssl}ms
+
+PERFORMANCE BENCHMARKS
+----------------------
+Good: < 800ms
+Needs Improvement: 800ms - 1800ms
+Poor: > 1800ms
+
+CURL TIMING EXPLANATION
+-----------------------
+- time_namelookup: DNS lookup time
+- time_connect: Time to establish TCP connection
+- time_appconnect: Time to complete SSL/TLS handshake
+- time_starttransfer: TTFB - Time until first byte received
+- time_total: Total time for complete request
+
+OPTIMIZATION RECOMMENDATIONS
+-----------------------------
+EOF
+
+# Add recommendations based on results
+if [ "$avg_ttfb" -ge 1800 ]; then
+  cat >> "${REPORT_FILE}" <<EOF
+❌ POOR TTFB DETECTED (${avg_ttfb}ms)
+
+Critical Actions:
+1. Check server resources (CPU, RAM, disk I/O)
+2. Review database query performance with Query Monitor
+3. Enable object caching (Redis/Memcached)
+4. Optimize WordPress configuration
+5. Consider upgrading hosting plan
+6. Review active plugins and disable unnecessary ones
+7. Check for slow database queries
+
+EOF
+elif [ "$avg_ttfb" -ge 800 ]; then
+  cat >> "${REPORT_FILE}" <<EOF
+⚠ TTFB NEEDS IMPROVEMENT (${avg_ttfb}ms)
+
+Recommended Actions:
+1. Enable page caching (already using Trellis/Nginx)
+2. Optimize database queries
+3. Enable Redis object caching
+4. Review plugin performance
+5. Consider CDN for static assets
+6. Optimize WordPress autoload data
+
+EOF
+else
+  cat >> "${REPORT_FILE}" <<EOF
+✓ GOOD TTFB (${avg_ttfb}ms)
+
+Your server response time is excellent.
+Continue monitoring and maintain current optimizations.
+
+EOF
+fi
+
+# Add DNS-specific recommendations if DNS is slow
+if [ "$avg_dns" -ge 100 ]; then
+  cat >> "${REPORT_FILE}" <<EOF
+DNS Performance:
+- Current DNS lookup: ${avg_dns}ms
+- Consider using Cloudflare DNS (1.1.1.1) or Google DNS (8.8.8.8)
+- Verify DNS provider performance
+
+EOF
+fi
+
+# Add SSL-specific recommendations if SSL is slow
+if [ "$avg_ssl" -ge 200 ]; then
+  cat >> "${REPORT_FILE}" <<EOF
+SSL/TLS Performance:
+- Current SSL handshake: ${avg_ssl}ms
+- Verify TLS 1.3 is enabled
+- Consider OCSP stapling
+- Check certificate chain optimization
+
+EOF
+fi
+
+cat >> "${REPORT_FILE}" <<EOF
+NEXT STEPS
+----------
+[ ] Review server response time in Google Search Console
+[ ] Check PageSpeed Insights for server response recommendations
+[ ] Monitor TTFB over time (weekly tests recommended)
+[ ] Compare TTFB with competitors
+[ ] If poor, investigate with Query Monitor plugin
+[ ] Test different pages (blog posts, product pages, etc.)
+
+RELATED TOOLS
+-------------
+- WebPageTest: https://www.webpagetest.org/
+- GTmetrix: https://gtmetrix.com/
+- Google PageSpeed Insights: https://pagespeed.web.dev/
+- Pingdom: https://tools.pingdom.com/
+
+========================================
+EOF
+
+echo "=========================================="
+echo "Report saved to: ${REPORT_FILE}"
+echo "=========================================="
+echo ""
+echo "View report: cat ${REPORT_FILE}"
+echo ""
+
+# Suggest next steps based on performance
+if [ "$avg_ttfb" -ge 1800 ]; then
+  echo -e "${RED}❌ Critical: TTFB is poor (${avg_ttfb}ms). Immediate optimization required.${NC}"
+elif [ "$avg_ttfb" -ge 800 ]; then
+  echo -e "${YELLOW}⚠ Warning: TTFB needs improvement (${avg_ttfb}ms). Consider optimizations.${NC}"
+else
+  echo -e "${GREEN}✓ Success: TTFB is good (${avg_ttfb}ms). Server performance is excellent.${NC}"
+fi
+echo ""

--- a/trellis/security/README.md
+++ b/trellis/security/README.md
@@ -45,6 +45,7 @@ This directory contains documentation and configurations for securing WordPress 
 | **fail2ban** | Automatic IP blocking for brute force attacks | Zero (once configured) | [FAIL2BAN.md](./FAIL2BAN.md) |
 | **Manual IP blocks** | Permanent Nginx-level IP blocking | Manual updates required | [MANUAL-IP-BLOCKING.md](./MANUAL-IP-BLOCKING.md) |
 | **IP reputation lookup** | Verify an IP is actually malicious before blocking it | Run as needed | [check-ips.sh](#ip-reputation-checking) |
+| **Deny-list audit** | Bulk-check every IP already in `deny-ips.conf.j2` and flag stale ones | Run periodically | [check-deny-ips.sh](#deny-list-auditing) |
 | **Security scanners** | Malware detection for WordPress | Run weekly/monthly | [wp-cli/security](../../wp-cli/security/) |
 
 ---
@@ -210,6 +211,28 @@ A high `score` (AbuseIPDB's 0-100 confidence rating) with recent, numerous
 `reports` supports a manual block. A `score` of 0 with no reports is a strong
 signal the IP is not actually malicious (a shared NAT gateway, a legitimate
 crawler, etc.) — don't block it.
+
+---
+
+## Deny-list Auditing
+
+`check-deny-ips.sh` bulk-checks every individual IP already in a Trellis
+project's `nginx-includes/all/deny-ips.conf.j2` against AbuseIPDB, so blocks
+that are no longer warranted (score dropped to 0, no recent reports) are easy
+to spot. CIDR subnet entries are skipped — AbuseIPDB checks single IPs, not
+ranges — and reported as a count instead. Uses the same `trellis/security/.env`
+as `check-ips.sh`.
+
+```bash
+# Compact summary (score, reports, lastSeen per IP)
+TRELLIS_DIR=/path/to/trellis ./trellis/security/check-deny-ips.sh
+
+# Full JSON output per IP, via check-ips.sh
+TRELLIS_DIR=/path/to/trellis ./trellis/security/check-deny-ips.sh --full
+
+# Via wp-ops
+TRELLIS_DIR=/path/to/trellis wp-ops trellis/security/check-deny-ips
+```
 
 ---
 

--- a/trellis/security/check-deny-ips.sh
+++ b/trellis/security/check-deny-ips.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# check-deny-ips.sh — Verify every individual IP in a Trellis project's
+# deny-ips.conf.j2 against AbuseIPDB, so stale blocks (score dropped to 0,
+# no recent reports) are easy to spot and remove.
+#
+# Usage:
+#   TRELLIS_DIR=/path/to/trellis ./check-deny-ips.sh [--full]
+#
+# Without flags: compact one-line-per-IP summary (score, reports, lastSeen)
+# With --full:   full JSON output via wp-ops's check-ips.sh
+#
+# Subnet entries (CIDR blocks) in the conf are skipped — AbuseIPDB checks
+# single IPs, not ranges — and reported as a count instead.
+#
+# API key loaded from trellis/security/.env (ABUSEIPDB_KEY=xxx), the same
+# file check-ips.sh uses.
+#
+# @desc     Check every individual IP in a Trellis deny-ips.conf.j2 against AbuseIPDB
+# @category security
+# @runs     local
+# @requires curl jq trellis
+# @flag     --full  optional  {}  Full JSON output per IP via check-ips.sh, instead of the compact summary
+# @example  wp-ops trellis/security/check-deny-ips
+# @example  wp-ops trellis/security/check-deny-ips --full
+# @doc      trellis/security/README.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${TRELLIS_DIR:-}" ]]; then
+  echo "Error: TRELLIS_DIR is not set. Point it at your Trellis project:" >&2
+  echo "  export TRELLIS_DIR=/path/to/trellis" >&2
+  exit 1
+fi
+
+CONF="$TRELLIS_DIR/nginx-includes/all/deny-ips.conf.j2"
+if [[ ! -f "$CONF" ]]; then
+  echo "Error: deny-ips.conf.j2 not found at $CONF" >&2
+  exit 1
+fi
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+if [[ -z "${ABUSEIPDB_KEY:-}" ]]; then
+  echo "Error: ABUSEIPDB_KEY not set."
+  echo "Add it to trellis/security/.env:"
+  echo "  echo 'ABUSEIPDB_KEY=your_key_here' > trellis/security/.env"
+  exit 1
+fi
+export ABUSEIPDB_KEY
+
+ALL_ENTRIES=$(grep -E '^deny [0-9a-f:.]' "$CONF" | awk '{print $2}' | sed 's/;//')
+IPS=$(echo "$ALL_ENTRIES" | grep -v '/' || true)
+SUBNET_COUNT=$(echo "$ALL_ENTRIES" | grep -c '/' || true)
+
+if [[ "${1:-}" == "--full" ]]; then
+  if ! command -v wp-ops >/dev/null 2>&1; then
+    echo "Error: wp-ops not found on PATH." >&2
+    exit 1
+  fi
+  echo "$IPS" | xargs wp-ops trellis/security/check-ips
+  exit 0
+fi
+
+# Compact summary mode
+echo "$(echo "$IPS" | grep -c . || true) IPs checked, ${SUBNET_COUNT} subnet(s) skipped"
+echo ""
+printf "%-42s %-6s %-8s %-12s %s\n" "IP" "SCORE" "REPORTS" "LAST_SEEN" "NOTE"
+printf '%s\n' "$(printf '─%.0s' {1..90})"
+
+echo "$IPS" | while read -r IP; do
+  [[ -z "$IP" ]] && continue
+  RESP=$(curl -s --max-time 10 \
+    -G https://api.abuseipdb.com/api/v2/check \
+    --data-urlencode "ipAddress=$IP" \
+    -d maxAgeInDays=90 \
+    -H "Key: $ABUSEIPDB_KEY" \
+    -H "Accept: application/json")
+
+  SCORE=$(echo "$RESP" | jq -r '.data.abuseConfidenceScore // "ERR"')
+  REPORTS=$(echo "$RESP" | jq -r '.data.totalReports // "?"')
+  LAST=$(echo "$RESP" | jq -r '.data.lastReportedAt // "never"' | cut -c1-10)
+
+  NOTE=""
+  if [[ "$SCORE" =~ ^[0-9]+$ ]]; then
+    if   (( SCORE == 0 ));  then NOTE="⚠ CONSIDER REMOVING (score 0)"
+    elif (( SCORE <= 10 )); then NOTE="⚠ score dropped low"
+    elif (( SCORE <= 25 )); then NOTE="~ borderline"
+    fi
+  fi
+
+  printf "%-42s %-6s %-8s %-12s %s\n" "$IP" "$SCORE" "$REPORTS" "$LAST" "$NOTE"
+  sleep 1
+done

--- a/wordpress-utilities/speed-optimization/README.md
+++ b/wordpress-utilities/speed-optimization/README.md
@@ -52,3 +52,29 @@ For more detailed timing:
 ```bash
 time wget --spider --quiet https://domain.nl
 ```
+
+## Running the Bundled Scripts
+
+Two runnable scripts back the manual `curl`/`wget` checks above with repeatable,
+averaged measurements. They live in
+[`scripts/monitoring/`](../../scripts/monitoring/), not this folder — everything
+under `wordpress-utilities/` is treated by the `wp-ops` CLI as a copy-paste
+reference snippet (printed or clipboard-copied, never executed), which doesn't
+fit an actual runnable tool. This README stays the docs home; `@doc` on both
+scripts points back here.
+
+- [`../../scripts/monitoring/ttfb-test.sh`](../../scripts/monitoring/ttfb-test.sh) —
+  runs `curl` against a URL 5 times from your machine, averages
+  TTFB/DNS/connect/SSL timings, rates the result against the benchmarks above,
+  and writes a detailed report with optimization recommendations to `audits/`.
+  ```bash
+  wp-ops ttfb-test https://example.com
+  ```
+- [`../../scripts/monitoring/remote-ttfb-ua.sh`](../../scripts/monitoring/remote-ttfb-ua.sh) —
+  runs `curl` on the server itself over SSH (so your own network distance
+  doesn't skew the result), once per URL for each of: default, Googlebot,
+  AhrefsBot, and Screaming Frog user agents — useful when a WAF or cache
+  treats bots differently from regular visitors.
+  ```bash
+  wp-ops remote-ttfb-ua web@example.com https://example.com/ https://example.com/blog/
+  ```

--- a/wp-cli/content-creation/README.md
+++ b/wp-cli/content-creation/README.md
@@ -13,11 +13,13 @@ WP-CLI, Trellis, and block-pattern tooling for creating and updating WordPress c
 - [`PAGE-CREATION.md`](PAGE-CREATION.md) – Full workflows for local (Trellis VM) and production deployments.
 - [`PATTERN-REQUIREMENTS.md`](PATTERN-REQUIREMENTS.md) – Canonical block pattern standards and validation checklist.
 - [`page-creation.sh`](page-creation.sh) – Automated production page deploy script (copies content, checks conflicts, verifies output).
+- [`import-page-draft.sh`](import-page-draft.sh) – Update an *existing* page's content from an HTML draft, locally and/or in production (complements `page-creation.sh`, which only creates).
 - [`examples/example-page-content.html`](examples/example-page-content.html) – Gutenberg block markup sample to copy and customize.
 
 ## Choose Your Path
 - **Create/update pages end-to-end:** Follow [`PAGE-CREATION.md`](PAGE-CREATION.md) (includes slug checks, remote commands, troubleshooting).
 - **Automate production deploys:** Configure and run `./page-creation.sh path/to/content.html "Page Title" "page-slug"` (see script header for server vars).
+- **Update an existing page from a draft:** `TRELLIS_DIR=/path/to/trellis SITE_DIR=/path/to/bedrock-site ./import-page-draft.sh draft.html 7673` — see script header for the full argument list (site, environment, template).
 - **Validate or author patterns:** Read [`PATTERN-REQUIREMENTS.md`](PATTERN-REQUIREMENTS.md) for required metadata, spacing, and layout rules before adding pattern-based content.
 - **Need a starting template?** Copy [`examples/example-page-content.html`](examples/example-page-content.html) and edit the block markup to fit your page.
 

--- a/wp-cli/content-creation/import-page-draft.sh
+++ b/wp-cli/content-creation/import-page-draft.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+#
+# Import an HTML draft (Gutenberg block markup) into an existing WordPress
+# page, on the local Trellis VM and/or production. Complements
+# page-creation.sh, which only creates new pages — this updates one that
+# already exists.
+#
+# Draft files may start with Blade `{{-- ... --}}` documentation comments
+# (template/page-ID notes for humans) — this script strips those before
+# import, since they are not valid post_content and WordPress would
+# otherwise store them as literal text.
+#
+# Uses `wp eval` + `file_get_contents()` rather than `wp post update
+# --post_content="$(cat file)"` — safer for large HTML with quotes/JSON-LD
+# than passing the whole page as a shell argument.
+#
+# Usage:
+#   TRELLIS_DIR=/path/to/trellis SITE_DIR=/path/to/bedrock-site \
+#     ./import-page-draft.sh <draft-file> <page-id> [site-name] [environment] [template]
+#
+# TRELLIS_DIR and SITE_DIR are only required for a local (or both) update —
+# TRELLIS_DIR to run `trellis vm shell`, SITE_DIR the Bedrock checkout beside
+# it whose `/srv/www/<site>/current` mount the VM sees. A production-only
+# import needs neither.
+#
+# @desc     Update an existing WordPress page from an HTML draft, locally and/or in production
+# @category content-creation
+# @runs     local
+# @requires ssh trellis
+# @arg      draft-file   required  {draft.html}  Local HTML draft with block markup
+# @arg      page-id      required  {7673}  WordPress page ID to update
+# @arg      site-name    optional  {example.com}  Site name under /srv/www (default: example.com)
+# @arg      environment  optional  {local|production|both}  Where to apply the update (default: local)
+# @arg      template     optional  {template-no-header.blade.php}  Optional _wp_page_template value to set
+# @example  wp-ops wp-cli/content-creation/import-page-draft draft.html 7673
+# @example  wp-ops wp-cli/content-creation/import-page-draft draft.html 7673 example.com both template-no-header.blade.php
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
+print_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+print_step()  { echo -e "${BLUE}[STEP]${NC} $1"; }
+
+DRAFT_FILE="$1"
+PAGE_ID="$2"
+SITE_NAME="${3:-example.com}"
+ENVIRONMENT="${4:-local}"
+TEMPLATE="$5"
+
+if [ -z "$DRAFT_FILE" ] || [ -z "$PAGE_ID" ]; then
+    print_error "Usage: $0 <draft-file> <page-id> [site-name] [environment] [template]"
+    exit 1
+fi
+
+if [ ! -f "$DRAFT_FILE" ]; then
+    print_error "Draft file not found: $DRAFT_FILE"
+    exit 1
+fi
+
+if [ "$ENVIRONMENT" != "local" ] && [ "$ENVIRONMENT" != "production" ] && [ "$ENVIRONMENT" != "both" ]; then
+    print_error "Invalid environment: $ENVIRONMENT (must be local, production, or both)"
+    exit 1
+fi
+
+SERVER_USER="web"
+SERVER_HOST="$SITE_NAME"
+SERVER_PATH="/srv/www/$SITE_NAME/current"
+WP_PATH="web/wp"
+
+TMP_NAME="tmp-import-$PAGE_ID-$(date +%s).html"
+STRIPPED_FILE="/tmp/$TMP_NAME"
+
+print_step "Stripping Blade doc-comments from draft"
+grep -v '^{{--' "$DRAFT_FILE" > "$STRIPPED_FILE"
+
+update_local() {
+    if [ -z "$TRELLIS_DIR" ] || [ -z "$SITE_DIR" ]; then
+        print_error "TRELLIS_DIR and SITE_DIR must be set for a local update:"
+        echo "  TRELLIS_DIR=/path/to/trellis SITE_DIR=/path/to/bedrock-site $0 ..." >&2
+        exit 1
+    fi
+
+    print_step "Updating local page $PAGE_ID"
+    cp "$STRIPPED_FILE" "$SITE_DIR/$TMP_NAME"
+
+    (cd "$TRELLIS_DIR" && trellis vm shell --workdir "$SERVER_PATH" -- \
+        wp eval 'wp_update_post(array("ID" => '"$PAGE_ID"', "post_content" => file_get_contents("'"$SERVER_PATH"'/'"$TMP_NAME"'")));' \
+        --path="$WP_PATH")
+
+    if [ -n "$TEMPLATE" ]; then
+        (cd "$TRELLIS_DIR" && trellis vm shell --workdir "$SERVER_PATH" -- \
+            wp post meta update "$PAGE_ID" _wp_page_template "$TEMPLATE" --path="$WP_PATH")
+    fi
+
+    (cd "$TRELLIS_DIR" && trellis vm shell --workdir "$SERVER_PATH" -- wp cache flush --path="$WP_PATH")
+    rm -f "$SITE_DIR/$TMP_NAME"
+
+    URL=$(cd "$TRELLIS_DIR" && trellis vm shell --workdir "$SERVER_PATH" -- wp eval "echo get_permalink($PAGE_ID);" --path="$WP_PATH" | tail -1)
+    print_info "Local: $URL"
+}
+
+update_production() {
+    print_step "Updating production page $PAGE_ID"
+    scp "$STRIPPED_FILE" "$SERVER_USER@$SERVER_HOST:$SERVER_PATH/$TMP_NAME"
+
+    ssh "$SERVER_USER@$SERVER_HOST" "cd $SERVER_PATH && wp eval 'wp_update_post(array(\"ID\" => $PAGE_ID, \"post_content\" => file_get_contents(\"$SERVER_PATH/$TMP_NAME\")));' --path=$WP_PATH"
+
+    if [ -n "$TEMPLATE" ]; then
+        ssh "$SERVER_USER@$SERVER_HOST" "cd $SERVER_PATH && wp post meta update $PAGE_ID _wp_page_template '$TEMPLATE' --path=$WP_PATH"
+    fi
+
+    ssh "$SERVER_USER@$SERVER_HOST" "cd $SERVER_PATH && wp cache flush --path=$WP_PATH && rm -f $SERVER_PATH/$TMP_NAME"
+
+    URL=$(ssh "$SERVER_USER@$SERVER_HOST" "cd $SERVER_PATH && wp eval 'echo get_permalink($PAGE_ID);' --path=$WP_PATH")
+    print_info "Production: $URL"
+}
+
+if [ "$ENVIRONMENT" == "local" ] || [ "$ENVIRONMENT" == "both" ]; then
+    update_local
+fi
+
+if [ "$ENVIRONMENT" == "production" ] || [ "$ENVIRONMENT" == "both" ]; then
+    print_warn "About to write to PRODUCTION page ID $PAGE_ID on $SERVER_HOST"
+    read -p "Type 'yes' to continue: " CONFIRM
+    if [ "$CONFIRM" != "yes" ]; then
+        print_warn "Skipped production update."
+    else
+        update_production
+    fi
+fi
+
+rm -f "$STRIPPED_FILE"
+print_info "Done."


### PR DESCRIPTION
## Summary

Upstreams the four "Take" candidates from `docs/wp-ops-recommendations.md` Gap 5, generalized off their site-specific originals in `seo-strategy/tools/scripts` and `imagewize.com/scripts`:

- `scripts/monitoring/ttfb-test.sh` + `remote-ttfb-ua.sh` — TTFB measurement with averaging/reporting, and a multi-user-agent variant that runs from the server itself. Placed under `scripts/monitoring/` rather than `wordpress-utilities/speed-optimization/` (as the doc originally suggested) because the CLI treats everything under `wordpress-utilities/` as a copy-paste snippet and never executes it — the speed-optimization README stays the docs home via `@doc`.
- `wp-cli/content-creation/import-page-draft.sh` — updates an *existing* page from an HTML draft (complements `page-creation.sh`, which only creates). Site name is now a positional arg; local paths come from `TRELLIS_DIR`/`SITE_DIR` env vars, matching `db-pull.sh`'s convention.
- `trellis/security/check-deny-ips.sh` — bulk AbuseIPDB check of every IP already in a Trellis project's `deny-ips.conf.j2`, to flag stale blocks. Conf path now comes from `TRELLIS_DIR`; dropped the original's hardcoded subnet IP list in favor of actually skipping/counting subnets as its own docstring claimed.

All four are manifest-annotated (`@desc`/`@category`/`@runs`/`@requires`/`@arg`/`@example`) and resolve by basename in both CLIs. `go/internal/catalog/catalog.json` is regenerated in its own commit.

## Test plan

- [x] `bash go/scripts/parity-check.sh` — 8/8 passed, bash and Go `--json` catalogs match field-for-field (72 commands each)
- [x] `./wp-ops manifest lint` — clean, 0 problems
- [x] `./wp-ops <name> --help` for all four resolves correctly by basename in the bash CLI
- [ ] Manual run of each script against a real Trellis project (not done here — needs a live site/API key)