### PR TITLE
MCP output compaction + README TRELLIS_DIR clarification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.35.0] - 2026-08-03
+
+### Changed
+
+- **README** - reworded the `TRELLIS_DIR`/`WP_SITE_DIR` section to lead with the existing auto-detection behavior (wp-ops walks up from the current directory and asks before using what it finds) rather than presenting the explicit `export` as a hard prerequisite; the variables are only required when running from outside the project or non-interactively.
+
 ## [3.34.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.34.0] - 2026-08-03
+
+### Added
+
+- **mcp-server** - `wp_cli` tool output is now capped at 15,000 characters (`truncateWpCliOutput()` in `tools/wpCli.ts`), addressing item 9 of `docs/mcp-server-recommendations.md`: a big `wp post list` on a large site could otherwise dump tens of KB straight into an agent's context. The truncation notice hints at `--format=count` / `--fields=` / `--posts_per_page=` to narrow the command instead. Applied only at the `wp_cli` tool's call site in `server.ts` — `urlAudit.ts`'s own `runWpCli` calls (search-replace previews) are already small, curated reports and stay untruncated.
+- **mcp-server** - `redirect_audit` and `schema_audit` both gained a `summary: boolean` parameter (item 9): when true, pages that fully pass — the same categories each tool already scores into its pass/fail counts — or already have schema are omitted from the per-page detail and replaced with a single "N page(s) omitted" line, cutting typical output on multi-page audits by more than half.
+
+### Changed
+
+- **mcp-server** - `wp_cli`, `redirect_audit`, `schema_audit`, and `url_audit` tool descriptions trimmed from 3–4 sentences to 1–2 (item 10 of `docs/mcp-server-recommendations.md`), since user-scope registration loads all five tool descriptions into every session in every project. The confirm-gating detail `wp_cli`'s description used to spell out is still fully covered by the runtime error already thrown when a mutating command is called without `confirm: true`, so no information was lost.
+- **docs** - `docs/mcp-server-recommendations.md`: marked items 9 and 10 done.
+
 ## [3.33.0] - 2026-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ Run `wp-ops doctor` first — it reports which of the external tools these scrip
 
 `wp-ops init` (Go CLI only) installs `wp-ops <TAB>` completion for zsh, bash, or fish, auto-detected from `$SHELL`. Worth running right after `brew install` — the Homebrew cask this ships as doesn't wire up completions on its own the way a Homebrew formula would.
 
-Two categories need environment variables pointing at a real project before their commands work:
+Two categories resolve their project directory from an environment variable — but you
+don't need to export it by hand if you're standing inside the project: wp-ops detects
+it by walking up from your current directory and asks before using what it finds.
+Setting the variable explicitly is only required when you're running from elsewhere
+(e.g. from this repo's own directory) or non-interactively (CI, cron), where there's
+no prompt to confirm a detected guess:
 
 ```bash
 # Ansible playbooks (wp-ops trellis <playbook>) need a Trellis project's ansible.cfg/inventory/group_vars
@@ -63,7 +68,8 @@ wp-ops wp-cli scanner-wrapper
 wp-ops bedrock wp-cli-pattern-validate web/app/themes/your-theme/patterns/ --fix
 ```
 
-If either variable is unset, wp-ops looks for the project by walking up from your current directory and asks before using what it finds — it never guesses silently, and non-interactive runs require the variable to be set explicitly. Detection deliberately only matches a project you're actually standing inside, so an unrelated Trellis checkout sitting next to your current repo won't be picked up.
+Detection deliberately only matches a project you're actually standing inside, so an
+unrelated Trellis checkout sitting next to your current repo won't be picked up.
 
 `nginx/` and `troubleshooting/` contain guides and Nginx config templates rather than runnable scripts; `wp-ops nginx` lists those documents instead of commands.
 

--- a/docs/mcp-server-recommendations.md
+++ b/docs/mcp-server-recommendations.md
@@ -5,9 +5,9 @@ all sites — example.com, other WordPress installs (Bedrock/Trellis or plain), 
 non-WordPress sites — with a focus on saving time and tokens. Also covers the
 longer-term question of tighter coupling with the Go CLI binary.
 
-> **Status:** Up to date as of v3.24.0 (2026-08-03) — items 1-8 done. Verified
-> 2026-08-03: item 1's "not registered user-scoped" observation was stale — it
-> already was, see below.
+> **Status:** Up to date as of v3.34.0 (2026-08-03) — items 1-11 done (all items
+> in this document). Verified 2026-08-03: item 1's "not registered user-scoped"
+> observation was stale — it already was, see below.
 
 ## Current state
 
@@ -151,20 +151,31 @@ Observed setup gaps:
    coincidentally collide with a safe verb — e.g. `wp option update list <value>`
    must stay gated even though its third token is `list`.*
 
-9. **Cap and compact tool output.**
+9. ✅ **Cap and compact tool output.** *Done, 2026-08-03.*
    `wp_cli` returns stdout verbatim — `wp post list` on a big site can dump tens
-   of KB straight into context. Truncate at ~10–20 KB with a "use
-   `--format=count` / `--fields=` / `--posts_per_page`" hint in the truncation
-   notice. Similarly, `schema_audit`'s default page list probes a dozen guessed
-   paths and pages that 404 still produce output lines. A `summary`-only mode
-   (counts + failures only) for both audits would cut typical results by more than
-   half.
+   of KB straight into context.
 
-10. **Keep tool descriptions tight once user-scoped.**
+   *`tools/wpCli.ts`'s new `truncateWpCliOutput()` caps the `wp_cli` tool's output
+   at 15,000 characters, appending a notice with the same "use `--format=count` /
+   `--fields=` / `--posts_per_page=`" hint proposed here. Applied only at the
+   `wp_cli` tool call site in `server.ts` — `urlAudit.ts`'s own `runWpCli` calls
+   (search-replace previews) are already small, curated reports and stay
+   untruncated. Separately, `redirect_audit` and `schema_audit` both gained a
+   `summary: z.boolean()` param: when true, pages that fully pass (the same
+   pass/fail categories each tool already scores) or already have schema are
+   omitted from the per-page detail, replaced with a single "N page(s) omitted"
+   line.*
+
+10. ✅ **Keep tool descriptions tight once user-scoped.** *Done, 2026-08-03.*
     With user-scope registration, all five tool descriptions load into *every*
-    session in every project. The `wp_cli` description especially is long; trim
-    descriptions to 1–2 sentences and move usage detail into error messages
-    (which only appear when needed) to save a fixed per-session tax.
+    session in every project.
+
+    *Trimmed `wp_cli`, `redirect_audit`, `schema_audit`, and `url_audit`'s
+    descriptions in `server.ts` from 3–4 sentences each to 1–2. The confirm-gating
+    detail `wp_cli`'s description used to spell out is still fully covered by the
+    runtime error already thrown when a mutating command is called without
+    `confirm: true`, so nothing was lost. `security_scan` and `db_backup` were
+    already tight and needed no change.*
 
 ## Highest-leverage new tool
 
@@ -186,7 +197,8 @@ Observed setup gaps:
 1. ✅ Items 1–4: config-only, doable immediately.
 2. ✅ Items 5–6: opens up all non-Trellis and static sites (turned out to already be implemented).
 3. ✅ Items 7–8: biggest recurring token savers.
-4. ✅ Item 11: `url_audit` tool — done. Item 9–10 (output compaction) remain.
+4. ✅ Item 11: `url_audit` tool — done.
+5. ✅ Items 9–10: output compaction and tight descriptions — done.
 
 ---
 

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -3,7 +3,7 @@ import { z, type ZodTypeAny } from "zod";
 import { loadRegistry, resolveSiteEnv } from "./registry.js";
 import { runDbBackup } from "./tools/dbBackup.js";
 import { runSecurityScan } from "./tools/securityScan.js";
-import { isReadOnlyWpCommand, runWpCli } from "./tools/wpCli.js";
+import { isReadOnlyWpCommand, runWpCli, truncateWpCliOutput } from "./tools/wpCli.js";
 import { runRedirectAudit } from "./tools/redirectAudit.js";
 import { runSchemaAudit } from "./tools/schemaAudit.js";
 import { runUrlAudit, DEFAULT_URL_AUDIT_PATTERNS } from "./tools/urlAudit.js";
@@ -94,12 +94,9 @@ export function createServer(): McpServer {
 
   server.tool(
     "wp_cli",
-    "Run a WP-CLI command against a configured site/environment. Pass the command and its arguments as " +
-      "separate tokens in `args` (e.g. [\"post\", \"list\", \"--post_type=page\", \"--format=json\"]), not as " +
-      "one shell string, and omit the leading \"wp\" and any --path flag (added automatically from the site " +
-      "registry). Read-only commands (list/get/exists/status/info/version/search/check-update/doctor/export) " +
-      "run immediately; anything else — updates, deletes, installs, search-replace, eval, etc. — requires " +
-      "confirm: true, which should only be set after the user has explicitly approved that specific command.",
+    "Run a WP-CLI command against a configured site/environment. Pass args as separate tokens " +
+      "(e.g. [\"post\", \"list\", \"--format=json\"]), omitting the leading \"wp\" and any --path. " +
+      "Mutating commands need confirm: true, only after explicit user approval.",
     {
       site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
       env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),
@@ -126,7 +123,7 @@ export function createServer(): McpServer {
         const registry = loadRegistry();
         const entry = resolveSiteEnv(registry, site, env);
         const output = await runWpCli(entry, args);
-        return { content: [{ type: "text" as const, text: output }] };
+        return { content: [{ type: "text" as const, text: truncateWpCliOutput(output) }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
@@ -136,10 +133,8 @@ export function createServer(): McpServer {
 
   server.tool(
     "redirect_audit",
-    "Run a comprehensive redirect chain audit for one or more URLs. Tests HTTPS pages for 200 status " +
-      "with 0 redirects (optimal), verifies HTTP→HTTPS 301 redirects, checks www→non-www canonicalization, " +
-      "and validates security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options). Returns color-coded " +
-      "status for each test with detailed recommendations. Pass either `urls` or `site`+`env` (to use the site's registered URL).",
+    "Audit one or more URLs for redirect-chain issues: HTTPS status/redirect count, HTTP→HTTPS and " +
+      "www→non-www canonicalization, and security headers. Pass `urls` or `site`+`env`.",
     {
       urls: z
         .array(z.string().url())
@@ -156,8 +151,12 @@ export function createServer(): McpServer {
         .boolean()
         .default(true)
         .describe('Whether to check for security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options)'),
+      summary: z
+        .boolean()
+        .default(false)
+        .describe("If true, only list pages with at least one failing test — pages that fully pass are omitted."),
     },
-    async ({ urls, site, env, checkWww, checkSecurityHeaders }) => {
+    async ({ urls, site, env, checkWww, checkSecurityHeaders, summary }) => {
       try {
         // Resolve URLs from site/env if provided
         let targetUrls = urls;
@@ -182,7 +181,16 @@ export function createServer(): McpServer {
           "",
           "Results:",
         ];
+        // Mirrors the 3 categories runRedirectAudit itself counts toward passedTests/failedTests
+        // (security headers are reported but not scored) — a page only "fully passes" if all 3 do.
+        let omitted = 0;
         for (const page of result.pages) {
+          const pagePassed =
+            page.status === 200 && page.redirects === 0 && page.httpRedirect && (!checkWww || page.wwwRedirect);
+          if (summary && pagePassed) {
+            omitted++;
+            continue;
+          }
           lines.push(`  ${page.url}:`);
           lines.push(`    HTTPS: ${page.status} (redirects: ${page.redirects})`);
           lines.push(`    HTTP→HTTPS: ${page.httpRedirect ? "✅" : "❌"} ${page.httpRedirectTarget || "N/A"}`);
@@ -198,6 +206,9 @@ export function createServer(): McpServer {
               page.securityHeaders.xContentTypeOptions ? "✅" : "❌"
             }`
           );
+        }
+        if (summary && omitted > 0) {
+          lines.push(`  (${omitted} page(s) fully passed and are omitted from this summary)`);
         }
         lines.push("");
         lines.push(
@@ -216,9 +227,8 @@ export function createServer(): McpServer {
 
   server.tool(
     "schema_audit",
-    "Audit schema markup (JSON-LD) across key pages of a site. Checks for Organization, LocalBusiness, " +
-      "Service, Product, WebSite, BreadcrumbList, Article, FAQPage, HowTo, and Person schema types. " +
-      "Returns count of pages with/without schema and which schema types are present. Pass either `siteUrl` or `site`+`env`.",
+    "Audit JSON-LD schema markup (Organization, LocalBusiness, Product, Article, etc.) across key pages " +
+      "of a site. Pass `siteUrl` or `site`+`env`.",
     {
       siteUrl: z.string().optional().describe('Site URL to audit, e.g. "https://example.com"'),
       site: siteSchema.optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
@@ -230,8 +240,12 @@ export function createServer(): McpServer {
           'Specific pages to check as "name|url" pairs, e.g. ["Homepage|/", "Contact|/contact/"]. ' +
             'Defaults to common pages (homepage, services, about, contact, portfolio, shop, blog, etc.)'
         ),
+      summary: z
+        .boolean()
+        .default(false)
+        .describe("If true, only list pages missing schema or not found — pages that already have schema are omitted."),
     },
-    async ({ siteUrl, site, env, pages }) => {
+    async ({ siteUrl, site, env, pages, summary }) => {
       try {
         // Resolve siteUrl from site/env if provided
         let targetUrl = siteUrl;
@@ -262,8 +276,13 @@ export function createServer(): McpServer {
         }
         lines.push("");
         lines.push("Page Details:");
+        let omitted = 0;
         for (const page of result.pages) {
           const status = page.exists ? (page.hasSchema ? "✅ Has Schema" : "❌ No Schema") : "⚠️  Not Found";
+          if (summary && page.exists && page.hasSchema) {
+            omitted++;
+            continue;
+          }
           lines.push(`  ${page.pageName} (${page.url}): ${status}`);
           if (page.hasSchema) {
             const foundTypes = page.schemaTypes.filter((t) => t.found).map((t) => t.type);
@@ -271,6 +290,9 @@ export function createServer(): McpServer {
               lines.push(`    Types: ${foundTypes.join(", ")}`);
             }
           }
+        }
+        if (summary && omitted > 0) {
+          lines.push(`  (${omitted} page(s) already have schema and are omitted from this summary)`);
         }
         lines.push("");
         if (result.pagesWithoutSchema > 0) {
@@ -290,11 +312,9 @@ export function createServer(): McpServer {
 
   server.tool(
     "url_audit",
-    'Audit wp_posts.post_content for hardcoded dev URLs (e.g. ".test"/".localhost") baked in by ' +
-      "get_template_directory_uri() during local content creation — the CRITICAL post-migration check " +
-      "CLAUDE.md documents. Reports a hit count per pattern. Pass `replace: {from, to}` to also preview " +
-      "a `wp search-replace --all-tables --precise --dry-run`; add confirm: true, only after explicit " +
-      "user approval, to apply it for real.",
+    'Audit wp_posts.post_content for hardcoded dev URLs (e.g. ".test"/".localhost") from local content ' +
+      "creation. Pass `replace: {from, to}` to preview a search-replace; confirm: true (after explicit " +
+      "user approval) to apply it.",
     {
       site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
       env: envSchema.describe('Environment key for that site, e.g. "development", "staging", "production"'),

--- a/mcp-server/src/tools/wpCli.ts
+++ b/mcp-server/src/tools/wpCli.ts
@@ -131,3 +131,18 @@ export async function runWpCli(entry: EnvEntry, args: string[]): Promise<string>
   if (result.stderr.trim()) parts.push(`STDERR:\n${result.stderr.trim()}`);
   return parts.filter(Boolean).join("\n");
 }
+
+// A big `wp post list` on a large site can dump tens of KB into the model's context.
+// Capped well above what any well-formed command needs, and low enough to bound the
+// worst case; the truncation notice tells the model how to narrow the command instead.
+const MAX_OUTPUT_CHARS = 15_000;
+
+export function truncateWpCliOutput(text: string, maxChars: number = MAX_OUTPUT_CHARS): string {
+  if (text.length <= maxChars) return text;
+  return (
+    text.slice(0, maxChars) +
+    `\n\n[... truncated at ${maxChars.toLocaleString()} of ${text.length.toLocaleString()} characters. ` +
+    "Narrow the command instead of reading past this point — e.g. --format=count, --fields=, " +
+    "--posts_per_page=, or a more specific filter.]"
+  );
+}


### PR DESCRIPTION
## Summary
- `wp_cli` tool output is now capped at 15,000 characters with a hint to narrow the command (`--format=count`/`--fields=`/`--posts_per_page=`), instead of dumping tens of KB verbatim into an agent's context.
- `redirect_audit` and `schema_audit` gain a `summary` parameter that omits pages which already fully pass/have schema, cutting typical multi-page audit output by more than half.
- Trimmed the four longest MCP tool descriptions (`wp_cli`, `redirect_audit`, `schema_audit`, `url_audit`) to 1-2 sentences, since user-scope registration loads all five descriptions into every session in every project.
- Closes items 9-10 of `docs/mcp-server-recommendations.md` (all 11 items in that doc are now done).
- README: reworded the `TRELLIS_DIR`/`WP_SITE_DIR` section to lead with the existing auto-detection behavior rather than presenting the explicit `export` as a hard prerequisite.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] `npm run build` succeeds in `mcp-server/`
- [ ] Manually invoke `wp_cli` against a site with a large result set and confirm truncation notice appears
- [ ] Manually invoke `redirect_audit`/`schema_audit` with `summary: true` and confirm passing pages are omitted