### PR TITLE
fix(scripts/backup): rebuild db-backup.sh as a local SSH wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.27.1] - 2026-08-03
+
+### Fixed
+
+- **scripts/backup** - `db-backup.sh` wrote its export to `/srv/backups/<site>/database` on the remote server, but a stock Trellis box provisions and `chown`s `/srv/www`, never `/srv/backups` itself — the `web` user the script runs as couldn't `mkdir` there, so the script failed on every Trellis server's first run, not just the one it was caught on (`imagewize.com`). Rebuilt as a local wrapper: it SSHes into the site's own web directory (already `web`-writable) and streams `wp db export - | gzip` straight into a local `database_backup/` directory, the same pattern `db-pull.sh` and the MCP `db_backup` tool (`mcp-server/src/tools/dbBackup.ts`) already use — no remote temp file is ever written, so there's nothing to clean up server-side either.
+
+### Changed
+
+- **scripts/backup** - `db-backup.sh` is now `@runs local` (was `server`) and no longer needs the `ssh web@example.com 'bash -s' < db-backup.sh` invocation — `wp-ops db-backup example.com production` runs it directly, matching `db-pull.sh`'s calling convention. New `--host`/`--dest` flags; the `backup-type` argument's `development` choice was dropped (development is already local — running `wp db export` directly needs no SSH hop) in favor of `environment` (`production`/`staging`). `trellis/backup/database-backup.yml` is unchanged and still the right tool for automated/Ansible-native backups.
+- **wp-ops**, **go** - Removed `scripts/backup/db-backup` from the now-stale hardcoded server-side command lists (`BACKUP_COMMANDS`/`SERVER_SIDE_COMMANDS` in `wp-ops`, `backupCommands` in `go/cmd/serverside.go`, `serverSideFallback` in `go/internal/catalog/gen/main.go`) now that its manifest declares `@runs local` directly — `wp-ops`'s `is_server_side_command()` already prefers the manifest over these lists, but leaving stale entries there was misleading. `catalog.json` regenerated; `go/scripts/parity-check.sh` passes 8/8.
+- **docs** - `docs/wp-ops-recommendations.md`: marked Gap 6's `db-backup` item done. `trellis/backup/README.md`: added a "Direct Shell Script Method" subsection under Database Backup pointing at the new script, mirroring the existing one under Database Pull.
+
+Addresses Gap 6 of `docs/wp-ops-recommendations.md`.
+
 ## [3.27.0] - 2026-08-03
 
 ### Added

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -251,6 +251,21 @@ playbook does (never touching `/srv/backups`), fetch to local
 `trellis/backup/database-backup.yml` for the same reason `database-pull.yml`
 was kept: it's still the right tool for Ansible-native workflows.
 
+**Done, 2026-08-03.** `scripts/backup/db-backup.sh` is now `@runs local`
+(previously `server`) — positional args (`wp-ops db-backup example.com
+production`), `--host`/`--dest` flags. Deviates from "fetch, then delete the
+remote temp file" in favor of `db-pull.sh`'s own streaming pattern: `ssh ...
+'wp db export -' | gzip > local-file`, so there is no remote temp file to
+create or clean up in the first place — same approach the MCP `db_backup`
+tool (`mcp-server/src/tools/dbBackup.ts`) already used. `wp-ops` and the Go
+CLI both read `runs_on`/`requires` off the manifest already (bash's
+`is_server_side_command()` checks `@runs` before its hardcoded command
+lists), so flipping the header line was sufficient in both places once the
+now-stale command lists (`BACKUP_COMMANDS`/`SERVER_SIDE_COMMANDS` in
+`wp-ops`, `backupCommands` in `go/cmd/serverside.go`,
+`serverSideFallback` in `go/internal/catalog/gen/main.go`) were cleaned up
+and `catalog.json` regenerated. `go/scripts/parity-check.sh` passes 8/8.
+
 The remaining 6a playbooks and 6b scripts are lower-value repeats of the same
 fix — worth doing, but `db-pull.sh` and (once built) `db-backup.sh` between
 them cover the two highest-frequency operations already.
@@ -264,7 +279,7 @@ them cover the two highest-frequency operations already.
 2. **Gap 2** — `scripts/backup/db-pull.sh`. Highest daily value. **Done.**
 3. **Gap 5 "Take" rows** — four scripts, mechanical work. **Done (2026-08-03).**
 4. **Gap 6, `db-backup`** — positional wrapper + fixes the `/srv/backups`
-   permission dead end. Same shape and value as Gap 2; do this next.
+   permission dead end. Same shape and value as Gap 2. **Done.**
 5. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap.
 6. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to.
 7. **Gap 6, remaining items** — the other eight `-e`-style playbooks and four

--- a/go/cmd/serverside.go
+++ b/go/cmd/serverside.go
@@ -26,8 +26,11 @@ import (
 // playbooks under trellis/backup/ do the same job *and* retrieve the archive,
 // which is usually what someone reaching for a backup from their workstation
 // actually wants.
+//
+// db-backup isn't in this list: it's @runs local now — it SSHes out and
+// streams straight to this machine, the same shape as db-pull. See
+// docs/wp-ops-recommendations.md Gap 6.
 var backupCommands = map[string]bool{
-	"scripts/backup/db-backup":   true,
 	"scripts/backup/site-backup": true,
 }
 
@@ -51,8 +54,6 @@ func serverSideExampleArgs(key string) string {
 		return "example.com 48"
 	case "scripts/monitoring/run-monitoring":
 		return "24 example.com"
-	case "scripts/backup/db-backup":
-		return "example.com production"
 	case "scripts/backup/site-backup":
 		return "example.com"
 	default:
@@ -146,9 +147,7 @@ func printServerSideGuidance(w io.Writer, e catalog.Entry) {
 		fmt.Fprintln(w, "to this machine in one step, use the Ansible playbooks instead:")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production")
-		if e.Key != "scripts/backup/db-backup" {
-			fmt.Fprintln(w, "  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production")
-		}
+		fmt.Fprintln(w, "  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production")
 		return
 	}
 

--- a/go/cmd/serverside_test.go
+++ b/go/cmd/serverside_test.go
@@ -120,7 +120,7 @@ func TestServerSideGuard(t *testing.T) {
 		},
 		{
 			name:        "backup command ignores a real file argument",
-			entry:       serverEntry("scripts/backup/db-backup"),
+			entry:       serverEntry("scripts/backup/site-backup"),
 			args:        []string{logFile},
 			onHost:      false,
 			gnuDate:     true,
@@ -181,23 +181,12 @@ func TestPrintServerSideGuidanceVariants(t *testing.T) {
 		wantAbsent  []string
 	}{
 		{
-			name:    "db-backup names the backup paths and one pull playbook",
-			key:     "scripts/backup/db-backup",
-			gnuDate: true,
-			wantContain: []string{
-				"writes the archive to /srv/backups/<site>",
-				"ssh web@example.com 'bash -s' < scripts/backup/db-backup.sh",
-				"example.com production",
-				"wp-ops trellis/backup/database-pull",
-			},
-			// A database backup has no uploads archive to pull.
-			wantAbsent: []string{"files-pull", "gawk"},
-		},
-		{
-			name:    "site-backup also points at files-pull",
+			name:    "site-backup points at both pull playbooks",
 			key:     "scripts/backup/site-backup",
 			gnuDate: true,
 			wantContain: []string{
+				"writes the archive to /srv/backups/<site>",
+				"ssh web@example.com 'bash -s' < scripts/backup/site-backup.sh",
 				"wp-ops trellis/backup/database-pull",
 				"wp-ops trellis/backup/files-pull",
 				"example.com",
@@ -283,7 +272,6 @@ func TestServerSideExampleArgs(t *testing.T) {
 	tests := map[string]string{
 		"scripts/monitoring/error-monitor":    "example.com 48",
 		"scripts/monitoring/run-monitoring":   "24 example.com",
-		"scripts/backup/db-backup":            "example.com production",
 		"scripts/backup/site-backup":          "example.com",
 		"scripts/monitoring/traffic-monitor":  "/srv/www/example.com/logs/access.log 24",
 		"scripts/monitoring/security-monitor": "/srv/www/example.com/logs/access.log 24",

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -2,12 +2,12 @@
   {
     "category": "scripts",
     "key": "scripts/backup/db-backup",
-    "description": "Back up a Trellis site database with WP-CLI, gzip it, and prune backups older than 30 days",
+    "description": "Back up a remote site's database over SSH straight to your machine",
     "script_path": "scripts/backup/db-backup.sh",
-    "runs_on": "server",
-    "runs": "server",
+    "runs_on": "local",
+    "runs": "local",
     "requires": [
-      "wp"
+      "ssh"
     ],
     "doc": "trellis/backup/README.md",
     "args": [
@@ -16,24 +16,41 @@
         "required_raw": "optional",
         "required": false,
         "default": "example.com",
-        "description": "Site directory under /srv/www",
-        "raw": "site-name    optional  {example.com}  Site directory under /srv/www"
+        "description": "Site name under /srv/www, as in wordpress_sites.yml",
+        "raw": "site-name    optional  {example.com}  Site name under /srv/www, as in wordpress_sites.yml"
       },
       {
-        "name": "backup-type",
+        "name": "environment",
         "required_raw": "optional",
         "required": false,
         "choices": [
           "production",
-          "staging",
-          "development"
+          "staging"
         ],
-        "description": "Backup type",
-        "raw": "backup-type  optional  {production|staging|development}  Backup type"
+        "description": "Remote environment to back up",
+        "raw": "environment  optional  {production|staging}  Remote environment to back up"
+      }
+    ],
+    "flags": [
+      {
+        "name": "--host",
+        "required_raw": "optional",
+        "required": false,
+        "default": "example.com",
+        "description": "SSH host to back up from (default: site-name)",
+        "raw": "--host       optional  {example.com}  SSH host to back up from (default: site-name)"
+      },
+      {
+        "name": "--dest",
+        "required_raw": "optional",
+        "required": false,
+        "default": "database_backup",
+        "description": "Local destination directory",
+        "raw": "--dest       optional  {database_backup}  Local destination directory"
       }
     ],
     "examples": [
-      "ssh web@example.com 'bash -s' \u003c db-backup.sh example.com production"
+      "wp-ops db-backup example.com production"
     ],
     "manifest_category": "backup",
     "display_category": "scripts",

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -25,8 +25,8 @@ func TestLookup(t *testing.T) {
 	if !ok {
 		t.Fatal("Lookup(scripts/backup/db-backup) not found")
 	}
-	if e.RunsOn != "server" {
-		t.Errorf("RunsOn = %q, want server", e.RunsOn)
+	if e.RunsOn != "local" {
+		t.Errorf("RunsOn = %q, want local", e.RunsOn)
 	}
 
 	if _, ok := c.Lookup("does/not/exist"); ok {

--- a/go/internal/catalog/gen/main.go
+++ b/go/internal/catalog/gen/main.go
@@ -94,7 +94,6 @@ var serverSideFallback = map[string]bool{
 	"scripts/monitoring/ai-bot-monitor":   true,
 	"scripts/monitoring/error-monitor":    true,
 	"scripts/monitoring/run-monitoring":   true,
-	"scripts/backup/db-backup":            true,
 	"scripts/backup/site-backup":          true,
 }
 

--- a/go/internal/catalog/gen/main_test.go
+++ b/go/internal/catalog/gen/main_test.go
@@ -77,7 +77,7 @@ func TestRunsOnFor(t *testing.T) {
 		{"explicit server", "server", "scripts/git/git-log-oneline", "server"},
 		{"explicit local", "local", "scripts/git/git-log-oneline", "local"},
 		{"no runs, not in fallback list", "", "scripts/git/git-log-oneline", "local"},
-		{"no runs, in fallback list", "", "scripts/backup/db-backup", "server"},
+		{"no runs, in fallback list", "", "scripts/backup/site-backup", "server"},
 		{
 			// The whole point of the precedence: an explicit @runs local on a
 			// command that's *also* in the hardcoded list must stay local.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ This directory contains utility scripts organized into functional areas:
 ```
 scripts/
 ├── backup/                      # Backup automation scripts
-│   ├── db-backup.sh            # Database-only backup with URL replacement
+│   ├── db-backup.sh            # Back up a remote database over SSH straight to your machine
 │   ├── db-pull.sh              # Pull a remote database into development via SSH
 │   └── site-backup.sh          # Complete site backup (DB + files + config)
 ├── git/                         # Git/GitHub utilities
@@ -1159,68 +1159,40 @@ site restores the released code.
 
 ## Backup Scripts
 
-### db-backup.sh (196 lines)
+### db-backup.sh
 
-Trellis-aware database backup with optional URL replacement for staging/development environments.
+Backs up a remote site's database over SSH, straight to your machine. Runs on your machine — no `trellis vm shell` or VM dependency, unlike `db-pull.sh`; it just SSHes directly to the site's own web directory.
 
 #### Features
 
-- **WP-CLI Based Export**:
-  - `--add-drop-table` for clean imports
-  - `--single-transaction` for InnoDB consistency
-  - `--default-character-set=utf8mb4` for proper encoding
-  - Automatic gzip compression
-
-- **Backup Metadata**:
-  - Creates `.txt` info file with:
-    - WordPress version
-    - Database name, size, table count
-    - Charset information
-    - Backup timestamp
-
-- **URL Replacement** (for non-production):
-  - **Staging**: Replaces `.com` with `.staging.com`
-  - **Development**: Generates `.test` URL variants
-  - Creates separate backup file with replaced URLs
-
-- **Retention Policy**:
-  - 30-day automatic cleanup
-  - Removes old `.sql.gz` and `.txt` files
-
-- **Colored Logging**:
-  - Timestamps on all messages
-  - Color-coded output (green=success, red=error, yellow=warning)
+- **No remote temp file**: streams `wp db export - --path=web/wp` over SSH directly into `gzip`, writing straight to a local file
+- **Never touches `/srv/backups`**: a stock Trellis box provisions and `chown`s `/srv/www`, never `/srv/backups` itself, so the old version of this script (which wrote there) failed with a permission error on every site's first run. SSHing into the already-`web`-writable web directory instead sidesteps that entirely.
+- **Local retention**: prunes this site's own backups in the destination directory older than 30 days
 
 #### Usage
 
 ```bash
-# Production backup (no URL replacement)
+# Backup production
 ./db-backup.sh example.com production
 
-# Staging backup (with URL replacement)
-./db-backup.sh demo.example.com staging
+# Backup staging, from a host that differs from the site key
+./db-backup.sh example.com staging --host staging.example.com
 
-# Development backup (with URL replacement)
-./db-backup.sh example.com development
+# Custom local destination directory
+./db-backup.sh example.com production --dest ~/backups/example.com
 ```
+
+Backing up `development` is already local — just run `wp db export --path=web/wp` directly; no SSH hop needed.
+
+Via wp-ops: `wp-ops db-backup example.com production`.
+
+For automated/repeatable backups instead, use `trellis/backup/database-backup.yml` (`wp-ops trellis database-backup -e site=example.com -e env=production`). See [trellis/backup/README.md](../trellis/backup/README.md) for the tradeoffs.
 
 #### Output Files
 
 ```
-/srv/backups/example.com/database/
-├── production_db_20251231_120000.sql.gz
-├── staging_db_with_urls_20251231_120000.sql.gz
-└── backup_info_20251231_120000.txt
-```
-
-#### Directory Structure
-
-```bash
-/srv/backups/{site}/
-└── database/
-    ├── {env}_db_{timestamp}.sql.gz
-    ├── {env}_db_with_urls_{timestamp}.sql.gz  # staging/dev only
-    └── backup_info_{timestamp}.txt
+database_backup/
+└── example_com_production_2026_08_03_14_30_00.sql.gz
 ```
 
 ---
@@ -2098,10 +2070,18 @@ tail -f /home/web/monitoring/webhook.log
 
 ### Backup Automation
 
-```bash
-# Daily database backup at 2 AM
-0 2 * * * /srv/scripts/backup/db-backup.sh example.com production > /var/log/db-backup.log 2>&1
+`db-backup.sh` runs on your machine, not the server (it SSHes out), so it
+doesn't belong in a server crontab. For scheduled/automated database
+backups, use the Ansible playbook instead:
 
+```bash
+# Daily database backup at 2 AM, from wherever the playbook is scheduled
+0 2 * * * cd /path/to/trellis && ansible-playbook /path/to/wp-ops/trellis/backup/database-backup.yml -e site=example.com -e env=production > /var/log/db-backup.log 2>&1
+```
+
+`site-backup.sh` is still server-side and belongs in the server's own crontab:
+
+```bash
 # Weekly full site backup on Sundays at 3 AM
 0 3 * * 0 /srv/scripts/backup/site-backup.sh example.com > /var/log/site-backup.log 2>&1
 

--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -1,235 +1,139 @@
 #!/bin/bash
 
 # Trellis Database Backup Script
-# Focused database backup using WP-CLI for WordPress sites on Trellis
+# Back up a remote site's database over SSH, straight to your machine.
 #
-# Runs on the server: it reads /srv/www/<site-name> and writes to
-# /srv/backups/<site-name>/database, so both paths have to be the host's own.
-# Stream it over SSH the same way as the monitoring scripts — nothing needs to
-# be installed on the server.
+# Runs on your machine — no /srv/backups involved. A stock Trellis box
+# provisions and chowns /srv/www, never /srv/backups itself, so the old
+# server-side version of this script (which wrote there) failed with a
+# permission error on every site's first run. This version never touches
+# that path: it SSHes into the site's own web dir (already web-user-writable
+# since Trellis deploys there), runs `wp db export` over that connection, and
+# gzips the stream straight into a local database_backup/ directory. No
+# remote temp file, so nothing needs cleaning up on the server either.
 #
 # Usage:
-#   ssh web@example.com 'bash -s' < ./db-backup.sh [site-name] [backup-type]
-#   ./db-backup.sh example.com production     # on the server itself
+#   ./db-backup.sh [site-name] [environment] [options]
+#   wp-ops db-backup example.com production
 #
-# Backup types: production, staging, development
+# Options:
+#   --host HOST   SSH host to back up from (default: site-name)
+#   --dest DIR    Local destination directory (default: database_backup)
 #
-# staging and development additionally produce a second dump with the site URL
-# rewritten for that environment; production produces the plain dump only.
-#
-# @desc     Back up a Trellis site database with WP-CLI, gzip it, and prune backups older than 30 days
+# @desc     Back up a remote site's database over SSH straight to your machine
 # @category backup
-# @runs     server
-# @requires wp
-# @arg      site-name    optional  {example.com}  Site directory under /srv/www
-# @arg      backup-type  optional  {production|staging|development}  Backup type
-# @example  ssh web@example.com 'bash -s' < db-backup.sh example.com production
+# @runs     local
+# @requires ssh
+# @arg      site-name    optional  {example.com}  Site name under /srv/www, as in wordpress_sites.yml
+# @arg      environment  optional  {production|staging}  Remote environment to back up
+# @flag     --host       optional  {example.com}  SSH host to back up from (default: site-name)
+# @flag     --dest       optional  {database_backup}  Local destination directory
+# @example  wp-ops db-backup example.com production
 # @doc      trellis/backup/README.md
 
 set -euo pipefail
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-    echo "Usage: $(basename "$0") [site-name] [backup-type]"
+usage() {
+    echo "Usage: $(basename "$0") [site-name] [environment] [options]"
     echo ""
-    echo "Back up a Trellis site database with WP-CLI, gzip it, write a summary"
-    echo "file alongside it, and prune backups older than 30 days."
+    echo "Back up a remote site's database over SSH, straight to your machine."
+    echo "Streams 'wp db export' over the SSH connection and gzips it locally —"
+    echo "no file is ever written to the server."
     echo ""
     echo "Arguments:"
-    echo "  site-name    Site directory under /srv/www (default: example.com)"
-    echo "  backup-type  production | staging | development (default: production)"
+    echo "  site-name    Site name under /srv/www, as in wordpress_sites.yml (default: example.com)"
+    echo "  environment  production | staging (default: production) — used for messaging only"
     echo ""
-    echo "Runs on the server — /srv/www and /srv/backups are the host's paths."
-    echo "From your machine:"
-    echo "  ssh web@example.com 'bash -s' < $(basename "$0") example.com production"
+    echo "Options:"
+    echo "  --host HOST  SSH host to back up from (default: site-name)"
+    echo "  --dest DIR   Local destination directory (default: database_backup)"
     echo ""
-    echo "Writes to /srv/backups/<site-name>/database/ on the server. To pull a"
-    echo "copy down to your machine instead, use the Ansible playbook:"
-    echo "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production"
-    exit 0
-fi
-
-# Configuration
-SITE_NAME="${1:-example.com}"
-BACKUP_TYPE="${2:-production}"
-SITE_PATH="/srv/www/$SITE_NAME"
-BACKUP_DIR="/srv/backups/$SITE_NAME/database"
-DATE=$(date +%Y%m%d_%H%M%S)
-RETENTION_DAYS=30
+    echo "Backing up development? It's already local — just run:"
+    echo "  wp db export --path=web/wp"
+    echo ""
+    echo "For automated/repeatable backups instead, use the Ansible playbook:"
+    echo "  wp-ops trellis/backup/database-backup -e site=example.com -e env=production"
+}
 
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Logging functions
-log() {
-    echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"
-}
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" >&2; }
+warning() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
 
-error() {
-    echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" >&2
-}
+# Parse arguments
+POSITIONAL=()
+REMOTE_HOST=""
+DEST_DIR="database_backup"
 
-warning() {
-    echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"
-}
-
-# Validate inputs
-if [ ! -d "$SITE_PATH" ]; then
-    error "Site directory not found: $SITE_PATH"
-    exit 1
-fi
-
-if ! command -v wp &> /dev/null; then
-    error "WP-CLI not found. Please install WP-CLI."
-    exit 1
-fi
-
-# Create backup directory
-mkdir -p "$BACKUP_DIR"
-
-# Change to WordPress directory
-cd "$SITE_PATH/current" || {
-    error "Cannot access WordPress directory: $SITE_PATH/current"
-    exit 1
-}
-
-log "Starting database backup for $SITE_NAME ($BACKUP_TYPE environment)"
-
-# Check if WordPress is installed
-if ! wp core is-installed --quiet; then
-    error "WordPress is not properly installed in $SITE_PATH/current"
-    exit 1
-fi
-
-# Get database info
-DB_NAME=$(wp config get DB_NAME --quiet)
-DB_SIZE=$(wp db size --size_format=human --quiet)
-log "Database: $DB_NAME ($DB_SIZE)"
-
-# Perform database backup
-BACKUP_FILE="$BACKUP_DIR/${BACKUP_TYPE}_db_$DATE.sql"
-log "Creating database backup..."
-
-if wp db export "$BACKUP_FILE" \
-    --add-drop-table \
-    --single-transaction \
-    --default-character-set=utf8mb4 \
-    --quiet; then
-
-    # Compress the backup using gzip (optimal for single file)
-    gzip "$BACKUP_FILE"
-    BACKUP_FILE="${BACKUP_FILE}.gz"
-
-    BACKUP_SIZE=$(ls -lh "$BACKUP_FILE" | awk '{print $5}')
-    log "Database backup completed: $(basename "$BACKUP_FILE") ($BACKUP_SIZE)"
-else
-    error "Database backup failed"
-    exit 1
-fi
-
-# Create additional backup with URL replacement for staging/development
-if [ "$BACKUP_TYPE" != "production" ]; then
-    log "Creating backup with URL replacement for $BACKUP_TYPE environment..."
-
-    # Define URL mappings
-    case "$BACKUP_TYPE" in
-        "staging")
-            PROD_URL=$(wp option get home --quiet)
-            STAGING_URL=$(echo "$PROD_URL" | sed 's/\.com/.staging.com/g')
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
             ;;
-        "development")
-            PROD_URL=$(wp option get home --quiet)
-            DEV_URL=$(echo "$PROD_URL" | sed 's/https\?:\/\/[^\/]*/http:\/\/'"${SITE_NAME%.*}"'.test/g')
+        --host)
+            REMOTE_HOST="${2:-}"
+            shift 2
+            ;;
+        --dest)
+            DEST_DIR="${2:-}"
+            shift 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
             ;;
     esac
+done
 
-    if [ -n "${STAGING_URL:-}" ] || [ -n "${DEV_URL:-}" ]; then
-        REPLACEMENT_FILE="$BACKUP_DIR/${BACKUP_TYPE}_db_with_urls_$DATE.sql"
-        TARGET_URL="${STAGING_URL:-$DEV_URL}"
+SITE_NAME="${POSITIONAL[0]:-example.com}"
+ENVIRONMENT="${POSITIONAL[1]:-production}"
+REMOTE_HOST="${REMOTE_HOST:-$SITE_NAME}"
 
-        if wp db export "$REPLACEMENT_FILE" \
-            --add-drop-table \
-            --single-transaction \
-            --default-character-set=utf8mb4 \
-            --quiet; then
-
-            # Perform URL replacement
-            wp search-replace "$PROD_URL" "$TARGET_URL" \
-                --dry-run \
-                --quiet > /dev/null && \
-            wp search-replace "$PROD_URL" "$TARGET_URL" \
-                --skip-columns=guid \
-                --quiet
-
-            # Export again with replaced URLs
-            wp db export "$REPLACEMENT_FILE" \
-                --add-drop-table \
-                --single-transaction \
-                --default-character-set=utf8mb4 \
-                --quiet
-
-            gzip "$REPLACEMENT_FILE"
-            log "URL-replaced backup created: $(basename "$REPLACEMENT_FILE.gz")"
-
-            # Restore original URLs
-            wp search-replace "$TARGET_URL" "$PROD_URL" \
-                --skip-columns=guid \
-                --quiet
-        fi
-    fi
+if [[ "$ENVIRONMENT" == "development" ]]; then
+    error "development is already local — no SSH hop needed. Run this instead:"
+    echo "  wp db export --path=web/wp" >&2
+    exit 1
 fi
 
-# Create backup info file
-INFO_FILE="$BACKUP_DIR/backup_info_$DATE.txt"
-cat > "$INFO_FILE" << EOF
-Database Backup Information
-==========================
-Site: $SITE_NAME
-Environment: $BACKUP_TYPE
-Date: $(date)
-WordPress Version: $(wp core version --quiet)
+REMOTE_PATH="/srv/www/${SITE_NAME}/current"
+WP_PATH="web/wp"
+DATE=$(date +%Y_%m_%d_%H_%M_%S)
+BACKUP_FILE="${SITE_NAME//./_}_${ENVIRONMENT}_${DATE}.sql.gz"
 
-Database Information:
-- Name: $DB_NAME
-- Size: $DB_SIZE
-- Tables: $(wp db query "SHOW TABLES;" --skip-column-names --quiet | wc -l)
-- Charset: $(wp config get DB_CHARSET --quiet)
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Database Backup: ${SITE_NAME} (${ENVIRONMENT})${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "  Remote: web@${REMOTE_HOST}:${REMOTE_PATH}"
+echo -e "  Local:  ${DEST_DIR}/${BACKUP_FILE}"
+echo ""
 
-Backup Files:
-- Main backup: $(basename "$BACKUP_FILE")
-EOF
+mkdir -p "$DEST_DIR"
 
-if [ -f "$BACKUP_DIR/${BACKUP_TYPE}_db_with_urls_$DATE.sql.gz" ]; then
-    echo "- URL-replaced backup: ${BACKUP_TYPE}_db_with_urls_$DATE.sql.gz" >> "$INFO_FILE"
+log "Exporting ${ENVIRONMENT} database from ${REMOTE_HOST}..."
+if ! ssh -o StrictHostKeyChecking=no "web@${REMOTE_HOST}" \
+    "cd ${REMOTE_PATH} && wp db export - --path=${WP_PATH}" | gzip > "${DEST_DIR}/${BACKUP_FILE}"; then
+    error "Database export failed."
+    rm -f "${DEST_DIR}/${BACKUP_FILE}"
+    exit 1
 fi
 
-echo "" >> "$INFO_FILE"
-echo "File sizes:" >> "$INFO_FILE"
-find "$BACKUP_DIR" -name "*_$DATE.*" -exec ls -lh {} \; | awk '{print "- " $9 ": " $5}' >> "$INFO_FILE"
+BACKUP_SIZE=$(ls -lh "${DEST_DIR}/${BACKUP_FILE}" | awk '{print $5}')
+log "Backup complete: ${DEST_DIR}/${BACKUP_FILE} (${BACKUP_SIZE})"
 
-# Clean up old backups
-log "Cleaning up old database backups (older than $RETENTION_DAYS days)..."
-DELETED_COUNT=$(find "$BACKUP_DIR" -name "*.sql.gz" -mtime +$RETENTION_DAYS -delete -print | wc -l)
-INFO_DELETED=$(find "$BACKUP_DIR" -name "backup_info_*.txt" -mtime +$RETENTION_DAYS -delete -print | wc -l)
-TOTAL_DELETED=$((DELETED_COUNT + INFO_DELETED))
-
-if [ $TOTAL_DELETED -gt 0 ]; then
-    log "Cleaned up $TOTAL_DELETED old backup files"
-else
-    log "No old backup files to clean up"
+# Prune this site's old local backups (default 30 days), same as the old
+# server-side script did for /srv/backups.
+RETENTION_DAYS=30
+DELETED_COUNT=$(find "$DEST_DIR" -name "${SITE_NAME//./_}_*.sql.gz" -mtime "+${RETENTION_DAYS}" -delete -print | wc -l | tr -d ' ')
+if [[ "$DELETED_COUNT" -gt 0 ]]; then
+    log "Cleaned up ${DELETED_COUNT} old backup(s) older than ${RETENTION_DAYS} days."
 fi
-
-# Final summary
-log "Database backup completed successfully"
-log "Backup location: $BACKUP_DIR"
-log "Info file: $(basename "$INFO_FILE")"
-
-# Show recent backups
-log "Recent database backups:"
-find "$BACKUP_DIR" -name "*.sql.gz" -mtime -7 -exec ls -lh {} \; | \
-    awk '{print "  " $6 " " $7 " " $8 " - " $9 " (" $5 ")"}' | \
-    sort -r
 
 exit 0

--- a/trellis/backup/README.md
+++ b/trellis/backup/README.md
@@ -9,8 +9,9 @@ Ansible playbooks for automated database backup, synchronization, and management
 - [Installation](#installation)
 - [Usage](#usage)
   - [Database Backup](#database-backup)
-  - [Database Pull](#database-pull)
     - [Alternative: Direct Shell Script Method](#alternative-direct-shell-script-method)
+  - [Database Pull](#database-pull)
+    - [Alternative: Direct Shell Script Method](#alternative-direct-shell-script-method-1)
   - [Database Push](#database-push)
   - [Files Backup](#files-backup)
   - [Files Pull](#files-pull)
@@ -97,6 +98,17 @@ ansible-playbook database-backup.yml -e site=example.com -e env=development
 - For remote environments: downloads backup to development server
 - Stores backup in `web/app/database_backup/` directory
 - Automatically cleans up temporary files
+
+#### Alternative: Direct Shell Script Method
+
+**Prefer [`scripts/backup/db-backup.sh`](../../scripts/backup/db-backup.sh)** (`wp-ops db-backup example.com production`) for a quick manual backup of a remote environment. It SSHes into the site's own web directory — already web-user-writable, unlike `/srv/backups`, which a stock Trellis box never provisions or `chown`s, so the backup fails with a permission error there on every site's first run — and streams `wp db export | gzip` straight into a local `database_backup/` directory. No remote temp file is ever written, so there's nothing to clean up on the server either.
+
+```bash
+wp-ops db-backup example.com production
+wp-ops db-backup example.com staging --host staging.example.com
+```
+
+Backing up `development` is already local — just run `wp db export --path=web/wp` directly. For automated/repeatable backups instead, use the Ansible playbook above.
 
 ### Database Pull
 

--- a/wp-ops
+++ b/wp-ops
@@ -100,7 +100,6 @@ scripts/monitoring/security-monitor
 scripts/monitoring/ai-bot-monitor
 scripts/monitoring/error-monitor
 scripts/monitoring/run-monitoring
-scripts/backup/db-backup
 scripts/backup/site-backup
 "
 
@@ -108,8 +107,10 @@ scripts/backup/site-backup
 # because the Ansible playbooks under trellis/backup/ do the same job *and*
 # retrieve the archive to this machine, which is usually what someone reaching
 # for a backup from their workstation actually wants.
+#
+# db-backup isn't in this list: it's @runs local now — it SSHes out and
+# streams straight to this machine, the same shape as db-pull.
 BACKUP_COMMANDS="
-scripts/backup/db-backup
 scripts/backup/site-backup
 "
 
@@ -168,7 +169,6 @@ server_side_example_args() {
     case "$1" in
         scripts/monitoring/error-monitor) echo "example.com 48" ;;
         scripts/monitoring/run-monitoring) echo "24 example.com" ;;
-        scripts/backup/db-backup) echo "example.com production" ;;
         scripts/backup/site-backup) echo "example.com" ;;
         *) echo "/srv/www/example.com/logs/access.log 24" ;;
     esac
@@ -1324,12 +1324,8 @@ print_server_side_guidance() {
         echo "${DIM}That leaves the archive on the server. To back up *and* retrieve a copy${RESET}"
         echo "${DIM}to this machine in one step, use the Ansible playbooks instead:${RESET}"
         echo ""
-        if [[ "$command_key" == "scripts/backup/db-backup" ]]; then
-            echo "${DIM}  wp-ops trellis/backup/database-pull -e site=example.com -e env=production${RESET}"
-        else
-            echo "${DIM}  wp-ops trellis/backup/database-pull -e site=example.com -e env=production${RESET}"
-            echo "${DIM}  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production${RESET}"
-        fi
+        echo "${DIM}  wp-ops trellis/backup/database-pull -e site=example.com -e env=production${RESET}"
+        echo "${DIM}  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production${RESET}"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

- `scripts/backup/db-backup.sh` wrote its export to `/srv/backups/<site>/database` on the remote server, but a stock Trellis box provisions and `chown`s `/srv/www`, never `/srv/backups` itself — the `web` user the script runs as can't `mkdir` there, so it failed on every site's first run, not just the one it was caught on (imagewize.com).
- Rebuilt as a local wrapper, the same shape as `db-pull.sh`: SSHes into the site's own web directory (already `web`-writable) and streams `wp db export - | gzip` straight into a local `database_backup/` directory. No remote temp file is ever written, so there's nothing to clean up server-side either.
- `wp-ops db-backup example.com production` now runs directly instead of needing a manual `ssh ... 'bash -s' < db-backup.sh` pipe.
- Flips the script's `@runs` manifest tag from `server` to `local`, cleans up the now-stale hardcoded server-side command lists in `wp-ops`, `go/cmd/serverside.go`, and `go/internal/catalog/gen/main.go`, regenerates `catalog.json`, and updates the affected Go tests.
- Updates `trellis/backup/README.md` and `scripts/README.md` (the latter's `db-backup.sh` section fully described the old `/srv/backups`/URL-replacement behavior).
- Marks Gap 6's `db-backup` item done in `docs/wp-ops-recommendations.md`; bumps `CHANGELOG.md` to 3.27.1.

## Test plan

- [x] `./scripts/backup/db-backup.sh --help` and `./wp-ops db-backup --help` show the new usage
- [x] `./wp-ops db-backup --json` reports `runs_on: local`
- [x] `cd go && go build -o wp-ops . && go vet ./... && go test ./...` — all pass
- [x] `./go/scripts/parity-check.sh` — 8/8 pass
- [x] `./wp-ops --version` / `./go/wp-ops --version` report 3.27.1
- [x] Passing `development` as the environment prints the "already local" error instead of attempting SSH