### PR TITLE
Gap 6a: positional args for Ansible playbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.29.0] - 2026-08-03
+
+### Added
+
+- **wp-ops**, **go** - a generic positional-argument translator for `trellis/**/*.yml` (Ansible playbook) commands: `build_playbook_args()` in `wp-ops` (bash), `BuildPlaybookArgs()` in `go/internal/exec/ansible.go` (Go). Every `.yml` command's manifest already declares its `@arg`/`@flag` names, so the executor now consumes required `@arg` entries positionally, in manifest order, into `-e name=value`, then reads anything after that as `--name value` / `--name=value` against the declared `@flag` names into more `-e name=value` pairs — `wp-ops database-backup example.com production` and `wp-ops security-scan example.com production --hours 48 --threshold 50` both now work, matching `db-backup`/`db-pull`'s ergonomics without a bespoke script per playbook. The legacy explicit `-e key=value [...]` form keeps working unchanged: if the first raw arg already starts with `-`, nothing is translated. Covers all ten `trellis/backup/*.yml` and `trellis/monitoring/*.yml` commands from one change per CLI.
+
+### Changed
+
+- **trellis/backup**, **trellis/monitoring** - `@example` lines updated to the new positional form across `database-backup.yml`, `database-push.yml`, `database-pull.yml`, `files-backup.yml`, `files-pull.yml`, `files-push.yml`, `quick-status.yml`, `security-scan.yml`, `traffic-report.yml`, `setup-monitoring.yml`; the four with optional `@flag`s gained a second example demonstrating `--flag value` usage. `catalog.json` regenerated; `go/scripts/parity-check.sh` passes 8/8.
+- **docs** - `docs/wp-ops-recommendations.md`: marked Gap 6a done, with a note on why this was one generic translator rather than nine bespoke scripts (per `go-mcp-parity.md`'s "the scripts are the single source of truth" decision), and why a `@key`/`@alias` short-name directive was considered again and rejected for the same reason the original `@key` proposal was — bare-basename resolution already gives every one of these commands its short name today.
+
+Addresses Gap 6a of `docs/wp-ops-recommendations.md`.
+
 ## [3.28.0] - 2026-08-03
 
 ### Added

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -191,13 +191,13 @@ convention is what's awkward." Verified 2026-08-03: the same complaint applies
 to nine more Ansible playbooks, and a related-but-distinct one applies to five
 `scripts/*.sh` commands that have no wrapper of any kind yet.
 
-### 6a. Ansible playbooks still needing `-e site=... -e env=...`
+### 6a. Ansible playbooks still needing `-e site=... -e env=...` — done, 2026-08-03
 
-Every one of these takes exactly the `site`/`env` pair `db-pull` used to
+Every one of these took exactly the `site`/`env` pair `db-pull` used to
 require, resolved from `docs/wp-ops-recommendations.md`'s own catalog
 (`./wp-ops --json`, filtered to `.yml` scripts):
 
-| Command | Extra args | Today |
+| Command | Extra args | Before |
 |---------|-----------|-------|
 | `trellis/backup/database-backup` | — | `wp-ops trellis/backup/database-backup -e site=example.com -e env=production` |
 | `trellis/backup/database-push` | — | `wp-ops trellis/backup/database-push -e site=example.com -e env=staging` |
@@ -211,6 +211,37 @@ require, resolved from `docs/wp-ops-recommendations.md`'s own catalog
 
 (`trellis/backup/database-pull` is the tenth — already fixed by `db-pull.sh`,
 Gap 2.)
+
+**Done, 2026-08-03 — a generic translator, not nine bespoke scripts.** These
+nine playbooks work fine as-is; the only complaint was calling convention, so
+rewriting each as its own `.sh` (à la `db-pull.sh`/`db-backup.sh`) would have
+forked Ansible's logic into duplicate shell code for zero functional gain —
+against `go-mcp-parity.md`'s "the scripts are the single source of truth"
+decision. Instead, every `.yml` command's manifest already declares its
+`@arg`/`@flag` names (Phase A rollout group 2), so the executor itself now
+translates positional args against that declaration: required `@arg` entries
+are consumed positionally in manifest order into `-e name=value`; anything
+after that is read as `--name value` / `--name=value` against the declared
+`@flag` names into more `-e name=value` pairs. `wp-ops database-backup
+example.com production` and `wp-ops security-scan example.com production
+--hours 48 --threshold 50` both now work. The legacy explicit form keeps
+working unchanged — if the first raw arg already starts with `-` (i.e. `-e
+key=value ...`), nothing is translated, so no existing invocation (docs,
+muscle memory, other tooling) breaks.
+
+Implemented once in each CLI: `build_playbook_args()` in `wp-ops` (bash),
+`BuildPlaybookArgs()` in `go/internal/exec/ansible.go` (Go), both called from
+the same place the raw args used to be passed straight to
+`ansible-playbook`/`RunPlaybook`. Covers all nine playbooks (and any future
+`.yml` command with manifest args) from one change per CLI, not nine. Note
+the short command names above (`database-backup`, `security-scan`, ...)
+already worked before this — bare-basename resolution has always resolved
+them to their full catalog key (see "The verbose-path premise is false"); a
+`@key`/`@alias` directive giving them a *second*, different registered name
+was considered again while doing this work and rejected for the same reason
+the original `@key` proposal was: it would duplicate catalog entries in
+`list`/`--json` and risk `go/scripts/parity-check.sh` drift, for no gain over
+the exact-match basename resolution that already exists.
 
 ### 6b. `scripts/*.sh` commands with no wrapper at all — manual SSH pipe every time
 
@@ -347,9 +378,11 @@ follow-up.
    permission dead end. Same shape and value as Gap 2. **Done.**
 5. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap. **Done.**
 6. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to.
-7. **Gap 6, remaining items** — the other eight `-e`-style playbooks and four
-   unwrapped server scripts. Same mechanical pattern as `db-backup`; lower
-   priority since they're used less often.
+7. **Gap 6, remaining items** — 6a (the nine `-e`-style playbooks) **done**,
+   via a generic positional-arg translator rather than nine bespoke scripts.
+   6b (four unwrapped server scripts) remains — different shape, since there's
+   no underlying playbook to translate against; needs either real wrapper
+   scripts or M5's `--on <env>` SSH dispatch.
 8. **Gap 7** — `--dry-run` for `create-product-variations.sh`; a confirmation
    prompt for `trellis-updater.sh`. Small, isolated fixes.
 

--- a/go/cmd/dispatch.go
+++ b/go/cmd/dispatch.go
@@ -207,6 +207,12 @@ func executeAnsible(e catalog.Entry, args []string, isHelp bool) int {
 		return 1
 	}
 
+	playbookArgs, err := wpexec.BuildPlaybookArgs(e, args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
 	trellisDir, ok := resolveTrellisDir()
 	if !ok {
 		return 1
@@ -218,7 +224,7 @@ func executeAnsible(e catalog.Entry, args []string, isHelp bool) int {
 		return 1
 	}
 
-	code, err := wpexec.RunPlaybook(trellisDir, filepath.Join(root, e.ScriptPath), args)
+	code, err := wpexec.RunPlaybook(trellisDir, filepath.Join(root, e.ScriptPath), playbookArgs)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -1999,7 +1999,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/database-backup -e site=example.com -e env=production"
+      "wp-ops database-backup example.com production"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2038,7 +2038,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/database-pull -e site=example.com -e env=production"
+      "wp-ops database-pull example.com production"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2077,7 +2077,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/database-push -e site=example.com -e env=staging"
+      "wp-ops database-push example.com staging"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2117,7 +2117,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/files-backup -e site=example.com -e env=production"
+      "wp-ops files-backup example.com production"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2156,7 +2156,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/files-pull -e site=example.com -e env=production"
+      "wp-ops files-pull example.com production"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2195,7 +2195,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/backup/files-push -e site=example.com -e env=staging"
+      "wp-ops files-push example.com staging"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",
@@ -2245,7 +2245,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/monitoring/quick-status -e site=example.com -e env=production"
+      "wp-ops quick-status example.com production",
+      "wp-ops quick-status example.com production --log_path /var/log/custom.log"
     ],
     "manifest_category": "monitoring",
     "display_category": "trellis",
@@ -2311,7 +2312,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/monitoring/security-scan -e site=example.com -e env=production"
+      "wp-ops security-scan example.com production",
+      "wp-ops security-scan example.com production --hours 48 --threshold 50"
     ],
     "manifest_category": "monitoring",
     "display_category": "trellis",
@@ -2369,7 +2371,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/monitoring/setup-monitoring -e site=example.com -e env=production"
+      "wp-ops setup-monitoring example.com production",
+      "wp-ops setup-monitoring example.com production --email alerts@example.com"
     ],
     "manifest_category": "monitoring",
     "display_category": "trellis",
@@ -2427,7 +2430,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/monitoring/traffic-report -e site=example.com -e env=production"
+      "wp-ops traffic-report example.com production",
+      "wp-ops traffic-report example.com production --hours 48"
     ],
     "manifest_category": "monitoring",
     "display_category": "trellis",

--- a/go/internal/exec/ansible.go
+++ b/go/internal/exec/ansible.go
@@ -38,6 +38,77 @@ func RunPlaybook(trellisDir, playbookPath string, args []string) (exitCode int, 
 	return 0, nil
 }
 
+// BuildPlaybookArgs translates positional CLI args into ansible-playbook
+// "-e name=value" extra-vars using the command's manifest @arg/@flag
+// declarations, so e.g. "wp-ops database-backup example.com production"
+// becomes ["-e", "site=example.com", "-e", "env=production"] — the same
+// ergonomics db-pull.sh/db-backup.sh already have, without a bespoke script
+// per playbook (see docs/wp-ops-recommendations.md, Gap 6a).
+//
+// Required @arg entries are consumed positionally, in manifest order.
+// Anything after that is read as "--name value" or "--name=value" against
+// the declared @flag names. If the first raw arg already looks like a flag
+// (starts with "-"), nothing is translated — the caller is using the raw
+// "-e key=value [...]" form directly, which keeps working unchanged, same
+// as an entry with no manifest args at all.
+func BuildPlaybookArgs(e catalog.Entry, rawArgs []string) ([]string, error) {
+	if len(rawArgs) == 0 || strings.HasPrefix(rawArgs[0], "-") {
+		return rawArgs, nil
+	}
+	if !e.Annotated || len(e.Args) == 0 {
+		return rawArgs, nil
+	}
+
+	built := make([]string, 0, len(rawArgs)*2)
+
+	i := 0
+	for _, a := range e.Args {
+		if i >= len(rawArgs) || strings.HasPrefix(rawArgs[i], "-") {
+			return nil, fmt.Errorf(
+				"missing required argument <%s> (%s)\n\nUsage: wp-ops %s %s",
+				a.Name, a.Description, e.Key, positionalUsage(e),
+			)
+		}
+		built = append(built, "-e", a.Name+"="+rawArgs[i])
+		i++
+	}
+
+	for i < len(rawArgs) {
+		tok := rawArgs[i]
+		if strings.HasPrefix(tok, "--") {
+			name := strings.TrimPrefix(tok, "--")
+			var value string
+			if eq := strings.IndexByte(name, '='); eq >= 0 {
+				value = name[eq+1:]
+				name = name[:eq]
+			} else {
+				i++
+				if i >= len(rawArgs) {
+					return nil, fmt.Errorf("flag --%s needs a value", name)
+				}
+				value = rawArgs[i]
+			}
+			built = append(built, "-e", name+"="+value)
+			i++
+			continue
+		}
+		// Anything else (a raw "-e" pair, a stray positional) passes through
+		// untouched — same escape hatch as the leading-dash check above.
+		built = append(built, tok)
+		i++
+	}
+
+	return built, nil
+}
+
+func positionalUsage(e catalog.Entry) string {
+	parts := make([]string, len(e.Args))
+	for idx, a := range e.Args {
+		parts[idx] = "<" + a.Name + ">"
+	}
+	return strings.Join(parts, " ")
+}
+
 // FormatHelp renders --help for a trellis/*.yml command from its catalog
 // entry — manifest-first by construction, so unlike bash's pre-3.11 bug
 // (parent plan, Phase A rollout step 2) there's no probe and no

--- a/go/internal/exec/ansible_test.go
+++ b/go/internal/exec/ansible_test.go
@@ -1,10 +1,12 @@
 package exec
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/imagewize/wp-ops/go/internal/catalog"
+	"github.com/imagewize/wp-ops/go/internal/manifest"
 )
 
 func TestFormatHelp_AnnotatedPlaybook(t *testing.T) {
@@ -48,5 +50,136 @@ func TestFormatHelp_TrellisDirNotSet(t *testing.T) {
 	help := FormatHelp(e, "")
 	if !strings.Contains(help, "(currently: not set)") {
 		t.Errorf("FormatHelp with empty trellisDir missing 'not set':\n%s", help)
+	}
+}
+
+func testEntry() catalog.Entry {
+	return catalog.Entry{
+		Key:       "trellis/monitoring/security-scan",
+		Annotated: true,
+		Args: []manifest.Param{
+			{Name: "site", Required: true, Description: "Site name as in wordpress_sites.yml"},
+			{Name: "env", Required: true, Description: "Target environment"},
+		},
+		Flags: []manifest.Param{
+			{Name: "hours", Description: "How many hours of log history to scan"},
+			{Name: "threshold", Description: "Requests-per-IP alert threshold"},
+		},
+	}
+}
+
+func TestBuildPlaybookArgs_Positional(t *testing.T) {
+	got, err := BuildPlaybookArgs(testEntry(), []string{"example.com", "production"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"-e", "site=example.com", "-e", "env=production"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildPlaybookArgs_PositionalWithFlags(t *testing.T) {
+	got, err := BuildPlaybookArgs(testEntry(), []string{
+		"example.com", "production", "--hours", "48", "--threshold=50",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"-e", "site=example.com",
+		"-e", "env=production",
+		"-e", "hours=48",
+		"-e", "threshold=50",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildPlaybookArgs_TrailingRawExtraVar(t *testing.T) {
+	got, err := BuildPlaybookArgs(testEntry(), []string{
+		"example.com", "production", "-e", "retention_days=10",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"-e", "site=example.com",
+		"-e", "env=production",
+		"-e", "retention_days=10",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildPlaybookArgs_LegacyRawPassthrough(t *testing.T) {
+	raw := []string{"-e", "site=example.com", "-e", "env=production"}
+	got, err := BuildPlaybookArgs(testEntry(), raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, raw) {
+		t.Errorf("got %v, want unchanged %v", got, raw)
+	}
+}
+
+func TestBuildPlaybookArgs_MissingRequiredArg(t *testing.T) {
+	_, err := BuildPlaybookArgs(testEntry(), []string{"example.com"})
+	if err == nil {
+		t.Fatal("expected an error for a missing required argument, got nil")
+	}
+	if !strings.Contains(err.Error(), "<env>") {
+		t.Errorf("error should name the missing argument <env>: %v", err)
+	}
+}
+
+func TestBuildPlaybookArgs_MissingFlagValue(t *testing.T) {
+	_, err := BuildPlaybookArgs(testEntry(), []string{"example.com", "production", "--hours"})
+	if err == nil {
+		t.Fatal("expected an error for a flag with no value, got nil")
+	}
+}
+
+func TestBuildPlaybookArgs_EmptyArgs(t *testing.T) {
+	got, err := BuildPlaybookArgs(testEntry(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestBuildPlaybookArgs_NoManifestArgsPassesThrough(t *testing.T) {
+	e := catalog.Entry{Key: "trellis/backup/database-pull", Annotated: false}
+	raw := []string{"example.com", "production"}
+	got, err := BuildPlaybookArgs(e, raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, raw) {
+		t.Errorf("got %v, want unchanged %v", got, raw)
+	}
+}
+
+func TestBuildPlaybookArgs_RealCatalogEntry(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	e, ok := c.Lookup("trellis/backup/database-backup")
+	if !ok {
+		t.Fatal("trellis/backup/database-backup not found in catalog")
+	}
+
+	got, err := BuildPlaybookArgs(e, []string{"example.com", "production"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"-e", "site=example.com", "-e", "env=production"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/trellis/backup/database-backup.yml
+++ b/trellis/backup/database-backup.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging|development}  Target environment
-# @example  wp-ops trellis/backup/database-backup -e site=example.com -e env=production
+# @example  wp-ops database-backup example.com production
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/backup/database-pull.yml
+++ b/trellis/backup/database-pull.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging}  Remote environment to pull from
-# @example  wp-ops trellis/backup/database-pull -e site=example.com -e env=production
+# @example  wp-ops database-pull example.com production
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/backup/database-push.yml
+++ b/trellis/backup/database-push.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging}  Remote environment to push to
-# @example  wp-ops trellis/backup/database-push -e site=example.com -e env=staging
+# @example  wp-ops database-push example.com staging
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/backup/files-backup.yml
+++ b/trellis/backup/files-backup.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging|development}  Target environment
-# @example  wp-ops trellis/backup/files-backup -e site=example.com -e env=production
+# @example  wp-ops files-backup example.com production
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/backup/files-pull.yml
+++ b/trellis/backup/files-pull.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging}  Remote environment to pull from
-# @example  wp-ops trellis/backup/files-pull -e site=example.com -e env=production
+# @example  wp-ops files-pull example.com production
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/backup/files-push.yml
+++ b/trellis/backup/files-push.yml
@@ -7,7 +7,7 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging}  Remote environment to push to
-# @example  wp-ops trellis/backup/files-push -e site=example.com -e env=staging
+# @example  wp-ops files-push example.com staging
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/monitoring/quick-status.yml
+++ b/trellis/monitoring/quick-status.yml
@@ -8,7 +8,8 @@
 # @arg      site       required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env        required  {production|staging|development}  Target environment
 # @flag     log_path  optional  {/path/to/access.log}  Override the default per-site access log path
-# @example  wp-ops trellis/monitoring/quick-status -e site=example.com -e env=production
+# @example  wp-ops quick-status example.com production
+# @example  wp-ops quick-status example.com production --log_path /var/log/custom.log
 # @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/monitoring/security-scan.yml
+++ b/trellis/monitoring/security-scan.yml
@@ -10,7 +10,8 @@
 # @flag     hours       optional  {24}  How many hours of log history to scan
 # @flag     threshold   optional  {100}  Requests-per-IP alert threshold
 # @flag     log_path    optional  {/path/to/access.log}  Override the default per-site access log path
-# @example  wp-ops trellis/monitoring/security-scan -e site=example.com -e env=production
+# @example  wp-ops security-scan example.com production
+# @example  wp-ops security-scan example.com production --hours 48 --threshold 50
 # @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/monitoring/setup-monitoring.yml
+++ b/trellis/monitoring/setup-monitoring.yml
@@ -9,7 +9,8 @@
 # @arg      env         required  {production|staging|development}  Target environment
 # @flag     email      optional  {alerts@example.com}  Address to send monitoring alerts to
 # @flag     log_path   optional  {/path/to/access.log}  Override the default per-site access log path
-# @example  wp-ops trellis/monitoring/setup-monitoring -e site=example.com -e env=production
+# @example  wp-ops setup-monitoring example.com production
+# @example  wp-ops setup-monitoring example.com production --email alerts@example.com
 # @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/trellis/monitoring/traffic-report.yml
+++ b/trellis/monitoring/traffic-report.yml
@@ -9,7 +9,8 @@
 # @arg      env         required  {production|staging|development}  Target environment
 # @flag     hours      optional  {24}  How many hours of log history to include
 # @flag     log_path   optional  {/path/to/access.log}  Override the default per-site access log path
-# @example  wp-ops trellis/monitoring/traffic-report -e site=example.com -e env=production
+# @example  wp-ops traffic-report example.com production
+# @example  wp-ops traffic-report example.com production --hours 48
 # @doc      trellis/monitoring/README.md
 - import_playbook: variable-check.yml
   vars:

--- a/wp-ops
+++ b/wp-ops
@@ -1056,6 +1056,89 @@ require_trellis_dir() {
     return 0
 }
 
+# Translates positional CLI args into ansible-playbook "-e name=value" extra
+# vars using the command's manifest @arg/@flag declarations, so e.g.
+# "wp-ops database-backup example.com production" becomes "-e
+# site=example.com -e env=production" — the same ergonomics db-pull.sh/
+# db-backup.sh already have, without a bespoke script per playbook (see
+# docs/wp-ops-recommendations.md, Gap 6a).
+#
+# Required @arg entries are consumed positionally, in manifest order.
+# Anything after that is read as "--name value" or "--name=value" against
+# the declared @flag names. If the first raw arg already looks like a flag
+# (starts with "-"), nothing is translated — the caller is using the raw
+# "-e key=value [...]" form directly, which keeps working unchanged, same
+# as a command with no manifest @arg entries at all.
+#
+# Leaves the result in the global array PLAYBOOK_ARGS. Returns 1 (with an
+# error already printed) on a missing required argument or a flag with no
+# value.
+build_playbook_args() {
+    local command_key="$1"
+    shift
+    PLAYBOOK_ARGS=("$@")
+
+    [[ $# -eq 0 ]] && return 0
+    [[ "$1" == -* ]] && return 0
+    has_manifest "$command_key" || return 0
+
+    local manifest_args
+    manifest_args=$(manifest_get_all "$command_key" "arg")
+    [[ -z "$manifest_args" ]] && return 0
+
+    PLAYBOOK_ARGS=()
+    local line
+
+    while IFS= read -r line; do
+        manifest_parse_param_line "$line"
+        if [[ $# -eq 0 || "$1" == -* ]]; then
+            echo "${RED}${CROSS} Missing required argument <${_MP_NAME}> (${_MP_DESC})${RESET}" >&2
+            echo "" >&2
+            echo "Usage: wp-ops ${command_key} $(playbook_positional_usage "$command_key")" >&2
+            return 1
+        fi
+        PLAYBOOK_ARGS+=("-e" "${_MP_NAME}=$1")
+        shift
+    done <<< "$manifest_args"
+
+    while [[ $# -gt 0 ]]; do
+        if [[ "$1" == --* ]]; then
+            local flag_name="${1#--}"
+            local flag_value
+            if [[ "$flag_name" == *=* ]]; then
+                flag_value="${flag_name#*=}"
+                flag_name="${flag_name%%=*}"
+                shift
+            else
+                if [[ $# -lt 2 ]]; then
+                    echo "${RED}${CROSS} Flag --${flag_name} needs a value${RESET}" >&2
+                    return 1
+                fi
+                flag_value="$2"
+                shift 2
+            fi
+            PLAYBOOK_ARGS+=("-e" "${flag_name}=${flag_value}")
+        else
+            PLAYBOOK_ARGS+=("$1")
+            shift
+        fi
+    done
+
+    return 0
+}
+
+# "<site> <env>"-style usage fragment for build_playbook_args' missing-argument error.
+playbook_positional_usage() {
+    local command_key="$1"
+    local manifest_args line out=""
+    manifest_args=$(manifest_get_all "$command_key" "arg")
+    while IFS= read -r line; do
+        manifest_parse_param_line "$line"
+        out="${out}<${_MP_NAME}> "
+    done <<< "$manifest_args"
+    echo "${out% }"
+}
+
 execute_playbook() {
     local command_key="$1"
     local script_path="$2"
@@ -1086,10 +1169,12 @@ execute_playbook() {
         return 1
     fi
 
+    build_playbook_args "$command_key" "$@" || return 1
+
     require_trellis_dir || return 1
 
     local exit_code=0
-    (cd "$TRELLIS_DIR" && ansible-playbook "$script_path" "$@") || exit_code=$?
+    (cd "$TRELLIS_DIR" && ansible-playbook "$script_path" "${PLAYBOOK_ARGS[@]}") || exit_code=$?
 
     if [[ -t 1 ]]; then
         echo ""


### PR DESCRIPTION
## Summary
- Adds a generic positional-argument translator for `trellis/**/*.yml` commands, driven by each command's existing manifest `@arg`/`@flag` declarations, implemented once in each CLI (`build_playbook_args()` in bash `wp-ops`, `BuildPlaybookArgs()` in `go/internal/exec/ansible.go`).
- `wp-ops database-backup example.com production` and `wp-ops security-scan example.com production --hours 48 --threshold 50` now work, matching `db-backup`/`db-pull`'s ergonomics — no bespoke wrapper script per playbook. The legacy `-e site=... -e env=...` form keeps working unchanged (raw passthrough when the first arg starts with `-`).
- Covers all ten `trellis/backup/*.yml` and `trellis/monitoring/*.yml` commands (Gap 6a's nine, plus `database-pull.yml` for consistency).
- `@example` lines updated across all ten manifests; `catalog.json` regenerated.
- Docs: `docs/wp-ops-recommendations.md` Gap 6a marked done (with the reasoning for a generic translator over per-playbook scripts, and why an `@alias` short-name directive was reconsidered and rejected again — bare-basename resolution already gives every command its short name). `CHANGELOG.md` bumped to 3.29.0.

## Test plan
- [x] `wp-ops manifest lint` — 69 annotated commands, no problems
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all green
- [x] `go/scripts/parity-check.sh` — 8/8, including strict `--json list` field diff
- [x] Manual smoke test (both CLIs, `ansible-playbook` shimmed to echo argv): positional args, `--flag value`/`--flag=value`, trailing raw `-e` extra-var, legacy full `-e` passthrough, missing-required-arg error, missing-flag-value error — bash and Go produce byte-identical `ansible-playbook` argv in every case