### PR TITLE
Consolidate CHANGELOG 3.34.0 into 3.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.35.0] - 2026-08-03
 
-### Changed
-
-- **README** - reworded the `TRELLIS_DIR`/`WP_SITE_DIR` section to lead with the existing auto-detection behavior (wp-ops walks up from the current directory and asks before using what it finds) rather than presenting the explicit `export` as a hard prerequisite; the variables are only required when running from outside the project or non-interactively.
-
-## [3.34.0] - 2026-08-03
-
 ### Added
 
 - **mcp-server** - `wp_cli` tool output is now capped at 15,000 characters (`truncateWpCliOutput()` in `tools/wpCli.ts`), addressing item 9 of `docs/mcp-server-recommendations.md`: a big `wp post list` on a large site could otherwise dump tens of KB straight into an agent's context. The truncation notice hints at `--format=count` / `--fields=` / `--posts_per_page=` to narrow the command instead. Applied only at the `wp_cli` tool's call site in `server.ts` — `urlAudit.ts`'s own `runWpCli` calls (search-replace previews) are already small, curated reports and stay untruncated.
@@ -21,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **mcp-server** - `wp_cli`, `redirect_audit`, `schema_audit`, and `url_audit` tool descriptions trimmed from 3–4 sentences to 1–2 (item 10 of `docs/mcp-server-recommendations.md`), since user-scope registration loads all five tool descriptions into every session in every project. The confirm-gating detail `wp_cli`'s description used to spell out is still fully covered by the runtime error already thrown when a mutating command is called without `confirm: true`, so no information was lost.
+- **README** - reworded the `TRELLIS_DIR`/`WP_SITE_DIR` section to lead with the existing auto-detection behavior (wp-ops walks up from the current directory and asks before using what it finds) rather than presenting the explicit `export` as a hard prerequisite; the variables are only required when running from outside the project or non-interactively.
 - **docs** - `docs/mcp-server-recommendations.md`: marked items 9 and 10 done.
 
 ## [3.33.0] - 2026-08-03

--- a/docs/mcp-server-recommendations.md
+++ b/docs/mcp-server-recommendations.md
@@ -5,7 +5,7 @@ all sites — example.com, other WordPress installs (Bedrock/Trellis or plain), 
 non-WordPress sites — with a focus on saving time and tokens. Also covers the
 longer-term question of tighter coupling with the Go CLI binary.
 
-> **Status:** Up to date as of v3.34.0 (2026-08-03) — items 1-11 done (all items
+> **Status:** Up to date as of v3.35.0 (2026-08-03) — items 1-11 done (all items
 > in this document). Verified 2026-08-03: item 1's "not registered user-scoped"
 > observation was stale — it already was, see below.
 


### PR DESCRIPTION
## Summary
- PR #169 shipped as a single merge commit, tagged once as `v3.35.0` — there was never a separate `v3.34.0` release. `CHANGELOG.md` had split the changes across two version headers, implying a release that doesn't exist. Folded them into one `3.35.0` entry.
- Fixed the now-stale `v3.34.0` reference in `docs/mcp-server-recommendations.md`'s status line.

## Test plan
- [x] Diff reviewed — no content changes, only the two `CHANGELOG.md` headers merged into one