### PR TITLE
fix(trellis/backup): drop nonexistent development_host from files-pull/push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.30.3] - 2026-08-03
+
+### Fixed
+
+- **trellis/backup** - `files-pull` and `files-push` failed on every Trellis project with `Task failed: ... Error while resolving value for 'path': hostvars['development_host']`. Both playbooks read the development site's location as `{{ hostvars.development_host.wordpress_sites[site].local_path }}` and delegated their local-side tasks with `delegate_to: development_host`, but no such inventory host exists — Trellis's `hosts/development` lists the development machine by address (e.g. `192.168.56.5`), and nothing in Trellis or wp-ops ever defines a `development_host` alias. They now read `local_path` out of development's own `group_vars` via `lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml`, which is what the sibling `database-pull.yml`/`database-push.yml` already do (the play's own `wordpress_sites` belongs to the *remote* environment, so it can't supply a development path), and delegate their local tasks to `localhost` with `become: no` per the repo's local-delegation convention. The relative `local_path` this yields (e.g. `../site`) resolves against the playbook's directory, which is the Trellis project root — see 3.30.2's staging fix.
+
+Surfaced by the 3.30.2 end-to-end check: with `group_vars` finally resolving, `wp-ops files-pull imagewize.com production` got as far as the sync tasks and failed there instead, which is what exposed this second, older bug behind it. Verified fixed by a real pull against imagewize.com production — 140 files synced into `../site/web/app/uploads/`, with the staged `.wp-ops-run-*` playbooks cleaned up afterward.
+
 ## [3.30.2] - 2026-08-03
 
 ### Fixed

--- a/trellis/backup/files-pull.yml
+++ b/trellis/backup/files-pull.yml
@@ -21,7 +21,13 @@
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     remote_uploads_dir: "{{ project_root }}/shared/uploads/"
-    local_uploads_dir: "{{ hostvars.development_host.wordpress_sites[site].local_path }}/web/app/uploads/"
+    # `wordpress_sites` in this play is the remote environment's, so the
+    # development local_path has to be read out of development's own
+    # group_vars — same approach as database-pull.yml. The relative path it
+    # yields (e.g. ../site) resolves against the playbook's directory, which
+    # is the Trellis project root.
+    dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
+    local_uploads_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}/web/app/uploads/"
 
   pre_tasks:
     - name: Ensure site is valid
@@ -47,14 +53,15 @@
 
   tasks:
   - name: Ensure local uploads directory exists
-    delegate_to: development_host
+    delegate_to: localhost
+    become: no
     file:
       path: "{{ local_uploads_dir }}"
       state: directory
       mode: 0755
 
   - name: Sync uploads from {{ env }} to development using rsync
-    delegate_to: development_host
+    delegate_to: localhost
     synchronize:
       mode: pull
       src: "{{ remote_uploads_dir }}"

--- a/trellis/backup/files-push.yml
+++ b/trellis/backup/files-push.yml
@@ -21,7 +21,13 @@
     project: "{{ wordpress_sites[site] }}"
     project_root: "{{ www_root }}/{{ site }}"
     remote_uploads_dir: "{{ project_root }}/shared/uploads/"
-    local_uploads_dir: "{{ hostvars.development_host.wordpress_sites[site].local_path }}/web/app/uploads/"
+    # `wordpress_sites` in this play is the remote environment's, so the
+    # development local_path has to be read out of development's own
+    # group_vars — same approach as database-push.yml. The relative path it
+    # yields (e.g. ../site) resolves against the playbook's directory, which
+    # is the Trellis project root.
+    dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
+    local_uploads_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}/web/app/uploads/"
 
   pre_tasks:
     - name: Ensure site is valid
@@ -36,7 +42,8 @@
       when: env == "development"
 
     - name: Check if local uploads folder exists
-      delegate_to: development_host
+      delegate_to: localhost
+      become: no
       stat:
         path: "{{ local_uploads_dir }}"
       register: local_uploads_check
@@ -60,7 +67,7 @@
     become: no
 
   - name: Sync uploads from development to {{ env }} using rsync
-    delegate_to: development_host
+    delegate_to: localhost
     synchronize:
       mode: push
       src: "{{ local_uploads_dir }}"


### PR DESCRIPTION
## Summary

- `files-pull` and `files-push` failed on every Trellis project with `Task failed: ... Error while resolving value for 'path': hostvars['development_host']`.
- Both playbooks resolved the development site's location through `{{ hostvars.development_host.wordpress_sites[site].local_path }}` and delegated their local-side tasks with `delegate_to: development_host`. No inventory host by that name exists: Trellis's `hosts/development` lists the development machine by address (e.g. `192.168.56.5`), and neither Trellis nor wp-ops has ever defined a `development_host` alias — it isn't mentioned anywhere else in this repo or its docs.
- Fix: read `local_path` out of development's own `group_vars` with `lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml`, and delegate the local tasks to `localhost` with `become: no`. That is exactly what the sibling `database-pull.yml` / `database-push.yml` already do — the play's own `wordpress_sites` belongs to the *remote* environment, so it can't supply a development path. The relative `local_path` this yields (e.g. `../site`) resolves against the playbook's directory, which is the Trellis project root after #164's staging.

This bug predates #164 and was simply unreachable: before `group_vars` resolved at all, these playbooks failed earlier on `remote_user: "{{ web_user }}"`. Running the #164 end-to-end check is what surfaced it.

## Test plan

- [x] `wp-ops files-pull imagewize.com production` against the live production server: completes with `changed=1`, 140 files synced into `../site/web/app/uploads/`, and no `.wp-ops-run-*` files left in the Trellis project
- [x] `go test ./...` passes; `catalog.json` regenerated with no diff (manifest annotations untouched)
- [ ] `files-push` is fixed symmetrically but deliberately not exercised against a live environment — it overwrites remote uploads
