### PR TITLE
Add dry-run and confirmation safety nets (Gap 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.32.0] - 2026-08-03
+
+### Added
+
+- **scripts/woocommerce**, **trellis/updater** - the two mutating commands `docs/wp-ops-recommendations.md`'s Gap 7 audit flagged with no dry-run and no confirmation prompt now have both. `create-product-variations.sh` takes `-d`/`--dry-run` (matching `batch-resize.sh`'s convention): it builds each `wp wc product_variation create` invocation either way, but only prints it instead of running it over `trellis vm shell` when the flag is set, so the full attribute cross-product can be previewed with no VM round trip. `trellis-updater.sh` now prompts `This will overwrite files in $TRELLIS_DIR. Continue? (y/N)` before it starts backing up and rewriting the Trellis directory; `-y`/`--yes` (matching `db-pull.sh`'s convention) skips it for non-interactive use. Both scripts' manifest headers gained a `@flag` line so the new flags surface in `--help` and the interactive picker in both CLIs; `go/internal/catalog/catalog.json` regenerated, `go/scripts/parity-check.sh` still 8/8.
+
 ## [3.31.0] - 2026-08-03
 
 ### Added

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -366,6 +366,18 @@ there since the existing backup already covers "how do I undo this."
 Everything else in the catalog is adequately covered and doesn't need
 follow-up.
 
+**Done, 2026-08-03.** `scripts/woocommerce/create-product-variations.sh`
+takes `-d`/`--dry-run` (matching `batch-resize.sh`'s convention): builds
+each `wp wc product_variation create` invocation into an array either way,
+but only prints it (`[DRY RUN] ...`) instead of running it over `trellis vm
+shell` when the flag is set, so the full attribute cross-product can be
+previewed with no VM round trip. `trellis/updater/trellis-updater.sh` now
+prompts `This will overwrite files in $TRELLIS_DIR. Continue? (y/N)` before
+Step 1 (the backup, which still runs unconditionally once confirmed) — a
+`-y`/`--yes` flag (matching `db-pull.sh`'s convention) skips it for
+non-interactive use. Both scripts' manifest headers gained a `@flag` line
+so the new flag surfaces in `--help` and the interactive picker.
+
 ---
 
 ## Suggested order
@@ -384,7 +396,7 @@ follow-up.
    no underlying playbook to translate against; needs either real wrapper
    scripts or M5's `--on <env>` SSH dispatch.
 8. **Gap 7** — `--dry-run` for `create-product-variations.sh`; a confirmation
-   prompt for `trellis-updater.sh`. Small, isolated fixes.
+   prompt for `trellis-updater.sh`. Small, isolated fixes. **Done.**
 
 Deliberately not queued: `@key` or any new manifest directive (premise false, and
 per [go-mcp-parity.md](go-mcp-parity.md) any new directive must land in both

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -1958,8 +1958,18 @@
       "trellis"
     ],
     "doc": "wordpress-utilities/snippets/woocommerce-product-attributes-wpcli.md",
+    "flags": [
+      {
+        "name": "--dry-run",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Print the planned wp wc product_variation create commands without running them",
+        "raw": "--dry-run  optional  {}  Print the planned wp wc product_variation create commands without running them"
+      }
+    ],
     "examples": [
-      "wp-ops scripts/woocommerce/create-product-variations"
+      "wp-ops scripts/woocommerce/create-product-variations",
+      "wp-ops scripts/woocommerce/create-product-variations --dry-run"
     ],
     "manifest_category": "woocommerce",
     "display_category": "scripts",
@@ -2517,8 +2527,18 @@
       "git"
     ],
     "doc": "trellis/updater/README.md",
+    "flags": [
+      {
+        "name": "--yes",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Skip the confirmation prompt before overwriting trellis/",
+        "raw": "--yes  optional  {}  Skip the confirmation prompt before overwriting trellis/"
+      }
+    ],
     "examples": [
-      "wp-ops trellis/updater/trellis-updater"
+      "wp-ops trellis/updater/trellis-updater",
+      "wp-ops trellis/updater/trellis-updater --yes"
     ],
     "manifest_category": "updater",
     "display_category": "trellis",

--- a/scripts/woocommerce/create-product-variations.sh
+++ b/scripts/woocommerce/create-product-variations.sh
@@ -3,10 +3,14 @@
 # create-product-variations.sh - Bulk-create WooCommerce product variations via WP-CLI
 #
 # Usage:
-#   ./create-product-variations.sh
+#   ./create-product-variations.sh [-d|--dry-run]
+#
+# Options:
+#   -d, --dry-run   Print the wp wc product_variation create commands without running them
 #
 # Examples:
 #   ./create-product-variations.sh                        # Uses config below
+#   ./create-product-variations.sh --dry-run               # Preview without creating anything
 #   PRODUCT_ID=42 ./create-product-variations.sh          # Override product ID inline
 #
 # Notes:
@@ -19,11 +23,26 @@
 # @category woocommerce
 # @runs     local
 # @requires trellis
+# @flag     --dry-run  optional  {}  Print the planned wp wc product_variation create commands without running them
 # @example  wp-ops scripts/woocommerce/create-product-variations
+# @example  wp-ops scripts/woocommerce/create-product-variations --dry-run
 # @doc      wordpress-utilities/snippets/woocommerce-product-attributes-wpcli.md
 #
 
 set -euo pipefail
+
+# ============================================================================
+# Argument parsing
+# ============================================================================
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    -d|--dry-run)
+      DRY_RUN=1
+      ;;
+  esac
+done
 
 # ============================================================================
 # Configuration
@@ -51,18 +70,29 @@ ATTR2_VALUES=("A4 with Notepad" "A4 Slim" "A5 with Notepad")
 CREATED=0
 FAILED=0
 
-echo "Creating variations for product ID ${PRODUCT_ID} on ${SITE_URL}"
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[DRY RUN] Previewing variations for product ID ${PRODUCT_ID} on ${SITE_URL}"
+else
+  echo "Creating variations for product ID ${PRODUCT_ID} on ${SITE_URL}"
+fi
 echo "Attributes: ${ATTR1_SLUG} × ${ATTR2_SLUG}"
 echo "---"
 
 for val1 in "${ATTR1_VALUES[@]}"; do
   for val2 in "${ATTR2_VALUES[@]}"; do
+    WP_CMD=(wp --url="$SITE_URL" wc product_variation create "$PRODUCT_ID" \
+      --attributes="[{\"attribute\": \"${ATTR1_SLUG}\", \"value\": \"${val1}\"}, {\"attribute\": \"${ATTR2_SLUG}\", \"value\": \"${val2}\"}]" \
+      --regular_price="$REGULAR_PRICE" \
+      --user="$WP_USER" \
+      --path="$WP_PATH")
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "[DRY RUN] ${val1} / ${val2} — ${WP_CMD[*]}"
+      continue
+    fi
+
     RESULT=$(cd "$TRELLIS_DIR" && trellis vm shell --workdir "$WORKDIR" -- \
-      wp --url="$SITE_URL" wc product_variation create "$PRODUCT_ID" \
-        --attributes="[{\"attribute\": \"${ATTR1_SLUG}\", \"value\": \"${val1}\"}, {\"attribute\": \"${ATTR2_SLUG}\", \"value\": \"${val2}\"}]" \
-        --regular_price="$REGULAR_PRICE" \
-        --user="$WP_USER" \
-        --path="$WP_PATH" 2>&1 | grep -E "Success|Error|Created")
+      "${WP_CMD[@]}" 2>&1 | grep -E "Success|Error|Created")
 
     if echo "$RESULT" | grep -q "Success\|Created"; then
       echo "[OK]   ${val1} / ${val2} — ${RESULT}"
@@ -75,4 +105,8 @@ for val1 in "${ATTR1_VALUES[@]}"; do
 done
 
 echo "---"
-echo "Done: ${CREATED} created, ${FAILED} failed."
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Dry run complete: $(( ${#ATTR1_VALUES[@]} * ${#ATTR2_VALUES[@]} )) variation(s) would be created. No changes made."
+else
+  echo "Done: ${CREATED} created, ${FAILED} failed."
+fi

--- a/trellis/updater/trellis-updater.sh
+++ b/trellis/updater/trellis-updater.sh
@@ -10,14 +10,28 @@
 #
 # Edit the PROJECT variable below before running.
 #
+# Options:
+#   --yes, -y      Skip the confirmation prompt before overwriting trellis/
+#
 # @desc     Safely update a Trellis installation to the latest upstream while preserving vault/config customizations
 # @category updater
 # @runs     local
 # @requires git
+# @flag     --yes  optional  {}  Skip the confirmation prompt before overwriting trellis/
 # @example  wp-ops trellis/updater/trellis-updater
+# @example  wp-ops trellis/updater/trellis-updater --yes
 # @doc      trellis/updater/README.md
 
 set -e  # Exit on error
+
+SKIP_CONFIRM=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y)
+      SKIP_CONFIRM=1
+      ;;
+  esac
+done
 
 # Set your project slug here like example.com
 PROJECT="site.com"
@@ -40,6 +54,19 @@ echo "=== Trellis Updater for $PROJECT ==="
 echo "Project: $PROJECT_DIR"
 echo "Backup: $BACKUP_DIR"
 echo ""
+
+# Confirm before rewriting any files — a backup exists afterward, but nothing
+# previews the change first, so make the destructive step explicit.
+if [ "$SKIP_CONFIRM" -eq 1 ]; then
+  echo "Skipping confirmation (--yes)."
+else
+  read -p "This will overwrite files in $TRELLIS_DIR. Continue? (y/N) " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted. No changes made."
+    exit 1
+  fi
+fi
 
 # Step 1: Create backup directory
 mkdir -p $BACKUP_DIR


### PR DESCRIPTION
## Summary

- `scripts/woocommerce/create-product-variations.sh` gets `-d`/`--dry-run` (matching `batch-resize.sh`'s convention): previews every planned `wp wc product_variation create` call — the full attribute cross-product — without shelling into the Trellis VM.
- `trellis/updater/trellis-updater.sh` now confirms before it starts backing up and overwriting `trellis/`; `-y`/`--yes` (matching `db-pull.sh`'s convention) skips the prompt for non-interactive use.
- Both manifest headers gained a `@flag` line so the new flags surface in `--help` and the interactive picker in both CLIs; `go/internal/catalog/catalog.json` regenerated to match.
- `docs/wp-ops-recommendations.md` Gap 7 and CHANGELOG.md updated to record this as done.

This closes the two remaining items from Gap 7 of the wp-ops recommendations audit — the only two mutating commands in the catalog with no dry-run and no confirmation/backup safety net.

## Test plan

- [x] `bash -n` on both edited scripts
- [x] Manual dry-run of `create-product-variations.sh --dry-run` — confirmed it prints all 15 planned variation commands and makes no VM calls
- [x] `./wp-ops manifest lint` — 69 annotated commands, no problems
- [x] `go test ./...` — all packages pass
- [x] `go/scripts/parity-check.sh` — 8/8 passed (bash/Go `--json` still matches field-for-field)