### PR TITLE
Add --delete flag to files-pull for exact mirroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.31.0] - 2026-08-03
+
+### Added
+
+- **trellis/backup** - `files-pull` takes an optional `--delete yes` flag (`wp-ops files-pull example.com production --delete yes`, or `-e delete=yes` when running the playbook directly), which passes rsync's `--delete` through the `synchronize` task and makes the development uploads directory an exact mirror of the remote. The default stays `no`, i.e. a purely additive pull: local-only files survive, which is what you want most of the time — a long-lived development copy accumulates dev-only uploads and keeps media that has since been deleted from the remote library (on imagewize.com, 142 such files out of 16,670 after a fully-synced pull, mostly rotated `wc-logs/`, deleted screenshots and their generated sizes, and `.DS_Store`). Mirroring is destructive on the development side only and runs without a confirmation prompt, so the playbook emits an explicit warning task when the flag is on, and the completion message now states which mode ran (`mirrored — local-only files deleted` vs `additive — local-only files kept`). `trellis/backup/README.md` documents an `rsync --dry-run --itemize-changes` invocation for previewing the deletions first.
+
+  Deliberately not added to `files-push`: the same flag there would delete files on the remote server, a different risk class than pruning a local checkout.
+
 ## [3.30.3] - 2026-08-03
 
 ### Fixed

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -2155,8 +2155,19 @@
         "raw": "env   required  {production|staging}  Remote environment to pull from"
       }
     ],
+    "flags": [
+      {
+        "name": "delete",
+        "required_raw": "optional",
+        "required": false,
+        "default": "no",
+        "description": "yes = mirror the remote exactly, deleting local uploads the remote no longer has",
+        "raw": "delete  optional  {no}  yes = mirror the remote exactly, deleting local uploads the remote no longer has"
+      }
+    ],
     "examples": [
-      "wp-ops files-pull example.com production"
+      "wp-ops files-pull example.com production",
+      "wp-ops files-pull example.com production --delete yes"
     ],
     "manifest_category": "backup",
     "display_category": "trellis",

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -34,6 +34,32 @@ func TestLookup(t *testing.T) {
 	}
 }
 
+// TestFilesPullExposesDeleteFlag guards catalog.json staying in step with
+// trellis/backup/files-pull.yml's manifest: the entry is what turns
+// `--delete yes` into `-e delete=yes` (exec.BuildPlaybookArgs) and what
+// --help prints, so a manifest edit landing without a `go generate
+// ./internal/catalog` leaves the flag silently undocumented and untranslated.
+func TestFilesPullExposesDeleteFlag(t *testing.T) {
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	e, ok := c.Lookup("trellis/backup/files-pull")
+	if !ok {
+		t.Fatal("Lookup(trellis/backup/files-pull) not found")
+	}
+	for _, f := range e.Flags {
+		if f.Name == "delete" {
+			if f.Required {
+				t.Error("delete flag is required, want optional (a pull is additive by default)")
+			}
+			return
+		}
+	}
+	t.Errorf("files-pull flags = %v, want one named delete (run `go generate ./internal/catalog`)", e.Flags)
+}
+
 func TestFindByBasename(t *testing.T) {
 	c, err := Load()
 	if err != nil {

--- a/trellis/backup/README.md
+++ b/trellis/backup/README.md
@@ -323,13 +323,28 @@ ansible-playbook files-pull.yml -e site=example.com -e env=production
 
 # Pull staging uploads to development
 ansible-playbook files-pull.yml -e site=example.com -e env=staging
+
+# Mirror production exactly, deleting local uploads production no longer has
+ansible-playbook files-pull.yml -e site=example.com -e env=production -e delete=yes
+
+# Same via the wp-ops CLI
+wp-ops files-pull example.com production
+wp-ops files-pull example.com production --delete yes
 ```
 
 **What it does:**
-- Creates backup of current development uploads
-- Creates archive of uploads from remote environment
-- Downloads and extracts to development
-- Cleans up temporary files
+- Syncs the remote `shared/uploads/` into the development site's `web/app/uploads/` over rsync
+- Additive by default (`--delete no`): files that exist only locally are left alone, so dev-only uploads and media since deleted on the remote survive the pull
+- Reads the development path from `group_vars/development/wordpress_sites.yml` (`local_path`)
+
+**`--delete yes`** adds rsync's `--delete`, making the local directory an exact mirror of the remote. Local-only files are removed. This is destructive on the development side only — it never touches the remote — but there is no confirmation prompt, so check what would go first:
+
+```bash
+# Dry run: list exactly what a mirror pull would delete or transfer
+rsync -a --dry-run --itemize-changes \
+  web@example.com:/srv/www/example.com/shared/uploads/ \
+  /path/to/site/web/app/uploads/
+```
 
 **Note:** Cannot pull from development to development (will abort with error).
 

--- a/trellis/backup/files-pull.yml
+++ b/trellis/backup/files-pull.yml
@@ -7,7 +7,9 @@
 # @requires ansible-playbook
 # @arg      site  required  {example.com}  Site name as in wordpress_sites.yml
 # @arg      env   required  {production|staging}  Remote environment to pull from
+# @flag     delete  optional  {no}  yes = mirror the remote exactly, deleting local uploads the remote no longer has
 # @example  wp-ops files-pull example.com production
+# @example  wp-ops files-pull example.com production --delete yes
 # @doc      trellis/backup/README.md
 - import_playbook: variable-check.yml
   vars:
@@ -28,6 +30,11 @@
     # is the Trellis project root.
     dev_wordpress_sites: "{{ lookup('file', 'group_vars/development/wordpress_sites.yml') | from_yaml }}"
     local_uploads_dir: "{{ dev_wordpress_sites.wordpress_sites[site].local_path }}/web/app/uploads/"
+    # Off by default: a pull is additive, so local-only uploads (dev
+    # experiments, files since deleted in the remote media library) survive.
+    # `--delete yes` makes the local directory an exact mirror of the remote
+    # instead, which is destructive on the development side only.
+    sync_delete: "{{ delete | default(false) | bool }}"
 
   pre_tasks:
     - name: Ensure site is valid
@@ -60,13 +67,22 @@
       state: directory
       mode: 0755
 
+  - name: Warn that --delete yes will remove local-only uploads
+    delegate_to: localhost
+    become: no
+    debug:
+      msg: >-
+        Mirroring {{ env }} into {{ local_uploads_dir }} — local files that do
+        not exist on {{ env }} will be DELETED.
+    when: sync_delete | bool
+
   - name: Sync uploads from {{ env }} to development using rsync
     delegate_to: localhost
     synchronize:
       mode: pull
       src: "{{ remote_uploads_dir }}"
       dest: "{{ local_uploads_dir }}"
-      delete: no
+      delete: "{{ sync_delete }}"
       rsync_opts:
         - "--archive"
         - "--compress"
@@ -76,4 +92,6 @@
 
   - name: Show sync completion message
     debug:
-      msg: "Uploads synced from {{ env }} to {{ local_uploads_dir }}"
+      msg: >-
+        Uploads synced from {{ env }} to {{ local_uploads_dir }}
+        ({{ 'mirrored — local-only files deleted' if sync_delete | bool else 'additive — local-only files kept' }})


### PR DESCRIPTION
## Summary

`files-pull` syncs a remote site's uploads into development over rsync (Ansible's `synchronize:` module), and it runs additively — no `--delete`. Files that exist only in development survive every pull: dev-only uploads, plus media since removed from the remote library. That is the right default, but there was no way to ask for an exact mirror short of running rsync by hand.

This adds an optional `delete` flag. Default behaviour is unchanged.

```bash
wp-ops files-pull example.com production              # additive (default)
wp-ops files-pull example.com production --delete yes # exact mirror

# direct playbook run
ansible-playbook files-pull.yml -e site=example.com -e env=production -e delete=yes
```

## Changes

- **[`trellis/backup/files-pull.yml`](../blob/feat/files-pull-delete-flag/trellis/backup/files-pull.yml)** — new `@flag delete optional {no}` manifest line and `sync_delete` var feeding the `synchronize` task's `delete:` parameter.
- **[`go/internal/catalog/catalog.json`](../blob/feat/files-pull-delete-flag/go/internal/catalog/catalog.json)** — regenerated (`go generate ./internal/catalog`) so the flag reaches `--help` and the positional→`-e` translation.
- **[`go/internal/catalog/catalog_test.go`](../blob/feat/files-pull-delete-flag/go/internal/catalog/catalog_test.go)** — `TestFilesPullExposesDeleteFlag`, guarding that regeneration step.
- **[`trellis/backup/README.md`](../blob/feat/files-pull-delete-flag/trellis/backup/README.md)** — documents the flag and corrects the Files Pull section, which still described the pre-rsync tar/archive behaviour.
- **[`CHANGELOG.md`](../blob/feat/files-pull-delete-flag/CHANGELOG.md)** — 3.31.0.

## Safety

Mirroring is destructive on the development side only, and takes no confirmation prompt, so:

- a warning task prints before the sync when the flag is on;
- the completion message states which mode ran (`mirrored — local-only files deleted` vs `additive — local-only files kept`);
- the README documents an `rsync --dry-run --itemize-changes` preview.

Deliberately **not** added to `files-push`, where the same flag would delete files on the remote server — a different risk class than pruning a local checkout.

## Testing

- `go test ./...` — all packages pass, including the new catalog test.
- `ansible-playbook --syntax-check` on `files-pull.yml`, with and without `-e delete=yes`.
- Flag translation verified against the real catalog entry: `wp-ops files-pull imagewize.com production --delete yes` → `-e site=imagewize.com -e env=production -e delete=yes`.
- Motivating case: a fully-synced `files-pull` of imagewize.com production left 16,670 local files against 16,528 remote (0 remote-only, 142 local-only — rotated `wc-logs/`, deleted screenshots and their generated sizes, `.DS_Store`). Those 142 are exactly what `--delete yes` now removes on request.

## Follow-ups (not in this PR)

- No general check that `catalog.json` is fresh against all 72 manifests; the new test covers this entry only.
- The Files Push section of `trellis/backup/README.md` still describes the old tar/archive behaviour.