### PR TITLE
feat(go): add wp-ops init command to install shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.0] - 2026-08-03
+
+### Added
+
+- **go** - `wp-ops init`: installs the Cobra-generated shell completion script for zsh, bash, or fish (auto-detected from `$SHELL`, or `--shell` to override), so `wp-ops <TAB>` works without the user hand-running `wp-ops completion <shell>` and figuring out where to put the output themselves. Prefers Homebrew-managed completion directories (`$(brew --prefix)/share/zsh/site-functions`, `.../share/bash-completion/completions`) when `brew` is on `PATH` — matching how this CLI is actually distributed (`homebrew_casks` in `.goreleaser.yml`, which unlike a Homebrew formula does *not* wire up completions automatically) — and falls back to a per-user directory (`~/.zsh/completions`, `~/.local/share/bash-completion/completions`, `~/.config/fish/completions`) otherwise, printing the `fpath`/`source` line the user still needs to add in that case. Named to match trellis-cli's `trellis init`; `doctor` remains the `trellis check` equivalent, which already existed.
+
+Addresses a gap raised in conversation: `doctor.go`'s `checkShellCompletion()` could tell you completions weren't installed but nothing installed them, and the Homebrew cask distribution path means no user gets them for free.
+
 ## [3.29.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A single entry point for everything in this repo. Auto-discovers commands across
 ```bash
 # Recommended: Homebrew (installs the Go binary)
 brew install imagewize/tap/wp-ops
+wp-ops init                  # install shell completions (one-time)
 
 # Without Homebrew, the bash CLI:
 ./install.sh                 # add wp-ops to your PATH (one-time)
@@ -46,6 +47,8 @@ wp-ops <command> --where     # print the path to a command's script
 `wp-ops` with no arguments opens an interactive picker. In the bash CLI, install [fzf](https://github.com/junegunn/fzf) (`brew install fzf`) and it becomes a fuzzy search over every command with the script's header as a live preview; without fzf it falls back to a numbered category → command menu. The Go CLI's picker (Bubble Tea) has this built in — no `fzf` dependency either way.
 
 Run `wp-ops doctor` first — it reports which of the external tools these scripts rely on (WP-CLI, Ansible, ImageMagick, `gh`, `cwebp`, Node, …) are actually installed, so you find out before a command fails partway through.
+
+`wp-ops init` (Go CLI only) installs `wp-ops <TAB>` completion for zsh, bash, or fish, auto-detected from `$SHELL`. Worth running right after `brew install` — the Homebrew cask this ships as doesn't wire up completions on its own the way a Homebrew formula would.
 
 Two categories need environment variables pointing at a real project before their commands work:
 

--- a/go/cmd/init.go
+++ b/go/cmd/init.go
@@ -1,0 +1,173 @@
+// One-time environment setup — currently just shell completions. Named to
+// match trellis-cli's `trellis init` (trellis's health check is `trellis
+// check`; wp-ops's equivalent is the pre-existing `doctor` command, so
+// `init` here is reserved for one-time setup rather than diagnostics).
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var initShellFlag string
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Install shell completions for wp-ops",
+	Long: `init installs the wp-ops completion script for your shell, so
+"wp-ops <TAB>" completes commands, categories, and command names.
+
+Detects your shell from $SHELL. Pass --shell to override.`,
+	RunE: func(cc *cobra.Command, args []string) error {
+		os.Exit(runInit(initShellFlag))
+		return nil
+	},
+}
+
+func init() {
+	initCmd.Flags().StringVar(&initShellFlag, "shell", "", "shell to install completions for (zsh, bash, fish) — default: detect from $SHELL")
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit(shell string) int {
+	if shell == "" {
+		shell = filepath.Base(os.Getenv("SHELL"))
+	}
+
+	switch shell {
+	case "zsh":
+		return installCompletion("zsh", "_wp-ops", zshCandidateDirs(), genZshCompletion)
+	case "bash":
+		return installCompletion("bash", "wp-ops", bashCandidateDirs(), genBashCompletion)
+	case "fish":
+		return installCompletion("fish", "wp-ops.fish", fishCandidateDirs(), genFishCompletion)
+	default:
+		fmt.Fprintf(os.Stderr, "wp-ops init: unrecognized shell %q — pass --shell zsh|bash|fish\n", shell)
+		return 1
+	}
+}
+
+func genZshCompletion(buf *bytes.Buffer) error  { return rootCmd.GenZshCompletion(buf) }
+func genBashCompletion(buf *bytes.Buffer) error { return rootCmd.GenBashCompletionV2(buf, true) }
+func genFishCompletion(buf *bytes.Buffer) error { return rootCmd.GenFishCompletion(buf, true) }
+
+// completionDir is one candidate install location. needsWiring is true for
+// per-user fallback directories that aren't on the shell's completion
+// search path by default (unlike a Homebrew-managed or system completions
+// dir, which is), so installCompletion knows when to print setup guidance.
+type completionDir struct {
+	path        string
+	needsWiring bool
+}
+
+// installCompletion generates the completion script and writes it to the
+// first candidate directory that accepts the write, falling back down the
+// list — e.g. a Homebrew-managed completions dir first, a per-user
+// directory last. Reports which directory it landed on and, if that
+// directory isn't on the shell's completion search path by default, what
+// the user still needs to do to make it load.
+func installCompletion(shell, filename string, candidates []completionDir, gen func(*bytes.Buffer) error) int {
+	var buf bytes.Buffer
+	if err := gen(&buf); err != nil {
+		fmt.Fprintf(os.Stderr, "wp-ops init: generating %s completion: %v\n", shell, err)
+		return 1
+	}
+
+	var lastErr error
+	for _, c := range candidates {
+		if err := os.MkdirAll(c.path, 0755); err != nil {
+			lastErr = err
+			continue
+		}
+		path := filepath.Join(c.path, filename)
+		if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+			lastErr = err
+			continue
+		}
+
+		fmt.Printf("Installed %s completion: %s\n", shell, path)
+		if c.needsWiring {
+			fmt.Println(fallbackNote(shell, c.path))
+		}
+		fmt.Println("Restart your shell (or open a new terminal) to pick it up.")
+		return 0
+	}
+
+	fmt.Fprintf(os.Stderr, "wp-ops init: couldn't write completion to any candidate directory: %v\n", lastErr)
+	return 1
+}
+
+func fallbackNote(shell, dir string) string {
+	switch shell {
+	case "zsh":
+		return fmt.Sprintf("Not on your fpath by default — add this to ~/.zshrc before compinit runs:\n  fpath=(%s $fpath)", dir)
+	case "bash":
+		return fmt.Sprintf("Not auto-sourced by default — add this to ~/.bashrc:\n  source %s/wp-ops", dir)
+	default:
+		return ""
+	}
+}
+
+// brewPrefix shells out to `brew --prefix`; returns ok=false if brew isn't
+// on PATH or the lookup fails, so callers fall through to non-Homebrew
+// candidates.
+func brewPrefix() (string, bool) {
+	out, err := osexec.Command("brew", "--prefix").Output()
+	if err != nil {
+		return "", false
+	}
+	prefix := string(bytes.TrimSpace(out))
+	if prefix == "" {
+		return "", false
+	}
+	return prefix, true
+}
+
+func zshCandidateDirs() []completionDir {
+	var dirs []completionDir
+	if prefix, ok := brewPrefix(); ok {
+		dirs = append(dirs, completionDir{filepath.Join(prefix, "share", "zsh", "site-functions"), false})
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, completionDir{filepath.Join(home, ".zsh", "completions"), true})
+	}
+	return dirs
+}
+
+func bashCandidateDirs() []completionDir {
+	var dirs []completionDir
+	if prefix, ok := brewPrefix(); ok {
+		// bash-completion@2 (share/bash-completion/completions) is what
+		// modern Homebrew installs; etc/bash_completion.d is the older
+		// bash-completion v1 layout. Prefer whichever already exists.
+		v2 := filepath.Join(prefix, "share", "bash-completion", "completions")
+		if info, err := os.Stat(v2); err == nil && info.IsDir() {
+			dirs = append(dirs, completionDir{v2, false})
+		} else {
+			dirs = append(dirs, completionDir{filepath.Join(prefix, "etc", "bash_completion.d"), false})
+		}
+	}
+	for _, d := range []string{"/usr/share/bash-completion/completions", "/etc/bash_completion.d"} {
+		if info, err := os.Stat(d); err == nil && info.IsDir() {
+			dirs = append(dirs, completionDir{d, false})
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, completionDir{filepath.Join(home, ".local", "share", "bash-completion", "completions"), true})
+	}
+	return dirs
+}
+
+func fishCandidateDirs() []completionDir {
+	if home, err := os.UserHomeDir(); err == nil {
+		// Fish auto-loads everything under its own completions dir, so this
+		// never needs manual wiring — unlike the zsh/bash per-user fallbacks.
+		return []completionDir{{filepath.Join(home, ".config", "fish", "completions"), false}}
+	}
+	return nil
+}

--- a/go/cmd/init.go
+++ b/go/cmd/init.go
@@ -139,6 +139,15 @@ func zshCandidateDirs() []completionDir {
 	return dirs
 }
 
+// systemBashCompletionDirs are the well-known install locations for the
+// bash-completion package on Linux, checked regardless of Homebrew — a
+// package-level var (rather than an inline literal) purely so tests can
+// override it and avoid ever touching real system directories.
+var systemBashCompletionDirs = []string{
+	"/usr/share/bash-completion/completions",
+	"/etc/bash_completion.d",
+}
+
 func bashCandidateDirs() []completionDir {
 	var dirs []completionDir
 	if prefix, ok := brewPrefix(); ok {
@@ -152,7 +161,7 @@ func bashCandidateDirs() []completionDir {
 			dirs = append(dirs, completionDir{filepath.Join(prefix, "etc", "bash_completion.d"), false})
 		}
 	}
-	for _, d := range []string{"/usr/share/bash-completion/completions", "/etc/bash_completion.d"} {
+	for _, d := range systemBashCompletionDirs {
 		if info, err := os.Stat(d); err == nil && info.IsDir() {
 			dirs = append(dirs, completionDir{d, false})
 		}

--- a/go/cmd/init_test.go
+++ b/go/cmd/init_test.go
@@ -150,24 +150,34 @@ func TestZshCandidateDirsFallBackWithoutBrew(t *testing.T) {
 	}
 }
 
+// withNoSystemBashCompletionDirs points systemBashCompletionDirs at
+// nonexistent paths for the duration of the test, restoring the original on
+// cleanup. Without this, bashCandidateDirs() checks real, hardcoded system
+// paths (/usr/share/bash-completion/completions, /etc/bash_completion.d)
+// that may genuinely exist — and be writable — on the machine running the
+// test (true on the Linux CI runner), which would both make the "no brew"
+// fallback assertion flaky across platforms and, worse, actually write a
+// completion file into a real system directory as a test side effect.
+func withNoSystemBashCompletionDirs(t *testing.T) {
+	t.Helper()
+	orig := systemBashCompletionDirs
+	systemBashCompletionDirs = []string{filepath.Join(t.TempDir(), "does-not-exist")}
+	t.Cleanup(func() { systemBashCompletionDirs = orig })
+}
+
 func TestBashCandidateDirsEndsWithHomeFallback(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("PATH", "/usr/bin:/bin")
+	withNoSystemBashCompletionDirs(t)
 
 	dirs := bashCandidateDirs()
-	if len(dirs) == 0 {
-		t.Fatal("bashCandidateDirs() returned no candidates")
+	if len(dirs) != 1 {
+		t.Fatalf("bashCandidateDirs() without brew or system dirs = %d entries, want 1 (home fallback only)", len(dirs))
 	}
-	last := dirs[len(dirs)-1]
 	want := filepath.Join(home, ".local", "share", "bash-completion", "completions")
-	if last.path != want || !last.needsWiring {
-		t.Errorf("last candidate = %+v, want {%q, true}", last, want)
-	}
-	for _, d := range dirs[:len(dirs)-1] {
-		if d.needsWiring {
-			t.Errorf("candidate %q marked needsWiring=true, want false for system/brew dirs", d.path)
-		}
+	if dirs[0].path != want || !dirs[0].needsWiring {
+		t.Errorf("candidate = %+v, want {%q, true}", dirs[0], want)
 	}
 }
 
@@ -215,6 +225,7 @@ func TestRunInitEndToEnd(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("PATH", "/usr/bin:/bin") // force the no-brew fallback paths
+	withNoSystemBashCompletionDirs(t)
 
 	cases := []struct {
 		shell string

--- a/go/cmd/init_test.go
+++ b/go/cmd/init_test.go
@@ -1,0 +1,237 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func fakeGen(content string) func(*bytes.Buffer) error {
+	return func(buf *bytes.Buffer) error {
+		buf.WriteString(content)
+		return nil
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what
+// was written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe(): %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	return buf.String()
+}
+
+// TestInstallCompletionWritesFirstWritableCandidate covers the fallback
+// walk: a candidate whose MkdirAll fails (it's a file, not a dir) must be
+// skipped in favor of the next one, and only that second candidate's
+// needsWiring note should print.
+func TestInstallCompletionWritesFirstWritableCandidate(t *testing.T) {
+	tmp := t.TempDir()
+	blocked := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(tmp, "good")
+
+	var code int
+	out := captureStdout(t, func() {
+		code = installCompletion("zsh", "_wp-ops", []completionDir{
+			{blocked, false},
+			{good, true},
+		}, fakeGen("# fake completion\n"))
+	})
+
+	if code != 0 {
+		t.Fatalf("installCompletion() = %d, want 0", code)
+	}
+
+	path := filepath.Join(good, "_wp-ops")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected completion written to %s: %v", path, err)
+	}
+	if string(content) != "# fake completion\n" {
+		t.Errorf("wrote %q, want the generated content", content)
+	}
+	if !bytes.Contains([]byte(out), []byte("fpath")) {
+		t.Errorf("output %q, want a fpath-wiring note since the winning candidate has needsWiring=true", out)
+	}
+}
+
+// TestInstallCompletionNoWiringNoteWhenNotNeeded is the inverse: landing on
+// a needsWiring=false candidate (e.g. Homebrew's site-functions dir) prints
+// no follow-up instructions.
+func TestInstallCompletionNoWiringNoteWhenNotNeeded(t *testing.T) {
+	good := filepath.Join(t.TempDir(), "good")
+
+	out := captureStdout(t, func() {
+		installCompletion("zsh", "_wp-ops", []completionDir{{good, false}}, fakeGen("# fake\n"))
+	})
+
+	if bytes.Contains([]byte(out), []byte("fpath")) {
+		t.Errorf("output %q, want no fpath-wiring note when needsWiring=false", out)
+	}
+}
+
+func TestInstallCompletionFailsWhenNoCandidateWritable(t *testing.T) {
+	tmp := t.TempDir()
+	blocked := filepath.Join(tmp, "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	code := installCompletion("zsh", "_wp-ops", []completionDir{{blocked, false}}, fakeGen("# fake\n"))
+	if code != 1 {
+		t.Fatalf("installCompletion() = %d, want 1 when every candidate is unwritable", code)
+	}
+}
+
+func TestInstallCompletionPropagatesGenError(t *testing.T) {
+	gen := func(buf *bytes.Buffer) error { return errors.New("boom") }
+	code := installCompletion("zsh", "_wp-ops", []completionDir{{t.TempDir(), false}}, gen)
+	if code != 1 {
+		t.Fatalf("installCompletion() = %d, want 1 when the generator errors", code)
+	}
+}
+
+func TestRunInitUnrecognizedShell(t *testing.T) {
+	if code := runInit("powershell"); code != 1 {
+		t.Errorf("runInit(%q) = %d, want 1", "powershell", code)
+	}
+}
+
+func TestFishCandidateDirsNeverNeedsWiring(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dirs := fishCandidateDirs()
+	if len(dirs) != 1 {
+		t.Fatalf("fishCandidateDirs() = %d entries, want 1", len(dirs))
+	}
+	if dirs[0].needsWiring {
+		t.Error("fish auto-loads its completions dir — should never need manual wiring")
+	}
+	want := filepath.Join(home, ".config", "fish", "completions")
+	if dirs[0].path != want {
+		t.Errorf("fishCandidateDirs()[0].path = %q, want %q", dirs[0].path, want)
+	}
+}
+
+// TestZshCandidateDirsFallBackWithoutBrew and
+// TestBashCandidateDirsFallBackWithoutBrew simulate a machine with no
+// Homebrew on PATH (same technique as the manual `env -i` check this was
+// verified against): the only remaining candidate must be the per-user
+// fallback dir, marked needsWiring.
+func TestZshCandidateDirsFallBackWithoutBrew(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	dirs := zshCandidateDirs()
+	if len(dirs) != 1 {
+		t.Fatalf("zshCandidateDirs() without brew = %d entries, want 1 (home fallback only)", len(dirs))
+	}
+	if !dirs[0].needsWiring {
+		t.Error("home-directory zsh completions dir needs manual fpath wiring")
+	}
+}
+
+func TestBashCandidateDirsEndsWithHomeFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	dirs := bashCandidateDirs()
+	if len(dirs) == 0 {
+		t.Fatal("bashCandidateDirs() returned no candidates")
+	}
+	last := dirs[len(dirs)-1]
+	want := filepath.Join(home, ".local", "share", "bash-completion", "completions")
+	if last.path != want || !last.needsWiring {
+		t.Errorf("last candidate = %+v, want {%q, true}", last, want)
+	}
+	for _, d := range dirs[:len(dirs)-1] {
+		if d.needsWiring {
+			t.Errorf("candidate %q marked needsWiring=true, want false for system/brew dirs", d.path)
+		}
+	}
+}
+
+func TestBrewPrefixFalseWithoutBrewOnPath(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	if _, ok := brewPrefix(); ok {
+		t.Error("brewPrefix() reported ok with brew excluded from PATH")
+	}
+}
+
+// TestGenCompletionsProduceRealOutput exercises the three Cobra generator
+// adapters directly — each must round-trip rootCmd into a non-empty,
+// shell-appropriate script.
+func TestGenCompletionsProduceRealOutput(t *testing.T) {
+	cases := []struct {
+		name   string
+		gen    func(*bytes.Buffer) error
+		marker string
+	}{
+		{"zsh", genZshCompletion, "#compdef wp-ops"},
+		{"bash", genBashCompletion, "bash completion"},
+		{"fish", genFishCompletion, "fish completion"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := c.gen(&buf); err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+			if buf.Len() == 0 {
+				t.Fatalf("%s: generated empty completion script", c.name)
+			}
+			if !bytes.Contains(buf.Bytes(), []byte(c.marker)) {
+				t.Errorf("%s: output missing expected marker %q", c.name, c.marker)
+			}
+		})
+	}
+}
+
+// TestRunInitEndToEnd exercises runInit's shell-dispatch switch for each
+// supported shell against a sandboxed HOME, covering the full path from
+// $SHELL detection through file-on-disk — not just installCompletion in
+// isolation.
+func TestRunInitEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin") // force the no-brew fallback paths
+
+	cases := []struct {
+		shell string
+		path  string
+	}{
+		{"zsh", filepath.Join(home, ".zsh", "completions", "_wp-ops")},
+		{"bash", filepath.Join(home, ".local", "share", "bash-completion", "completions", "wp-ops")},
+		{"fish", filepath.Join(home, ".config", "fish", "completions", "wp-ops.fish")},
+	}
+	for _, c := range cases {
+		t.Run(c.shell, func(t *testing.T) {
+			if code := runInit(c.shell); code != 0 {
+				t.Fatalf("runInit(%q) = %d, want 0", c.shell, code)
+			}
+			if _, err := os.Stat(c.path); err != nil {
+				t.Errorf("expected completion at %s: %v", c.path, err)
+			}
+		})
+	}
+}

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -33,6 +33,7 @@ playbooks, and more.
   wp-ops search <term>                    Search commands by name or description
   wp-ops docs [term] [-l]                 Search the guides (no term lists them)
   wp-ops doctor                           Check dependencies and environment
+  wp-ops init                             Install shell completions
   wp-ops --json                           Output the command list as JSON
   wp-ops --version                        Show version`,
 	// Arbitrary args: a bare command name that isn't one of the explicitly


### PR DESCRIPTION
## Summary
- Adds `wp-ops init` to the Go CLI: detects the user's shell from `$SHELL` (or `--shell` override) and installs the Cobra-generated completion script for zsh/bash/fish, so `wp-ops <TAB>` works out of the box.
- Prefers Homebrew-managed completion directories (`$(brew --prefix)/share/zsh/site-functions`, `.../share/bash-completion/completions`) since this CLI is distributed as a `homebrew_casks` release — unlike a Homebrew formula, casks don't wire up completions automatically. Falls back to a per-user directory (`~/.zsh/completions`, `~/.local/share/bash-completion/completions`, `~/.config/fish/completions`) when brew isn't on PATH, printing the `fpath`/`source` line still needed in that case.
- Named `init` to match trellis-cli's `trellis init`; `wp-ops doctor` already fills the `trellis check` role, so `init` was free for one-time setup.
- Bumped to `3.30.0` in `CHANGELOG.md` (this repo reads its version from the changelog at runtime) and documented in `README.md`.

## Test plan
- [x] `go build ./go/...`, `go vet ./go/...`, `go test ./go/...` all clean
- [x] `go/scripts/parity-check.sh` passes 8/8 (unaffected — no manifest/catalog changes)
- [x] Manually ran `wp-ops init --shell zsh|bash|fish` and confirmed correct completion files land in the expected Homebrew directories, with real zsh `compdef` registration verified
- [x] Manually simulated no-Homebrew-on-PATH (`env -i`) and confirmed fallback to per-user directories with the wiring note printed
- [x] New unit tests in `go/cmd/init_test.go` cover the candidate-directory fallback walk, wiring-note logic, unrecognized-shell handling, and end-to-end runs for all three shells against a sandboxed `$HOME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)