### PR TITLE
Rename run-monitoring.sh to monitor.sh (Gap 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.33.0] - 2026-08-03
+
+### Changed
+
+- **scripts/monitoring** - `run-monitoring.sh` renamed to `monitor.sh` (Gap 1 of `docs/wp-ops-recommendations.md`) — the one genuinely opaque script name in the catalog; nothing about "run-monitoring" suggested it was the combined traffic/security/AI-bot/error report. `wp-ops monitor` (and `wp-ops scripts/monitoring/monitor`) now resolves via the existing basename resolution, no new directive or alias needed. Every reference to the old key/filename was swept alongside the rename: `wp-ops` (bash — `SERVER_SIDE_COMMANDS`, `server_side_example_args`, doctor/guard prose), `go/cmd/serverside.go` and its tests, `go/internal/catalog/gen/main.go`'s `serverSideFallback` map (`catalog.json` regenerated), and the current-state docs `README.md`/`scripts/README.md`. `go/scripts/parity-check.sh` still 8/8.
+
 ## [3.32.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ When `wp-ops search` finds no command for a term, it checks the documentation an
 Everything else runs on your own machine, including the commands that touch a server — Ansible playbooks, `server-monitor`, and `post-count --ssh` all reach out over SSH from here. The exception is the log monitors, which read `/srv/www/<site>/logs/` and `/var/log/` directly and execute on the host. Those are tagged `(server)` in listings and search, and running one locally prints the SSH invocation rather than failing on a missing log path:
 
 ```bash
-ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh
 ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 48
 ```
 

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -47,7 +47,7 @@ current catalog:
 |------------|-------|---------------|
 | `wp-ops traffic` | fails | `scripts/monitoring/traffic-monitor.sh` |
 | `wp-ops security` | fails (suggests `security-monitor`) | `scripts/monitoring/security-monitor.sh` |
-| `wp-ops monitor` | fails | `scripts/monitoring/run-monitoring.sh` |
+| `wp-ops monitor` | works — resolves to `scripts/monitoring/monitor.sh` (renamed from `run-monitoring.sh`, 2026-08-03) | `scripts/monitoring/monitor.sh` |
 | `wp-ops ai-bots` | fails | `scripts/monitoring/ai-bot-monitor.sh` |
 | `wp-ops image-resize` | fails | `scripts/images/batch-resize.sh` |
 | `wp-ops page-create` | fails | `wp-cli/content-creation/page-creation.sh` |
@@ -72,6 +72,24 @@ quo is one extra round trip, not a lookup failure.
 opaque name — nothing about "run-monitoring" suggests it is the combined report),
 and leave the rest. Revisit only if the suggester turns out to be annoying in
 practice.
+
+**Done, 2026-08-03.** `git mv scripts/monitoring/run-monitoring.sh
+scripts/monitoring/monitor.sh` — basename resolution then does the rest, so
+`wp-ops monitor` (or `wp-ops scripts/monitoring/monitor`) now works in both
+CLIs with no new directive or alias table. Every reference to the old
+filename/key was swept and fixed alongside the rename, not left to the
+suggester: `wp-ops` (bash — `SERVER_SIDE_COMMANDS`, the `server_side_example_args`
+case, and prose in `doctor`/server-side-guard comments), `go/cmd/serverside.go`
+and its test (the `serverSideExampleArgs` case and `accessLogCommands` prose),
+`go/internal/catalog/gen/main.go`'s `serverSideFallback` map (regenerating
+`catalog.json`), and the current-state docs `README.md` and `scripts/README.md`
+(usage examples, the file-tree listing — reordered alphabetically since
+`monitor.sh` now sorts before `redirect-check.sh` — and the cron example).
+Historical status docs (`docs/m3-go-skeleton.md`, `CHANGELOG.md`) were left
+alone — they're dated records of what was true when written, not current
+reference material. The rest of Gap 1 (`traffic`, `security`, `ai-bots`,
+`image-resize`, `page-create`) stays as-is per the original recommendation —
+the did-you-mean suggester already covers those adequately.
 
 ---
 
@@ -389,7 +407,7 @@ so the new flag surfaces in `--help` and the interactive picker.
 4. **Gap 6, `db-backup`** — positional wrapper + fixes the `/srv/backups`
    permission dead end. Same shape and value as Gap 2. **Done.**
 5. **Gap 4** — `url_audit` MCP tool, per the MCP roadmap. **Done.**
-6. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to.
+6. **Gap 1** — rename `run-monitoring.sh`, or consciously decide not to. **Done.**
 7. **Gap 6, remaining items** — 6a (the nine `-e`-style playbooks) **done**,
    via a generic positional-arg translator rather than nine bespoke scripts.
    6b (four unwrapped server scripts) remains — different shape, since there's

--- a/go/cmd/serverside.go
+++ b/go/cmd/serverside.go
@@ -37,7 +37,7 @@ var backupCommands = map[string]bool{
 // accessLogCommands ports ACCESS_LOG_COMMANDS (wp-ops:149): the subset taking
 // an Nginx *access* log path as their first argument, for which "I already
 // have a copy of the log here" is a meaningful thing to say. error-monitor's
-// first argument is a domain and run-monitoring's is an hour count, so
+// first argument is a domain and monitor's is an hour count, so
 // neither has a log file you could hand it locally.
 var accessLogCommands = map[string]bool{
 	"scripts/monitoring/traffic-monitor":  true,
@@ -52,7 +52,7 @@ func serverSideExampleArgs(key string) string {
 	switch key {
 	case "scripts/monitoring/error-monitor":
 		return "example.com 48"
-	case "scripts/monitoring/run-monitoring":
+	case "scripts/monitoring/monitor":
 		return "24 example.com"
 	case "scripts/backup/site-backup":
 		return "example.com"

--- a/go/cmd/serverside_test.go
+++ b/go/cmd/serverside_test.go
@@ -107,7 +107,7 @@ func TestServerSideGuard(t *testing.T) {
 		},
 		{
 			// error-monitor's first argument is a domain and
-			// run-monitoring's is an hour count, so a file argument must not
+			// monitor's is an hour count, so a file argument must not
 			// be mistaken for a log they can read locally.
 			name:        "non-access-log command ignores a real file argument",
 			entry:       serverEntry("scripts/monitoring/error-monitor"),
@@ -229,8 +229,8 @@ func TestPrintServerSideGuidanceVariants(t *testing.T) {
 			wantAbsent: []string{"Already have a log file"},
 		},
 		{
-			name:    "run-monitoring gets the gawk note but no local-file offer",
-			key:     "scripts/monitoring/run-monitoring",
+			name:    "monitor gets the gawk note but no local-file offer",
+			key:     "scripts/monitoring/monitor",
 			gnuDate: true,
 			wantContain: []string{
 				"24 example.com",
@@ -271,7 +271,7 @@ func TestPrintServerSideGuidanceVariants(t *testing.T) {
 func TestServerSideExampleArgs(t *testing.T) {
 	tests := map[string]string{
 		"scripts/monitoring/error-monitor":    "example.com 48",
-		"scripts/monitoring/run-monitoring":   "24 example.com",
+		"scripts/monitoring/monitor":          "24 example.com",
 		"scripts/backup/site-backup":          "example.com",
 		"scripts/monitoring/traffic-monitor":  "/srv/www/example.com/logs/access.log 24",
 		"scripts/monitoring/security-monitor": "/srv/www/example.com/logs/access.log 24",

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -1074,6 +1074,43 @@
   },
   {
     "category": "scripts",
+    "key": "scripts/monitoring/monitor",
+    "description": "Run traffic, security, AI-bot, and error monitoring together and save timestamped reports",
+    "script_path": "scripts/monitoring/monitor.sh",
+    "runs_on": "server",
+    "runs": "server",
+    "requires": [
+      "gawk"
+    ],
+    "doc": "trellis/monitoring/README.md",
+    "args": [
+      {
+        "name": "hours",
+        "required_raw": "optional",
+        "required": false,
+        "default": "24",
+        "description": "How many hours back to analyze",
+        "raw": "hours   optional  {24}  How many hours back to analyze"
+      },
+      {
+        "name": "domain",
+        "required_raw": "optional",
+        "required": false,
+        "default": "example.com",
+        "description": "Site domain",
+        "raw": "domain  optional  {example.com}  Site domain"
+      }
+    ],
+    "examples": [
+      "ssh web@example.com 'bash -s' \u003c monitor.sh",
+      "ssh web@example.com 'bash -s' \u003c monitor.sh 24 othersite.com"
+    ],
+    "manifest_category": "monitoring",
+    "display_category": "monitoring",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
     "key": "scripts/monitoring/redirect-check",
     "description": "Mass-check a list of URLs for redirects with curl",
     "script_path": "scripts/monitoring/redirect-check.sh",
@@ -1129,43 +1166,6 @@
     ],
     "examples": [
       "wp-ops scripts/monitoring/remote-ttfb-ua web@example.com https://example.com/"
-    ],
-    "manifest_category": "monitoring",
-    "display_category": "monitoring",
-    "annotated": true
-  },
-  {
-    "category": "scripts",
-    "key": "scripts/monitoring/run-monitoring",
-    "description": "Run traffic, security, AI-bot, and error monitoring together and save timestamped reports",
-    "script_path": "scripts/monitoring/run-monitoring.sh",
-    "runs_on": "server",
-    "runs": "server",
-    "requires": [
-      "gawk"
-    ],
-    "doc": "trellis/monitoring/README.md",
-    "args": [
-      {
-        "name": "hours",
-        "required_raw": "optional",
-        "required": false,
-        "default": "24",
-        "description": "How many hours back to analyze",
-        "raw": "hours   optional  {24}  How many hours back to analyze"
-      },
-      {
-        "name": "domain",
-        "required_raw": "optional",
-        "required": false,
-        "default": "example.com",
-        "description": "Site domain",
-        "raw": "domain  optional  {example.com}  Site domain"
-      }
-    ],
-    "examples": [
-      "ssh web@example.com 'bash -s' \u003c run-monitoring.sh",
-      "ssh web@example.com 'bash -s' \u003c run-monitoring.sh 24 othersite.com"
     ],
     "manifest_category": "monitoring",
     "display_category": "monitoring",

--- a/go/internal/catalog/gen/main.go
+++ b/go/internal/catalog/gen/main.go
@@ -93,7 +93,7 @@ var serverSideFallback = map[string]bool{
 	"scripts/monitoring/security-monitor": true,
 	"scripts/monitoring/ai-bot-monitor":   true,
 	"scripts/monitoring/error-monitor":    true,
-	"scripts/monitoring/run-monitoring":   true,
+	"scripts/monitoring/monitor":          true,
 	"scripts/backup/site-backup":          true,
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,8 +43,8 @@ scripts/
 │   ├── 404-checker.sh          # Internal broken-link checker (homepage scan or recursive spider)
 │   ├── ai-bot-monitor.sh       # AI crawler traffic analysis (GPTBot, ClaudeBot, etc.)
 │   ├── error-monitor.sh        # Nginx/PHP-FPM/WordPress/MySQL/systemd error log review
+│   ├── monitor.sh              # Orchestrator: runs all monitors and generates summary
 │   ├── redirect-check.sh       # Mass URL redirect checker using curl
-│   ├── run-monitoring.sh       # Orchestrator: runs all monitors and generates summary
 │   ├── security-monitor.sh     # Nginx security threat detection
 │   ├── server-monitor.sh       # Live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot over SSH
 │   ├── traffic-monitor.sh      # Nginx traffic analysis and reporting
@@ -154,7 +154,7 @@ cd ~/code/my-plugin
 ssh root@example.com 'bash -s' < scripts/monitoring/error-monitor.sh example.com 24
 
 # Run all monitors and save timestamped reports
-ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh
 
 # Screenshot WordPress block patterns and convert to WebP
 cd scripts/patterns && npm install && npx playwright install chromium
@@ -1660,7 +1660,7 @@ monitors read the *access* log and answer "who is visiting?"; this one reads the
 *error* logs and answers "is anything broken?".
 
 Runs **on the server** — it reads `/var/log/` and `/srv/www/<domain>/logs/`
-directly and needs GNU `date` — so stream it over SSH like `run-monitoring.sh`.
+directly and needs GNU `date` — so stream it over SSH like `monitor.sh`.
 
 #### Features
 
@@ -1825,7 +1825,7 @@ https://example.com/old-page/ => 404 ->
 
 ---
 
-### run-monitoring.sh (285 lines)
+### monitor.sh (285 lines)
 
 Orchestrator that runs all four monitoring scripts in sequence and generates a consolidated markdown summary report.
 
@@ -1868,17 +1868,17 @@ Orchestrator that runs all four monitoring scripts in sequence and generates a c
 
 ```bash
 # Remote execution (recommended — streams script over SSH)
-ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh
 
 # Remote with custom hours window
-ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 48
+ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh 48
 
 # Remote, for a different site on the same server
-ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 24 othersite.com
+ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh 24 othersite.com
 
 # Local execution on production server
-./run-monitoring.sh 24
-./run-monitoring.sh 24 othersite.com
+./monitor.sh 24
+./monitor.sh 24 othersite.com
 ```
 
 ---
@@ -2093,7 +2093,7 @@ backups, use the Ansible playbook instead:
 
 ```bash
 # Run all monitors daily at 9 AM (traffic + security + AI bots + summary)
-0 9 * * * /srv/scripts/monitoring/run-monitoring.sh 24 >> /var/log/monitoring.log 2>&1
+0 9 * * * /srv/scripts/monitoring/monitor.sh 24 >> /var/log/monitoring.log 2>&1
 
 # Hourly security scan (standalone)
 0 * * * * /srv/scripts/monitoring/security-monitor.sh /srv/www/example.com/logs/access.log 1 50 > /var/log/security-scan.log 2>&1

--- a/scripts/monitoring/monitor.sh
+++ b/scripts/monitoring/monitor.sh
@@ -6,19 +6,19 @@
 # and error-monitor.sh, and saves timestamped reports to an output directory.
 #
 # Usage:
-#   ssh web@example.com 'bash -s' < ./run-monitoring.sh [hours] [domain]
-#   ./run-monitoring.sh 24              # Run locally on production server
+#   ssh web@example.com 'bash -s' < ./monitor.sh [hours] [domain]
+#   ./monitor.sh 24                     # Run locally on production server
 #
 # Examples:
 #   # From local machine (recommended):
-#   ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh
+#   ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh
 #
 #   # For a different site on the same server:
-#   ssh web@example.com 'bash -s' < scripts/monitoring/run-monitoring.sh 24 othersite.com
+#   ssh web@example.com 'bash -s' < scripts/monitoring/monitor.sh 24 othersite.com
 #
 #   # On production server:
 #   cd /srv/www/example.com/current
-#   ./run-monitoring.sh 24
+#   ./monitor.sh 24
 #
 # @desc     Run traffic, security, AI-bot, and error monitoring together and save timestamped reports
 # @category monitoring
@@ -26,8 +26,8 @@
 # @requires gawk
 # @arg      hours   optional  {24}  How many hours back to analyze
 # @arg      domain  optional  {example.com}  Site domain
-# @example  ssh web@example.com 'bash -s' < run-monitoring.sh
-# @example  ssh web@example.com 'bash -s' < run-monitoring.sh 24 othersite.com
+# @example  ssh web@example.com 'bash -s' < monitor.sh
+# @example  ssh web@example.com 'bash -s' < monitor.sh 24 othersite.com
 # @doc      trellis/monitoring/README.md
 
 set -e

--- a/wp-ops
+++ b/wp-ops
@@ -99,7 +99,7 @@ scripts/monitoring/traffic-monitor
 scripts/monitoring/security-monitor
 scripts/monitoring/ai-bot-monitor
 scripts/monitoring/error-monitor
-scripts/monitoring/run-monitoring
+scripts/monitoring/monitor
 scripts/backup/site-backup
 "
 
@@ -145,7 +145,7 @@ ${command_key}
 # argument. For these, "I already have a copy of the log here" is a meaningful
 # thing to say, and they're the ones that need gawk to parse the combined-format
 # timestamp. error-monitor reads a fixed set of system log paths for a domain and
-# filters them with plain awk, and run-monitoring's first argument is an hour
+# filters them with plain awk, and monitor's first argument is an hour
 # count — neither has a log file you could hand it locally.
 ACCESS_LOG_COMMANDS="
 scripts/monitoring/traffic-monitor
@@ -168,7 +168,7 @@ ${command_key}
 server_side_example_args() {
     case "$1" in
         scripts/monitoring/error-monitor) echo "example.com 48" ;;
-        scripts/monitoring/run-monitoring) echo "24 example.com" ;;
+        scripts/monitoring/monitor) echo "24 example.com" ;;
         scripts/backup/site-backup) echo "example.com" ;;
         *) echo "/srv/www/example.com/logs/access.log 24" ;;
     esac
@@ -1491,7 +1491,7 @@ execute_command() {
                 # on the server (run it), absent on a workstation. An explicit
                 # readable file argument is an intentional "I have the log here"
                 # — honoured for the commands that actually take a log path
-                # (error-monitor's first argument is a domain, run-monitoring's
+                # (error-monitor's first argument is a domain, monitor's
                 # is an hour count), and only where GNU date exists to run it,
                 # since otherwise it dies several screens in on `date: illegal
                 # option`.
@@ -1911,8 +1911,8 @@ run_doctor() {
     echo ""
 
     # The log monitors (traffic/security/ai-bot) read /srv/www/<site>/logs/
-    # directly and use GNU `date -d`, and run-monitoring.sh is invoked as
-    # `ssh host 'bash -s' < run-monitoring.sh`. They execute on the server, so
+    # directly and use GNU `date -d`, and monitor.sh is invoked as
+    # `ssh host 'bash -s' < monitor.sh`. They execute on the server, so
     # checking their dependencies against this machine would be misleading.
     echo "${BOLD}Server-side${RESET} ${DIM}(not checked here — these run on the server)${RESET}"
     printf "  ${DIM}%s %-18s %s${RESET}\n" "·" "gawk" "time filtering in the Nginx log monitors"


### PR DESCRIPTION
## Summary

- `git mv scripts/monitoring/run-monitoring.sh scripts/monitoring/monitor.sh` — the one genuinely opaque script name flagged in `docs/wp-ops-recommendations.md` Gap 1. Nothing about "run-monitoring" suggested it's the combined traffic/security/AI-bot/error report.
- `wp-ops monitor` (and `wp-ops scripts/monitoring/monitor`) now resolves via the existing basename-resolution mechanism — no new directive, no alias table.
- Swept every reference to the old key/filename across both CLIs and current-state docs:
  - `wp-ops` (bash) — `SERVER_SIDE_COMMANDS`, `server_side_example_args`, doctor/server-side-guard prose
  - `go/cmd/serverside.go` + `go/cmd/serverside_test.go`
  - `go/internal/catalog/gen/main.go`'s `serverSideFallback` map — `catalog.json` regenerated
  - `README.md`, `scripts/README.md` (usage examples, file-tree listing reordered alphabetically, cron example)
- Left historical/dated docs alone (`docs/m3-go-skeleton.md`, `CHANGELOG.md`) — they're point-in-time records, not current reference material.
- `docs/wp-ops-recommendations.md` Gap 1 and `CHANGELOG.md` updated to record this as done.

## Test plan

- [x] `./wp-ops manifest lint` — 69 annotated commands, no problems
- [x] `gofmt -l` on touched Go files — clean
- [x] `go build ./... && go test ./...` — all packages pass
- [x] `go generate ./internal/catalog/...` — catalog.json regenerated
- [x] `go/scripts/parity-check.sh` — 8/8 passed (bash/Go `--json` matches field-for-field)