### PR TITLE
fix(go): complete basenames like db-backup at wp-ops root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.1] - 2026-08-03
+
+### Fixed
+
+- **go** - `wp-ops <TAB>` (root-level completion) offered categories and other registered subcommands but no basenames (e.g. `db-backup`, `db-pull`) — the per-entry full-key commands (`scripts/backup/db-backup`) are registered `Hidden` so `wp-ops --help` isn't drowned in ~66 entries, and Cobra's default subcommand-name completion skips hidden commands. `wp-ops <category> <TAB>` (e.g. `wp-ops scripts <TAB>`) already worked via `categoryBasenameCompletions`; root itself had no `ValidArgsFunction` to fall back on. Added `rootBasenameCompletions` (`go/cmd/dispatch.go`) and wired it into `rootCmd.ValidArgsFunction` (`go/cmd/root.go`) — Cobra calls `ValidArgsFunction` in addition to its subcommand-name matching, not instead of it, so this supplements the existing category/subcommand completions rather than replacing them. Matches the bare-basename invocation `rootRunE` already supports via `FindByBasename`.
+
+Found after running `wp-ops init` and finding `wp-ops db<TAB>` produced no completions.
+
 ## [3.30.0] - 2026-08-03
 
 ### Added

--- a/go/cmd/dispatch.go
+++ b/go/cmd/dispatch.go
@@ -88,6 +88,32 @@ func categoryBasenameCompletions(cat string) func(cc *cobra.Command, args []stri
 	}
 }
 
+// rootBasenameCompletions backs `wp-ops <TAB>` for basenames like
+// "db-backup": the per-entry full-key commands registered above are
+// Hidden, and Cobra's default subcommand-name completion skips hidden
+// commands, so without this only categories/list/search/etc. would
+// complete — even though a bare basename (rootRunE's FindByBasename
+// fallback) is a valid invocation. Cobra calls ValidArgsFunction in
+// addition to its subcommand-name matching (not instead of), so this
+// supplements rather than replaces the category/subcommand completions.
+func rootBasenameCompletions(cc *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	entries := mustCatalog().Entries
+	seen := make(map[string]bool, len(entries))
+	basenames := make([]string, 0, len(entries))
+	for _, e := range entries {
+		b := filepath.Base(e.Key)
+		if seen[b] {
+			continue
+		}
+		seen[b] = true
+		basenames = append(basenames, b)
+	}
+	return basenames, cobra.ShellCompDirectiveNoFileComp
+}
+
 // runCategory resolves a bare command name within a category, port of
 // main()'s "wp-ops <category> <command>" branch (wp-ops:2246-2283):
 // preferring a basename match inside the category, falling back to the

--- a/go/cmd/dispatch_test.go
+++ b/go/cmd/dispatch_test.go
@@ -48,6 +48,71 @@ func TestCategoryBasenameCompletions(t *testing.T) {
 	}
 }
 
+// TestRootBasenameCompletions checks `wp-ops <TAB>` offers every catalog
+// basename (e.g. "db-backup"), deduplicated — the root-level counterpart to
+// TestCategoryBasenameCompletions. Without this, only registered
+// subcommands (categories, list, search, ...) would complete, since the
+// per-entry full-key commands are Hidden and Cobra's default subcommand
+// completion skips hidden commands.
+func TestRootBasenameCompletions(t *testing.T) {
+	got, directive := rootBasenameCompletions(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want ShellCompDirectiveNoFileComp", directive)
+	}
+	if len(got) == 0 {
+		t.Fatal("want at least one basename completion at the root")
+	}
+
+	seen := make(map[string]bool, len(got))
+	for _, b := range got {
+		if seen[b] {
+			t.Errorf("duplicate basename completion %q", b)
+		}
+		seen[b] = true
+	}
+
+	// db-backup/db-pull are registered as scripts/backup/db-backup(.sh) and
+	// scripts/backup/db-pull(.sh) — hidden full-key commands whose basename
+	// wouldn't complete at the root without rootBasenameCompletions.
+	for _, want := range []string{"db-backup", "db-pull"} {
+		if !seen[want] {
+			t.Errorf("want %q among root completions, got %v", want, got)
+		}
+	}
+
+	got2, directive2 := rootBasenameCompletions(nil, []string{"db-backup"}, "")
+	if directive2 != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive with a basename already chosen = %v, want ShellCompDirectiveNoFileComp", directive2)
+	}
+	if len(got2) != 0 {
+		t.Errorf("want no completions once a basename is already chosen, got %v", got2)
+	}
+}
+
+// TestRootBasenameCompletionsCoversAllEntries checks that every catalog
+// entry's basename appears among the root completions — the point of
+// scoping rootBasenameCompletions to the whole catalog rather than one
+// category, unlike categoryBasenameCompletions.
+func TestRootBasenameCompletionsCoversAllEntries(t *testing.T) {
+	c, err := catalog.Load()
+	if err != nil {
+		t.Fatalf("loading catalog: %v", err)
+	}
+
+	got, _ := rootBasenameCompletions(nil, nil, "")
+	offered := make(map[string]bool, len(got))
+	for _, b := range got {
+		offered[b] = true
+	}
+
+	for _, e := range c.Entries {
+		b := filepath.Base(e.Key)
+		if !offered[b] {
+			t.Errorf("root completions missing %q (from entry %q)", b, e.Key)
+		}
+	}
+}
+
 // TestCategoryBasenameCompletionsScoped checks that a category's
 // completions only ever contain basenames that actually live in that
 // category — the point of the two-token grammar

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -54,8 +54,9 @@ playbooks, and more.
 	// The dynamic per-entry/category commands manage their own exit codes
 	// via os.Exit (to propagate the underlying script's real exit status),
 	// so Cobra's own usage-on-error printing would be redundant/wrong here.
-	SilenceUsage:  true,
-	SilenceErrors: true,
+	SilenceUsage:      true,
+	SilenceErrors:     true,
+	ValidArgsFunction: rootBasenameCompletions,
 }
 
 func rootRunE(cc *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- `wp-ops <category> <TAB>` (e.g. `wp-ops scripts <TAB>`) already completed basenames within that category via `categoryBasenameCompletions`, but the root command had no `ValidArgsFunction`, so `wp-ops db<TAB>` produced no completions at all — even though `db-backup`/`db-pull` are reachable directly via the bare-basename fallback in `rootRunE` (`FindByBasename`).
- The per-entry full-key commands (`scripts/backup/db-backup`) are registered `Hidden` (so `wp-ops --help` isn't drowned in ~66 entries), and Cobra's default subcommand-name completion skips hidden commands — hence the gap.
- Added `rootBasenameCompletions` (`go/cmd/dispatch.go`) and wired it into `rootCmd.ValidArgsFunction` (`go/cmd/root.go`). Cobra calls `ValidArgsFunction` in addition to its subcommand-name matching, not instead of it, so this supplements the existing category/subcommand completions rather than replacing them.
- Bumped to `3.30.1` (patch) in `CHANGELOG.md`, which `wp-ops --version` reads directly.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass, including two new tests (`TestRootBasenameCompletions`, `TestRootBasenameCompletionsCoversAllEntries`)
- [x] `wp-ops __complete db ""` manually verified to return `db-backup`/`db-pull`
- [x] `wp-ops --version` verified to report `3.30.1` after the CHANGELOG bump