### PR TITLE
feat(mcp-server): add url_audit tool for dev-URL cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.28.0] - 2026-08-03
+
+### Added
+
+- **mcp-server** - `url_audit` tool (`mcp-server/src/tools/urlAudit.ts`, registered in `mcp-server/src/server.ts`): audits `wp_posts.post_content` for hardcoded dev URLs (default patterns `.test`/`.localhost`) that `get_template_directory_uri()` bakes in during local content creation and that survive a database migration unless search-replaced — the CRITICAL check documented in the parent repo's `CLAUDE.md`, previously only reconstructed by hand from `wp-cli/migration/URL-UPDATE-METHODS.md` and `wp-cli/content-creation/PAGE-CREATION.md` each time. Reports a `wp db query` hit count per pattern; an optional `replace: {from, to}` always previews `wp search-replace --all-tables --precise --dry-run` first and only applies it for real when `confirm: true` is also set, matching `wp_cli`'s existing confirm-gating convention.
+
+### Changed
+
+- **mcp-server** - `tools/wpCli.ts`: factored `runWpCliRaw` (returns the raw exit code/stdout/stderr) out of `runWpCli` (which formats that into a human-readable string), so `urlAudit.ts` can parse the count query's stdout directly instead of scraping it out of the formatted string. `runWpCli` is now a thin wrapper over `runWpCliRaw`; behavior unchanged for existing callers.
+- **docs** - `docs/mcp-server-recommendations.md`: marked item 11 (the `url_audit` tool) done. `docs/wp-ops-recommendations.md`: marked Gap 4 done.
+
+Addresses Gap 4 of `docs/wp-ops-recommendations.md` and item 11 of `docs/mcp-server-recommendations.md`.
+
 ## [3.27.1] - 2026-08-03
 
 ### Fixed

--- a/docs/mcp-server-recommendations.md
+++ b/docs/mcp-server-recommendations.md
@@ -168,7 +168,7 @@ Observed setup gaps:
 
 ## Highest-leverage new tool
 
-11. **A `url_audit` tool for the dev-URL problem CLAUDE.md marks CRITICAL** —
+11. ✅ **A `url_audit` tool for the dev-URL problem CLAUDE.md marks CRITICAL** —
     one call that runs the `%.test%` query against production, reports hits, and
     (with `confirm: true`) runs the `wp search-replace`. Today that workflow is
     two or three hand-composed `wp_cli` calls reconstructed from documentation
@@ -176,12 +176,17 @@ Observed setup gaps:
     single deterministic call. `db_pull` / `files_pull` wrappers (already planned
     in the mcp-server README) are the natural follow-ups.
 
+    **Done, 2026-08-03.** `tools/urlAudit.ts` + `url_audit` in `server.ts`. Counts
+    per pattern (default `.test`/`.localhost`) via `wp db query`; `replace:
+    {from, to}` always previews `wp search-replace --dry-run` and only applies
+    for real with `confirm: true`, matching `wp_cli`'s existing confirm gating.
+
 ## Suggested order of work
 
 1. ✅ Items 1–4: config-only, doable immediately.
 2. ✅ Items 5–6: opens up all non-Trellis and static sites (turned out to already be implemented).
 3. ✅ Items 7–8: biggest recurring token savers.
-4. Items 9–11: output compaction and new tools — remaining.
+4. ✅ Item 11: `url_audit` tool — done. Item 9–10 (output compaction) remain.
 
 ---
 

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -141,6 +141,16 @@ workflow an agent should get as one deterministic call.
 outside an agent session — the read-only check is a one-line `wp db query` that the
 docs already give you.
 
+**Done, 2026-08-03.** `mcp-server/src/tools/urlAudit.ts` + a `url_audit` registration in
+`mcp-server/src/server.ts`. Runs a `wp db query … LIKE '%pattern%'` count per pattern
+(default `[".test", ".localhost"]`) against `wp_posts.post_content`; with `replace:
+{from, to}` it always previews `wp search-replace --all-tables --precise --dry-run`
+first and only applies for real when `confirm: true`. Built on `wpCli.ts`'s existing
+SSH/VM/local dispatch — `runWpCliRaw` was factored out of `runWpCli` so the count query
+result can be parsed as a number instead of scraped from the human-formatted string.
+No standalone `scripts/content/url-audit.sh` — the MCP tool covers the agent-session
+case this was written for, and the doc-given one-liner still covers the manual case.
+
 ---
 
 ## Gap 5: scripts worth upstreaming
@@ -272,6 +282,61 @@ them cover the two highest-frequency operations already.
 
 ---
 
+## Gap 7: dry-run coverage — mostly fine, two real gaps
+
+Prompted by `url_audit`'s design (a `replace` always previews via `wp
+search-replace --dry-run` first, and only applies for real with `confirm:
+true`): audited every *mutating* command in the catalog — anything that
+deletes, overwrites, search-replaces, pushes, provisions, or installs, not
+the read-only list/status/monitoring/audit scripts — for whether it has a
+literal `--dry-run` flag or an equivalent safety net. Verified 2026-08-03
+against script/playbook source, not just manifest headers.
+
+**Most already have one, just not always a literal flag:**
+
+| Command | Mutates | Safety net |
+|---------|---------|------------|
+| `scripts/misc/find-and-replace-files.sh` | files repo-wide | `-n`/`--dry-run` |
+| `scripts/sync/rsync-package-to-site.sh`, `rsync-theme.sh` | site/theme files | `--dry-run` |
+| `scripts/images/batch-resize.sh` | image files | `-d`/`--dry-run` |
+| `scripts/git/create-pr.sh` | GitHub PR | `--dry-run` + `read -p` prompts |
+| `bedrock/wp-cli-config/wp-cli-pattern-validate.php` | pattern files | preview-by-default; `--fix` opts into writing |
+| `scripts/patterns/center-screenshots.sh`, `trim-screenshots.sh` | images in place | auto-backs up originals to `originals/` first |
+| `scripts/backup/db-pull.sh` | local dev DB | backs up dev DB first, confirms (`--yes` to skip) |
+| `scripts/release/release-plugin.sh`, `release-theme.sh` | version bump, git commit | two confirmation prompts |
+| `scripts/release/upload-release-asset.sh` | GitHub release asset | confirms before overwrite |
+| `scripts/release/deploy-plugin-wporg.sh` | WP.org SVN (irreversible) | stages to local SVN checkout, prints `svn status`, only `svn ci`s with `--commit` |
+| `trellis/backup/database-push.yml` | remote DB (overwrite) | auto-exports/pulls a remote backup first |
+| `trellis/backup/database-pull.yml` | local dev DB (overwrite) | auto-backs up dev DB first |
+| `trellis/backup/files-push.yml` | remote uploads | Ansible `pause` confirmation prompt |
+| `trellis/backup/files-pull.yml` | local uploads | non-destructive (`delete: no`) |
+| `wp-cli/content-creation/import-page-draft.sh`, `page-creation.sh` | live page content | `read -p "Type 'yes' to continue"` |
+| `mcp-server` `wp_cli` tool | arbitrary WP-CLI | `confirm: true` gate on everything outside the read-only verb allowlist |
+| `mcp-server` `url_audit` tool | search-replace | dry-run preview always runs first; `confirm: true` to apply |
+
+**Two real gaps — no dry-run and no confirmation/backup net:**
+
+- **`scripts/woocommerce/create-product-variations.sh`** — bulk-creates
+  WooCommerce product variations directly via WP-CLI over the Trellis VM.
+  No preview, no confirmation prompt, no backup, no undo path. Highest
+  priority of the two: it's a live commerce catalog.
+- **`trellis/updater/trellis-updater.sh`** — backs up the whole Trellis
+  directory before starting (`cp -r … $BACKUP_DIR`), so a rollback path
+  exists, but nothing previews the changes and nothing asks for
+  confirmation before it starts rewriting files. Lower priority — the
+  backup makes this recoverable, just not previewable.
+
+**Recommendation:** add a `--dry-run` flag (print planned WP-CLI calls,
+skip execution) to `create-product-variations.sh` — it's the one script
+here with no safety net of any kind. Add a `read -p` confirmation prompt
+to `trellis-updater.sh` before it starts writing, matching the pattern
+`db-pull.sh` and the release scripts already use; skip a literal dry-run
+there since the existing backup already covers "how do I undo this."
+Everything else in the catalog is adequately covered and doesn't need
+follow-up.
+
+---
+
 ## Suggested order
 
 1. **Gap 3** — delete the stale seo-strategy monitoring fork. Costs nothing, stops
@@ -280,11 +345,13 @@ them cover the two highest-frequency operations already.
 3. **Gap 5 "Take" rows** — four scripts, mechanical work. **Done (2026-08-03).**
 4. **Gap 6, `db-backup`** — positional wrapper + fixes the `/srv/backups`
    permission dead end. Same shape and value as Gap 2. **Done.**
-5. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap.
+5. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap. **Done.**
 6. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to.
 7. **Gap 6, remaining items** — the other eight `-e`-style playbooks and four
    unwrapped server scripts. Same mechanical pattern as `db-backup`; lower
    priority since they're used less often.
+8. **Gap 7** — `--dry-run` for `create-product-variations.sh`; a confirmation
+   prompt for `trellis-updater.sh`. Small, isolated fixes.
 
 Deliberately not queued: `@key` or any new manifest directive (premise false, and
 per [go-mcp-parity.md](go-mcp-parity.md) any new directive must land in both

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — five tools implemented so far:
+Scaffold — six tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -35,6 +35,13 @@ Scaffold — five tools implemented so far:
   Organization, LocalBusiness, Service, Product, WebSite, BreadcrumbList, Article,
   FAQPage, HowTo, and Person schema types. Returns count of pages with/without schema
   and which schema types are present. Uses `curl` to fetch pages and extract schema.
+- **`url_audit`** — audits `wp_posts.post_content` for hardcoded dev URLs (default
+  patterns `.test`/`.localhost`) that `get_template_directory_uri()` bakes in during local
+  content creation and that survive a database migration unless search-replaced — the
+  CRITICAL check documented in the parent repo's `CLAUDE.md`. Reports a hit count per
+  pattern. Pass `replace: {from, to}` to also preview a
+  `wp search-replace --all-tables --precise --dry-run`; add `confirm: true` (only after
+  explicit user approval) to apply it for real.
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each
@@ -98,9 +105,11 @@ Or add the same block under `mcpServers` in Claude Desktop's config file.
 
 ## Permissions (pre-approve read-only tools)
 
-The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, and
-read-only `wp_cli` commands) are safe to run without confirmation. Pre-approve
-them in `~/.claude/settings.json` to avoid repeated permission prompts:
+The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`, and
+read-only `wp_cli` commands) are safe to run without confirmation — `url_audit` only
+ever queries counts and, at most, a `--dry-run` search-replace preview unless
+`confirm: true` is explicitly set. Pre-approve them in `~/.claude/settings.json` to
+avoid repeated permission prompts:
 
 ```json
 {
@@ -109,14 +118,16 @@ them in `~/.claude/settings.json` to avoid repeated permission prompts:
       "mcp__wp-ops__redirect_audit": { "allowed": true },
       "mcp__wp-ops__schema_audit": { "allowed": true },
       "mcp__wp-ops__security_scan": { "allowed": true },
+      "mcp__wp-ops__url_audit": { "allowed": true },
       "mcp__wp-ops__wp_cli": { "allowed": true }
     }
   }
 }
 ```
 
-Write operations (e.g., `wp_cli` with `search-replace`, `post delete`, `plugin install`)
-still require `confirm: true` and will prompt for approval.
+Write operations (e.g., `wp_cli` with `search-replace`, `post delete`, `plugin install`,
+or `url_audit` with `replace` + `confirm: true`) still require `confirm: true` and will
+prompt for approval.
 
 ## Usage Tips
 
@@ -126,7 +137,7 @@ still require `confirm: true` and will prompt for approval.
   `schema_audit` for static/Jekyll sites.
 - **CLAUDE.md integration:** In each project that uses these tools, add a note
   in `CLAUDE.md` like: "Prefer the wp-ops MCP tools (`wp_cli`, `security_scan`,
-  `redirect_audit`, `schema_audit`, `db_backup`) with the site key from
+  `redirect_audit`, `schema_audit`, `db_backup`, `url_audit`) with the site key from
   `mcp-server/config/sites.json`."
 
 ## Running as a network service (Streamable HTTP)

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { runSecurityScan } from "./tools/securityScan.js";
 import { isReadOnlyWpCommand, runWpCli } from "./tools/wpCli.js";
 import { runRedirectAudit } from "./tools/redirectAudit.js";
 import { runSchemaAudit } from "./tools/schemaAudit.js";
+import { runUrlAudit, DEFAULT_URL_AUDIT_PATTERNS } from "./tools/urlAudit.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -279,6 +280,75 @@ export function createServer(): McpServer {
         } else if (result.totalPages > 0) {
           lines.push("✅ All pages have schema markup!");
         }
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "url_audit",
+    'Audit wp_posts.post_content for hardcoded dev URLs (e.g. ".test"/".localhost") baked in by ' +
+      "get_template_directory_uri() during local content creation — the CRITICAL post-migration check " +
+      "CLAUDE.md documents. Reports a hit count per pattern. Pass `replace: {from, to}` to also preview " +
+      "a `wp search-replace --all-tables --precise --dry-run`; add confirm: true, only after explicit " +
+      "user approval, to apply it for real.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),
+      patterns: z
+        .array(z.string())
+        .min(1)
+        .default(DEFAULT_URL_AUDIT_PATTERNS)
+        .describe('Substrings to search for in wp_posts.post_content, e.g. [".test", ".localhost"]'),
+      replace: z
+        .object({
+          from: z.string().min(1).describe('URL to replace, e.g. "http://example.test"'),
+          to: z.string().min(1).describe('Replacement URL, e.g. "https://example.com"'),
+        })
+        .optional()
+        .describe(
+          "If set, runs `wp search-replace <from> <to> --all-tables --precise` as a dry-run preview " +
+            "(and for real if confirm: true)."
+        ),
+      confirm: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Required (true) to actually apply `replace`, not just preview it. Only set after explicit user approval."
+        ),
+    },
+    async ({ site, env, patterns, replace, confirm }) => {
+      try {
+        const registry = loadRegistry();
+        const entry = resolveSiteEnv(registry, site, env);
+        const result = await runUrlAudit(entry, patterns, replace, confirm);
+
+        const lines: string[] = [`URL Audit for ${site}/${env}:`, ""];
+        for (const f of result.findings) {
+          lines.push(`  "${f.pattern}": ${f.count} hit(s) in wp_posts.post_content`);
+        }
+        lines.push("");
+        lines.push(
+          result.totalHits === 0 ? "✅ No dev URLs found." : `⚠️  ${result.totalHits} total hit(s) found.`
+        );
+
+        if (result.replacement) {
+          lines.push("");
+          lines.push(`Search-replace preview (${result.replacement.from} → ${result.replacement.to}), dry-run:`);
+          lines.push(result.replacement.dryRunReport);
+          if (result.replacement.applied) {
+            lines.push("");
+            lines.push("Applied for real:");
+            lines.push(result.replacement.applyReport ?? "");
+          } else {
+            lines.push("");
+            lines.push("Not applied — re-run with confirm: true after explicit user approval to apply it.");
+          }
+        }
+
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/mcp-server/src/tools/urlAudit.ts
+++ b/mcp-server/src/tools/urlAudit.ts
@@ -1,0 +1,86 @@
+import type { EnvEntry } from "../registry.js";
+import { runWpCli, runWpCliRaw } from "./wpCli.js";
+
+export const DEFAULT_URL_AUDIT_PATTERNS = [".test", ".localhost"];
+
+export interface UrlAuditFinding {
+  pattern: string;
+  count: number;
+}
+
+export interface UrlReplacement {
+  from: string;
+  to: string;
+  dryRunReport: string;
+  applied: boolean;
+  applyReport?: string;
+}
+
+export interface UrlAuditResult {
+  findings: UrlAuditFinding[];
+  totalHits: number;
+  replacement?: UrlReplacement;
+}
+
+function escapeSqlLikeString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "''");
+}
+
+function parseCount(stdout: string): number {
+  const n = parseInt(stdout.trim(), 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+/**
+ * Audit wp_posts.post_content for hardcoded dev URLs (the CRITICAL check CLAUDE.md
+ * documents: patterns like ".test" get baked in by get_template_directory_uri() during
+ * local content creation and survive a database migration unless search-replaced).
+ * With `replace` set, always previews a `wp search-replace --dry-run` first; only applies
+ * it for real when `confirm` is also true.
+ */
+export async function runUrlAudit(
+  entry: EnvEntry,
+  patterns: string[] = DEFAULT_URL_AUDIT_PATTERNS,
+  replace?: { from: string; to: string },
+  confirm = false
+): Promise<UrlAuditResult> {
+  const findings: UrlAuditFinding[] = [];
+  for (const pattern of patterns) {
+    const sql = `SELECT COUNT(*) FROM wp_posts WHERE post_content LIKE '%${escapeSqlLikeString(pattern)}%';`;
+    const result = await runWpCliRaw(entry, ["db", "query", sql, "--skip-column-names"]);
+    if (result.code !== 0) {
+      throw new Error(
+        `wp db query failed for pattern "${pattern}": ${result.stderr.trim() || result.stdout.trim()}`
+      );
+    }
+    findings.push({ pattern, count: parseCount(result.stdout) });
+  }
+
+  const totalHits = findings.reduce((sum, f) => sum + f.count, 0);
+
+  let replacement: UrlReplacement | undefined;
+  if (replace) {
+    const dryRunReport = await runWpCli(entry, [
+      "search-replace",
+      replace.from,
+      replace.to,
+      "--all-tables",
+      "--precise",
+      "--dry-run",
+    ]);
+    replacement = { from: replace.from, to: replace.to, dryRunReport, applied: false };
+
+    if (confirm) {
+      replacement.applyReport = await runWpCli(entry, [
+        "search-replace",
+        replace.from,
+        replace.to,
+        "--all-tables",
+        "--precise",
+      ]);
+      replacement.applied = true;
+    }
+  }
+
+  return { findings, totalHits, replacement };
+}

--- a/mcp-server/src/tools/wpCli.ts
+++ b/mcp-server/src/tools/wpCli.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import type { EnvEntry } from "../registry.js";
 import { hasTrellisVm, resolveWpBin, resolvePhpBin } from "../registry.js";
 
-interface ExecResult {
+export interface ExecResult {
   stdout: string;
   stderr: string;
   code: number;
@@ -104,21 +104,26 @@ function runVm(trellisDir: string, workdir: string, wpPath: string, args: string
   });
 }
 
-export async function runWpCli(entry: EnvEntry, args: string[]): Promise<string> {
+// Raw exit code/stdout/stderr, for callers (e.g. urlAudit's count queries) that need to
+// parse stdout programmatically rather than read runWpCli's human-formatted string.
+export async function runWpCliRaw(entry: EnvEntry, args: string[]): Promise<ExecResult> {
   const wpBin = resolveWpBin(entry);
   const phpBin = resolvePhpBin(entry);
-  let result: ExecResult;
   // Order matters: a Trellis dev VM keeps the DB in the VM, so prefer the VM over
   // localPath when both are set — plain `wp` against the host can't reach the database.
   if (hasTrellisVm(entry)) {
-    result = await runVm(entry.trellisDir, entry.vmWorkdir, entry.vmPath ?? "web/wp", args, wpBin, phpBin);
+    return runVm(entry.trellisDir, entry.vmWorkdir, entry.vmPath ?? "web/wp", args, wpBin, phpBin);
   } else if (entry.sshHost && entry.remotePath) {
-    result = await runRemote(entry.sshHost, args, entry.remotePath, wpBin, phpBin);
+    return runRemote(entry.sshHost, args, entry.remotePath, wpBin, phpBin);
   } else if (entry.localPath) {
-    result = await runLocal(args, entry.localPath, wpBin, phpBin);
+    return runLocal(args, entry.localPath, wpBin, phpBin);
   } else {
     throw new Error("Site/env entry has none of: trellisDir+vmWorkdir, sshHost+remotePath, localPath, or url.");
   }
+}
+
+export async function runWpCli(entry: EnvEntry, args: string[]): Promise<string> {
+  const result = await runWpCliRaw(entry, args);
 
   // Nonzero exit isn't necessarily failure (e.g. `plugin is-active` returns 1 for
   // "inactive"), so report it rather than throwing and let the caller interpret it.


### PR DESCRIPTION
## Summary
- Adds an `url_audit` MCP tool that audits `wp_posts.post_content` for hardcoded dev URLs (default `.test`/`.localhost`) — the CRITICAL post-migration check `CLAUDE.md` documents, previously only reconstructed by hand from docs each time.
- `replace: {from, to}` always previews `wp search-replace --all-tables --precise --dry-run` first, and only applies for real when `confirm: true` is explicitly set, matching the existing `wp_cli` confirm-gating convention.
- Factors `runWpCliRaw` out of `runWpCli` so the count query's stdout can be parsed as a number instead of scraped from the formatted string.
- Marks Gap 4 (`docs/wp-ops-recommendations.md`) and item 11 (`docs/mcp-server-recommendations.md`) done.
- Adds a new Gap 7 to `docs/wp-ops-recommendations.md`: an audit of dry-run/safety-net coverage across every mutating command in the catalog. Most already have adequate coverage (dry-run flags, auto-backups, or confirmation prompts); flags two real gaps for future work — `scripts/woocommerce/create-product-variations.sh` (no safety net) and `trellis/updater/trellis-updater.sh` (has a backup, no confirmation prompt).
- CHANGELOG bumped to 3.28.0.

## Test plan
- [x] `npm run build` (tsc) passes clean in `mcp-server/`
- [ ] Manually exercise `url_audit` against a registered site/env via an MCP client (count-only, then with `replace` + `confirm: true` on a throwaway pattern)