### PR TITLE
Add SVG export, traffic-by-country, and orphan-links-audit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-08-04
+
+### Added
+
+Four commands adopted from `seo-strategy/tools/scripts/`, generalized off
+imagewize-specific hardcodes. That repo had accumulated ~32 scripts, 16 of them
+forks of scripts already here; these four were the ones with no wp-ops
+equivalent, so they move up before the forks get deleted.
+
+- **scripts/images/svg-to-jpg.sh** - renders design SVGs to JPG next to their
+  source via librsvg (accurate font/gradient rendering) plus ImageMagick to
+  encode. Takes a directory or individual `.svg` files. `-w`/`-h` force output
+  dimensions for a platform spec (e.g. Mastodon's 1920x1080), `-s` scales by a
+  multiplier for high-DPI, `-q` sets quality. Since the source is vector,
+  upscaling is lossless.
+- **scripts/images/svg-to-png.sh** - the same, to PNG. Prefer it for any banner
+  or card carrying text or a logo — JPG compression blurs fine text edges, which
+  shows up on wordmarks and URL strips. Gained `-w`/`-h`/`-s` in the move; the
+  original was native-size only.
+- **scripts/monitoring/traffic-by-country.sh** - pulls an Nginx access log over
+  SSH, resolves every unique client IP through `geoip2fast`, and reports only
+  the requests from one country, with bots, static assets, attack probes, Tor
+  exits, and redirect/404 responses filtered out. Answers "did anyone from NL
+  actually read the page after that outreach batch went out?" `--quick`/`--hours`
+  bound how much log gets pulled; `--pattern` narrows to a URL regex.
+- **wp-cli/seo/orphan-links-audit.sh** - finds published posts/pages that no
+  other content links to, as a single SQL query. This is the inbound-link
+  sibling of the existing `orphan-pages-audit.sh`, which only checks navigation
+  menus — a page can sit in the nav with zero in-content links, or be linked
+  from a dozen posts while absent from every menu, so the two are worth running
+  together. Runs locally or against production over `--host`. Link detection is
+  a slug substring match, so the output is a shortlist to review rather than a
+  verdict; the script and README both say so.
+
+### Changed
+
+- **wp-cli/seo/README.md** - the orphan-pages "Important Note" pointed at
+  Screaming Frog/Ahrefs/Sitebulb for "filter for pages with 0 internal links".
+  That is now `orphan-links-audit.sh`, so the note points there first and keeps
+  the external crawlers as the step beyond both scripts.
+
+### Fixed
+
+- **go/internal/catalog/catalog_test.go** - count expectations updated for the
+  four new commands (72→76 entries, scripts 38→41, monitoring display 12→13),
+  following the existing running-tally comment convention.
+
 ## [4.0.0] - 2026-08-04
 
 ### Removed

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -677,6 +677,124 @@
   },
   {
     "category": "scripts",
+    "key": "scripts/images/svg-to-jpg",
+    "description": "Export design SVGs to JPG with librsvg, at native size or forced dimensions",
+    "script_path": "scripts/images/svg-to-jpg.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "rsvg-convert",
+      "magick"
+    ],
+    "args": [
+      {
+        "name": "target",
+        "required_raw": "optional",
+        "required": false,
+        "default": "designs/linkedin",
+        "description": "Directory or .svg file to export (repeatable)",
+        "raw": "target  optional  {designs/linkedin}  Directory or .svg file to export (repeatable)"
+      }
+    ],
+    "flags": [
+      {
+        "name": "-w",
+        "required_raw": "optional",
+        "required": false,
+        "default": "1920",
+        "description": "Output width in px",
+        "raw": "-w      optional  {1920}  Output width in px"
+      },
+      {
+        "name": "-h",
+        "required_raw": "optional",
+        "required": false,
+        "default": "1080",
+        "description": "Output height in px",
+        "raw": "-h      optional  {1080}  Output height in px"
+      },
+      {
+        "name": "-s",
+        "required_raw": "optional",
+        "required": false,
+        "default": "2",
+        "description": "Scale multiplier; ignored if -w/-h given",
+        "raw": "-s      optional  {2}  Scale multiplier; ignored if -w/-h given"
+      },
+      {
+        "name": "-q",
+        "required_raw": "optional",
+        "required": false,
+        "default": "90",
+        "description": "JPEG quality 1-100",
+        "raw": "-q      optional  {90}  JPEG quality 1-100"
+      }
+    ],
+    "examples": [
+      "wp-ops svg-to-jpg designs/linkedin",
+      "wp-ops svg-to-jpg -w 1920 -h 1080 designs/mastodon"
+    ],
+    "manifest_category": "images",
+    "display_category": "images",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
+    "key": "scripts/images/svg-to-png",
+    "description": "Export design SVGs to PNG with librsvg — lossless, best for text/logo banners",
+    "script_path": "scripts/images/svg-to-png.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "rsvg-convert",
+      "magick"
+    ],
+    "args": [
+      {
+        "name": "target",
+        "required_raw": "optional",
+        "required": false,
+        "default": "designs/linkedin",
+        "description": "Directory or .svg file to export (repeatable)",
+        "raw": "target  optional  {designs/linkedin}  Directory or .svg file to export (repeatable)"
+      }
+    ],
+    "flags": [
+      {
+        "name": "-w",
+        "required_raw": "optional",
+        "required": false,
+        "default": "1584",
+        "description": "Output width in px",
+        "raw": "-w      optional  {1584}  Output width in px"
+      },
+      {
+        "name": "-h",
+        "required_raw": "optional",
+        "required": false,
+        "default": "396",
+        "description": "Output height in px",
+        "raw": "-h      optional  {396}  Output height in px"
+      },
+      {
+        "name": "-s",
+        "required_raw": "optional",
+        "required": false,
+        "default": "2",
+        "description": "Scale multiplier; ignored if -w/-h given",
+        "raw": "-s      optional  {2}  Scale multiplier; ignored if -w/-h given"
+      }
+    ],
+    "examples": [
+      "wp-ops svg-to-png designs/linkedin",
+      "wp-ops svg-to-png -w 1584 -h 396 designs/linkedin/banner.svg"
+    ],
+    "manifest_category": "images",
+    "display_category": "images",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
     "key": "scripts/misc/convert-screenshot-for-claude",
     "description": "Convert a PNG screenshot to JPEG (Claude Code's VSCode extension mislabels PNGs)",
     "script_path": "scripts/misc/convert-screenshot-for-claude.sh",
@@ -1254,6 +1372,96 @@
     ],
     "examples": [
       "wp-ops scripts/monitoring/server-monitor web@example.com"
+    ],
+    "manifest_category": "monitoring",
+    "display_category": "monitoring",
+    "annotated": true
+  },
+  {
+    "category": "scripts",
+    "key": "scripts/monitoring/traffic-by-country",
+    "description": "Filter a server's Nginx access log by visitor country and show real page visits",
+    "script_path": "scripts/monitoring/traffic-by-country.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "ssh",
+      "python3",
+      "geoip2fast"
+    ],
+    "doc": "scripts/README.md",
+    "args": [
+      {
+        "name": "country-code",
+        "required_raw": "optional",
+        "required": false,
+        "default": "NL",
+        "description": "Two-letter ISO country code to filter for",
+        "raw": "country-code  optional  {NL}  Two-letter ISO country code to filter for"
+      },
+      {
+        "name": "date-filter",
+        "required_raw": "optional",
+        "required": false,
+        "default": "29/May/2026",
+        "description": "Only lines matching this date string",
+        "raw": "date-filter   optional  {29/May/2026}  Only lines matching this date string"
+      }
+    ],
+    "flags": [
+      {
+        "name": "--host",
+        "required_raw": "optional",
+        "required": false,
+        "default": "web@example.com",
+        "description": "SSH user@host to pull logs from",
+        "raw": "--host        optional  {web@example.com}  SSH user@host to pull logs from"
+      },
+      {
+        "name": "--log",
+        "required_raw": "optional",
+        "required": false,
+        "default": "/srv/www/example.com/logs/access.log",
+        "description": "Nginx access log path on the server",
+        "raw": "--log         optional  {/srv/www/example.com/logs/access.log}  Nginx access log path on the server"
+      },
+      {
+        "name": "--quick",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Only pull the last 10,000 log lines",
+        "raw": "--quick       optional  Only pull the last 10,000 log lines"
+      },
+      {
+        "name": "--pattern",
+        "required_raw": "optional",
+        "required": false,
+        "choices": [
+          "/nl-",
+          "/dutch-"
+        ],
+        "description": "Only count requests whose URL matches this regex",
+        "raw": "--pattern     optional  {/nl-|/dutch-}  Only count requests whose URL matches this regex"
+      },
+      {
+        "name": "--hours",
+        "required_raw": "optional",
+        "required": false,
+        "default": "24",
+        "description": "Only pull the last N hours (implies --quick)",
+        "raw": "--hours       optional  {24}  Only pull the last N hours (implies --quick)"
+      },
+      {
+        "name": "--show-bots",
+        "required_raw": "optional",
+        "required": false,
+        "description": "Include bot traffic instead of filtering it out",
+        "raw": "--show-bots   optional  Include bot traffic instead of filtering it out"
+      }
+    ],
+    "examples": [
+      "wp-ops traffic-by-country --host web@example.com NL",
+      "wp-ops traffic-by-country -q --hours 24 --pattern \"/contact/\" US"
     ],
     "manifest_category": "monitoring",
     "display_category": "monitoring",
@@ -2812,6 +3020,59 @@
     ],
     "examples": [
       "wp-ops wp-cli/seo/blog-audit --path web/wp --output reports/seo"
+    ],
+    "manifest_category": "seo",
+    "display_category": "wp-cli",
+    "annotated": true
+  },
+  {
+    "category": "wp-cli",
+    "key": "wp-cli/seo/orphan-links-audit",
+    "description": "Find published posts/pages that no other content links to internally",
+    "script_path": "wp-cli/seo/orphan-links-audit.sh",
+    "runs_on": "local",
+    "runs": "local",
+    "requires": [
+      "wp"
+    ],
+    "doc": "wp-cli/seo/README.md",
+    "flags": [
+      {
+        "name": "--host",
+        "required_raw": "optional",
+        "required": false,
+        "default": "web@example.com",
+        "description": "SSH user@host to run WP-CLI on",
+        "raw": "--host       optional  {web@example.com}  SSH user@host to run WP-CLI on"
+      },
+      {
+        "name": "--site-path",
+        "required_raw": "optional",
+        "required": false,
+        "default": "/srv/www/example.com/current",
+        "description": "Site root on the server",
+        "raw": "--site-path  optional  {/srv/www/example.com/current}  Site root on the server"
+      },
+      {
+        "name": "--path",
+        "required_raw": "optional",
+        "required": false,
+        "default": "web/wp",
+        "description": "WordPress path for WP-CLI",
+        "raw": "--path       optional  {web/wp}  WordPress path for WP-CLI"
+      },
+      {
+        "name": "--output",
+        "required_raw": "optional",
+        "required": false,
+        "default": "audits",
+        "description": "Output directory",
+        "raw": "--output     optional  {audits}  Output directory"
+      }
+    ],
+    "examples": [
+      "wp-ops orphan-links-audit --host web@example.com",
+      "wp-ops orphan-links-audit --path web/wp --output reports/seo"
     ],
     "manifest_category": "seo",
     "display_category": "wp-cli",

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -10,8 +10,8 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(c.Entries) != 72 {
-		t.Errorf("len(Entries) = %d, want 72 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0, +1 for scripts/backup/db-pull added in 3.26.0, +4 for ttfb-test/remote-ttfb-ua/import-page-draft/check-deny-ips added in 3.27.0)", len(c.Entries))
+	if len(c.Entries) != 76 {
+		t.Errorf("len(Entries) = %d, want 76 (66 per docs/m3-go-skeleton.md acceptance criteria, +1 for mcp-server/run added in 3.25.0, +1 for scripts/backup/db-pull added in 3.26.0, +4 for ttfb-test/remote-ttfb-ua/import-page-draft/check-deny-ips added in 3.27.0, +4 for svg-to-jpg/svg-to-png/traffic-by-country/orphan-links-audit added in 4.1.0)", len(c.Entries))
 	}
 }
 
@@ -150,8 +150,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	scriptsRaw := c.CommandsIn("scripts")
-	if len(scriptsRaw) != 38 {
-		t.Errorf("CommandsIn(scripts) = %d entries, want 38 (directory-based grouping must be unaffected by the display split; +2 for ttfb-test/remote-ttfb-ua added in 3.27.0)", len(scriptsRaw))
+	if len(scriptsRaw) != 41 {
+		t.Errorf("CommandsIn(scripts) = %d entries, want 41 (directory-based grouping must be unaffected by the display split; +2 for ttfb-test/remote-ttfb-ua added in 3.27.0, +3 for svg-to-jpg/svg-to-png/traffic-by-country added in 4.1.0)", len(scriptsRaw))
 	}
 	for _, e := range scriptsRaw {
 		if e.Category != "scripts" {
@@ -165,8 +165,8 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 	}
 
 	monitoring := c.CommandsInDisplay("monitoring")
-	if len(monitoring) != 12 {
-		t.Errorf("CommandsInDisplay(monitoring) = %d entries, want 12 (+2 for ttfb-test/remote-ttfb-ua added in 3.27.0)", len(monitoring))
+	if len(monitoring) != 13 {
+		t.Errorf("CommandsInDisplay(monitoring) = %d entries, want 13 (+2 for ttfb-test/remote-ttfb-ua added in 3.27.0, +1 for traffic-by-country added in 4.1.0)", len(monitoring))
 	}
 	for _, e := range monitoring {
 		if e.Category != "scripts" {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,7 +33,9 @@ scripts/
 │   ├── convert-to-webp.sh      # JPG to WebP conversion with center-crop (Facebook OG)
 │   ├── make-square-webp.sh     # Pad an image onto a square canvas and export as WebP
 │   ├── openverse_search.py     # Search Openverse for CC-licensed images
-│   └── openverse_download.py   # Download Openverse image URLs, optionally converting to WebP
+│   ├── openverse_download.py   # Download Openverse image URLs, optionally converting to WebP
+│   ├── svg-to-jpg.sh           # Render design SVGs to JPG via librsvg (native size or forced)
+│   └── svg-to-png.sh           # Render design SVGs to PNG via librsvg (lossless, best for text)
 ├── misc/                        # Miscellaneous utilities
 │   ├── convert-screenshot-for-claude.sh  # Convert PNG screenshots to JPEG for Claude Code compatibility
 │   ├── find-and-replace-files.sh     # Batch find and replace files across directory trees
@@ -48,6 +50,7 @@ scripts/
 │   ├── security-monitor.sh     # Nginx security threat detection
 │   ├── server-monitor.sh       # Live CPU/memory/disk/PHP-FPM/MySQL/nginx resource snapshot over SSH
 │   ├── traffic-monitor.sh      # Nginx traffic analysis and reporting
+│   ├── traffic-by-country.sh   # Filter Nginx logs by visitor country (geoip2fast) and show real visits
 │   ├── cf7-smoke-test.js             # Playwright CF7 form submission smoke test
 │   ├── updown-webhook-handler.sh     # Webhook event handler
 │   └── updown-webhook-receiver.php   # Webhook HTTP receiver
@@ -102,6 +105,13 @@ scripts/
 # Download Openverse image URLs and convert to WebP
 ./scripts/images/openverse_download.py --url https://example.com/photo.jpg --convert-webp
 
+# Render design SVGs to JPG (native size, or forced to a platform spec)
+./scripts/images/svg-to-jpg.sh designs/linkedin
+./scripts/images/svg-to-jpg.sh -w 1920 -h 1080 designs/mastodon
+
+# Render design SVGs to PNG (lossless — prefer for banners with text or logos)
+./scripts/images/svg-to-png.sh designs/linkedin
+
 # Create GitHub PR with AI description
 ./scripts/git/create-pr.sh main "Add feature name"
 
@@ -143,6 +153,10 @@ cd ~/code/my-plugin
 
 # Scan for security threats
 ./scripts/monitoring/security-monitor.sh /srv/www/example.com/logs/access.log 24
+
+# Show real page visits from a given country (pulls the log over SSH)
+./scripts/monitoring/traffic-by-country.sh --host web@example.com NL
+./scripts/monitoring/traffic-by-country.sh -q --hours 24 --pattern "/contact/" US
 
 # Analyze AI crawler traffic
 ./scripts/monitoring/ai-bot-monitor.sh /srv/www/example.com/logs/access.log 24

--- a/scripts/images/svg-to-jpg.sh
+++ b/scripts/images/svg-to-jpg.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# svg-to-jpg.sh — Export design SVGs to JPG (raster previews).
+#
+# Renders each .svg next to its source as a .jpg at the SVG's native size,
+# flattened on white at quality 90. Uses librsvg (rsvg-convert) for accurate
+# font + gradient rendering, then ImageMagick to encode JPG.
+#
+# The .svg stays the source of truth — these JPGs are throwaway exports for
+# platforms that need a raster (WordPress featured images, LinkedIn, Mastodon).
+# Re-run after editing any SVG. Keep the exports out of git.
+#
+# By default each SVG is rendered at its native viewBox size. Pass -w/-h to
+# force output dimensions (useful for platform specs, e.g. Mastodon's
+# recommended 1920x1080 landscape), or -s to scale by a multiplier for sharper
+# output on high-DPI screens. Since the source is vector, upscaling is lossless.
+#
+# Paths are resolved relative to the current directory.
+#
+# Usage:
+#   svg-to-jpg.sh                            # default: designs/linkedin
+#   svg-to-jpg.sh designs/business-cards     # one or more dirs/files
+#   svg-to-jpg.sh path/to/banner.svg
+#   svg-to-jpg.sh -w 1920 -h 1080 designs/mastodon   # force size
+#   svg-to-jpg.sh -s 2 designs/featured-images       # 2x scale
+#
+# Options:
+#   -w N   output width in px  (aspect ratio preserved if only one of -w/-h set)
+#   -h N   output height in px
+#   -s N   scale multiplier (e.g. 2 = twice native size); ignored if -w/-h given
+#   -q N   JPEG quality 1-100 (default 90)
+#
+# Requirements (install via brew if missing):
+#   brew install librsvg imagemagick
+#   brew install --cask font-montserrat   # if your SVGs use Montserrat
+#
+# @desc     Export design SVGs to JPG with librsvg, at native size or forced dimensions
+# @category images
+# @runs     local
+# @requires rsvg-convert magick
+# @arg      target  optional  {designs/linkedin}  Directory or .svg file to export (repeatable)
+# @flag     -w      optional  {1920}  Output width in px
+# @flag     -h      optional  {1080}  Output height in px
+# @flag     -s      optional  {2}  Scale multiplier; ignored if -w/-h given
+# @flag     -q      optional  {90}  JPEG quality 1-100
+# @example  wp-ops svg-to-jpg designs/linkedin
+# @example  wp-ops svg-to-jpg -w 1920 -h 1080 designs/mastodon
+
+set -euo pipefail
+
+QUALITY=90
+WIDTH=""
+HEIGHT=""
+SCALE=""
+
+while getopts ":w:h:s:q:" opt; do
+  case "$opt" in
+    w) WIDTH="$OPTARG" ;;
+    h) HEIGHT="$OPTARG" ;;
+    s) SCALE="$OPTARG" ;;
+    q) QUALITY="$OPTARG" ;;
+    :) echo "ERROR: -$OPTARG requires a value" >&2; exit 1 ;;
+    \?) echo "ERROR: unknown option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+# Build the rsvg-convert sizing flags from the options above.
+RSVG_SIZE=()
+if [ -n "$WIDTH" ]; then RSVG_SIZE+=(-w "$WIDTH"); fi
+if [ -n "$HEIGHT" ]; then RSVG_SIZE+=(-h "$HEIGHT"); fi
+if [ ${#RSVG_SIZE[@]} -eq 0 ] && [ -n "$SCALE" ]; then RSVG_SIZE+=(-z "$SCALE"); fi
+
+TMP_PNG="$(mktemp -t svg2jpg).png"
+trap 'rm -f "$TMP_PNG"' EXIT
+
+# --- dependency checks ---------------------------------------------------------
+for bin in rsvg-convert magick; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "ERROR: '$bin' not found. Install with:" >&2
+    echo "  brew install librsvg imagemagick" >&2
+    exit 1
+  fi
+done
+
+# --- resolve targets (default to designs/linkedin under the cwd) ---------------
+TARGETS=("$@")
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  if [ -d "designs/linkedin" ]; then
+    TARGETS=("designs/linkedin")
+  else
+    echo "ERROR: no target given and ./designs/linkedin does not exist." >&2
+    echo "Usage: $(basename "$0") [-w N] [-h N] [-s N] [-q N] <dir-or-file>..." >&2
+    exit 1
+  fi
+fi
+
+# Collect SVG files from the given dirs/files.
+svgs=()
+for t in "${TARGETS[@]}"; do
+  if [ -d "$t" ]; then
+    while IFS= read -r f; do svgs+=("$f"); done < <(find "$t" -type f -name '*.svg' | sort)
+  elif [ -f "$t" ] && [[ "$t" == *.svg ]]; then
+    svgs+=("$t")
+  else
+    echo "WARN: skipping '$t' (not a directory or .svg file)" >&2
+  fi
+done
+
+if [ ${#svgs[@]} -eq 0 ]; then
+  echo "No .svg files found." >&2
+  exit 1
+fi
+
+# --- convert -------------------------------------------------------------------
+count=0
+for svg in "${svgs[@]}"; do
+  jpg="${svg%.svg}.jpg"
+  rsvg-convert ${RSVG_SIZE[@]+"${RSVG_SIZE[@]}"} "$svg" -o "$TMP_PNG"
+  magick "$TMP_PNG" -background white -flatten -quality "$QUALITY" "$jpg"
+  printf "  %-58s -> %s\n" "$svg" "$(magick identify -format '%wx%h %b' "$jpg")"
+  count=$((count + 1))
+done
+
+echo "Done. Exported $count JPG(s)."

--- a/scripts/images/svg-to-png.sh
+++ b/scripts/images/svg-to-png.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# svg-to-png.sh — Export design SVGs to PNG (lossless raster previews).
+#
+# Renders each .svg next to its source as a .png, flattened on white. Uses
+# librsvg (rsvg-convert) for accurate font + gradient rendering, then
+# ImageMagick to flatten.
+#
+# Prefer PNG over JPG for any banner/card with text or logos — JPG compression
+# blurs fine text edges (wordmark, descriptor strip, URL). LinkedIn banners
+# should be uploaded as PNG. The .svg remains the source of truth; keep the
+# exports out of git and re-run after editing any SVG.
+#
+# By default each SVG is rendered at its native viewBox size. Pass -w/-h to
+# force output dimensions, or -s to scale by a multiplier for sharper output on
+# high-DPI screens. Since the source is vector, upscaling is lossless.
+#
+# Paths are resolved relative to the current directory.
+#
+# Usage:
+#   svg-to-png.sh                            # default: designs/linkedin
+#   svg-to-png.sh designs/business-cards     # one or more dirs/files
+#   svg-to-png.sh path/to/banner.svg
+#   svg-to-png.sh -w 1584 -h 396 designs/linkedin    # force LinkedIn banner size
+#
+# Options:
+#   -w N   output width in px  (aspect ratio preserved if only one of -w/-h set)
+#   -h N   output height in px
+#   -s N   scale multiplier (e.g. 2 = twice native size); ignored if -w/-h given
+#
+# Requirements (install via brew if missing):
+#   brew install librsvg imagemagick
+#   brew install --cask font-montserrat   # if your SVGs use Montserrat
+#
+# @desc     Export design SVGs to PNG with librsvg — lossless, best for text/logo banners
+# @category images
+# @runs     local
+# @requires rsvg-convert magick
+# @arg      target  optional  {designs/linkedin}  Directory or .svg file to export (repeatable)
+# @flag     -w      optional  {1584}  Output width in px
+# @flag     -h      optional  {396}  Output height in px
+# @flag     -s      optional  {2}  Scale multiplier; ignored if -w/-h given
+# @example  wp-ops svg-to-png designs/linkedin
+# @example  wp-ops svg-to-png -w 1584 -h 396 designs/linkedin/banner.svg
+
+set -euo pipefail
+
+WIDTH=""
+HEIGHT=""
+SCALE=""
+
+while getopts ":w:h:s:" opt; do
+  case "$opt" in
+    w) WIDTH="$OPTARG" ;;
+    h) HEIGHT="$OPTARG" ;;
+    s) SCALE="$OPTARG" ;;
+    :) echo "ERROR: -$OPTARG requires a value" >&2; exit 1 ;;
+    \?) echo "ERROR: unknown option -$OPTARG" >&2; exit 1 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+# Build the rsvg-convert sizing flags from the options above.
+RSVG_SIZE=()
+if [ -n "$WIDTH" ]; then RSVG_SIZE+=(-w "$WIDTH"); fi
+if [ -n "$HEIGHT" ]; then RSVG_SIZE+=(-h "$HEIGHT"); fi
+if [ ${#RSVG_SIZE[@]} -eq 0 ] && [ -n "$SCALE" ]; then RSVG_SIZE+=(-z "$SCALE"); fi
+
+TMP_PNG="$(mktemp -t svg2png).png"
+trap 'rm -f "$TMP_PNG"' EXIT
+
+# --- dependency checks ---------------------------------------------------------
+for bin in rsvg-convert magick; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "ERROR: '$bin' not found. Install with:" >&2
+    echo "  brew install librsvg imagemagick" >&2
+    exit 1
+  fi
+done
+
+# --- resolve targets (default to designs/linkedin under the cwd) ---------------
+TARGETS=("$@")
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  if [ -d "designs/linkedin" ]; then
+    TARGETS=("designs/linkedin")
+  else
+    echo "ERROR: no target given and ./designs/linkedin does not exist." >&2
+    echo "Usage: $(basename "$0") [-w N] [-h N] [-s N] <dir-or-file>..." >&2
+    exit 1
+  fi
+fi
+
+# Collect SVG files from the given dirs/files.
+svgs=()
+for t in "${TARGETS[@]}"; do
+  if [ -d "$t" ]; then
+    while IFS= read -r f; do svgs+=("$f"); done < <(find "$t" -type f -name '*.svg' | sort)
+  elif [ -f "$t" ] && [[ "$t" == *.svg ]]; then
+    svgs+=("$t")
+  else
+    echo "WARN: skipping '$t' (not a directory or .svg file)" >&2
+  fi
+done
+
+if [ ${#svgs[@]} -eq 0 ]; then
+  echo "No .svg files found." >&2
+  exit 1
+fi
+
+# --- convert -------------------------------------------------------------------
+count=0
+for svg in "${svgs[@]}"; do
+  png="${svg%.svg}.png"
+  rsvg-convert ${RSVG_SIZE[@]+"${RSVG_SIZE[@]}"} "$svg" -o "$TMP_PNG"
+  magick "$TMP_PNG" -background white -flatten "$png"
+  printf "  %-58s -> %s\n" "$svg" "$(magick identify -format '%wx%h %b' "$png")"
+  count=$((count + 1))
+done
+
+echo "Done. Exported $count PNG(s)."

--- a/scripts/monitoring/traffic-by-country.sh
+++ b/scripts/monitoring/traffic-by-country.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# traffic-by-country.sh
+# Filter Nginx access logs by country and show real page visits.
+#
+# Pulls the log from the server over SSH, resolves every unique client IP to a
+# country with geoip2fast, then reports only the requests from the country you
+# asked about — with bots, static assets, attack probes, Tor exits, and
+# redirect/404 responses filtered out, so what's left is real page views.
+#
+# Useful for checking whether outreach prospects actually visited after an
+# email went out, or auditing geo-specific traffic to localized pages.
+#
+# Usage:
+#   ./traffic-by-country.sh [OPTIONS] [COUNTRY_CODE] [DATE_FILTER]
+#
+# Options:
+#   --host HOST          SSH user@host to pull logs from (default: web@example.com)
+#   --log PATH           Nginx access log path on the server
+#   -q, --quick          Quick mode: last 10,000 log lines only (fast)
+#   -p, --pattern PAT    Filter for specific URL pattern (e.g., "/nl-" or "/dutch-")
+#   -h, --hours N        Last N hours of traffic (implies -q)
+#   --show-bots          Include bot traffic in results (default: exclude)
+#
+# Examples:
+#   ./traffic-by-country.sh --host web@example.com NL           # All NL traffic, current week
+#   ./traffic-by-country.sh NL "29/May/2026"                    # NL traffic on a specific date
+#   ./traffic-by-country.sh -q NL                               # Quick: last 10k lines, NL only
+#   ./traffic-by-country.sh -q -p "/nl-|/dutch-" NL             # Quick: NL visits to Dutch pages
+#   ./traffic-by-country.sh -q --hours 24 NL                    # Last 24h of NL traffic
+#   ./traffic-by-country.sh DE                                  # German traffic
+#
+# Requirements:
+#   - geoip2fast installed locally (brew install geoip2fast)
+#   - SSH access to the server
+#   - python3
+#
+# @desc     Filter a server's Nginx access log by visitor country and show real page visits
+# @category monitoring
+# @runs     local
+# @requires ssh python3 geoip2fast
+# @arg      country-code  optional  {NL}  Two-letter ISO country code to filter for
+# @arg      date-filter   optional  {29/May/2026}  Only lines matching this date string
+# @flag     --host        optional  {web@example.com}  SSH user@host to pull logs from
+# @flag     --log         optional  {/srv/www/example.com/logs/access.log}  Nginx access log path on the server
+# @flag     --quick       optional  Only pull the last 10,000 log lines
+# @flag     --pattern     optional  {/nl-|/dutch-}  Only count requests whose URL matches this regex
+# @flag     --hours       optional  {24}  Only pull the last N hours (implies --quick)
+# @flag     --show-bots   optional  Include bot traffic instead of filtering it out
+# @example  wp-ops traffic-by-country --host web@example.com NL
+# @example  wp-ops traffic-by-country -q --hours 24 --pattern "/contact/" US
+# @doc      scripts/README.md
+
+set -euo pipefail
+
+# --- Defaults ---
+COUNTRY="NL"
+DATE_FILTER=""
+QUICK_MODE=false
+URL_PATTERN=""
+HOURS_BACK=0
+SHOW_BOTS=false
+SSH_HOST="web@example.com"
+LOG_BASE=""
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            SSH_HOST="$2"
+            shift 2
+            ;;
+        --log)
+            LOG_BASE="$2"
+            shift 2
+            ;;
+        -q|--quick)
+            QUICK_MODE=true
+            shift
+            ;;
+        -p|--pattern)
+            URL_PATTERN="$2"
+            shift 2
+            ;;
+        -h|--hours)
+            HOURS_BACK="$2"
+            QUICK_MODE=true
+            shift 2
+            ;;
+        --show-bots)
+            SHOW_BOTS=true
+            shift
+            ;;
+        --help)
+            sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [OPTIONS] [COUNTRY_CODE] [DATE_FILTER]"
+            echo "  --host HOST      SSH user@host to pull logs from"
+            echo "  --log PATH       Nginx access log path on the server"
+            echo "  -q, --quick      Quick mode (last 10k lines)"
+            echo "  -p, --pattern P  Filter by URL pattern"
+            echo "  -h, --hours N    Last N hours (implies -q)"
+            echo "  --show-bots      Include bot traffic"
+            exit 1
+            ;;
+        *)
+            # Positional: could be country or date filter
+            if [[ "$1" =~ ^[A-Z]{2}$ ]]; then
+                COUNTRY="$1"
+            elif [ -z "$DATE_FILTER" ]; then
+                DATE_FILTER="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Default the log path to the domain implied by the SSH host, Trellis-style.
+if [ -z "$LOG_BASE" ]; then
+    LOG_BASE="/srv/www/${SSH_HOST#*@}/logs/access.log"
+fi
+
+TMP_DIR="/tmp/traffic-country-$$"
+mkdir -p "$TMP_DIR"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+# --- Patterns ---
+BOT_PATTERN='bot|Bot|crawler|spider|Prerender|GeedoShop|meta-externalagent|Googlebot|bingbot|AhrefsBot|SemrushBot|DataForSeoBot|PetalBot|YandexBot|DotBot|MJ12bot|Screaming|frog|ChatGPT|Claude|Amazonbot|Applebot|Bytespider|CCBot'
+ASSET_PATTERN='\.(css|js|png|jpg|jpeg|gif|svg|woff|woff2|ttf|ico|webp|map)(\?|$)'
+ATTACK_PATTERN='wp-login|xmlrpc|\.env|\.git/|phpinfo|wp-config|admin-ajax\.php'
+TOR_PATTERN='192\.42\.116\.|192\.42\.117\.|192\.42\.118\.|192\.42\.119\.'
+
+echo "=============================================================================="
+echo "Traffic by Country: $COUNTRY"
+echo "Server: $SSH_HOST"
+echo "Log: $LOG_BASE"
+if [ "$QUICK_MODE" = true ]; then
+    if [ "$HOURS_BACK" -gt 0 ] 2>/dev/null; then
+        echo "Mode: Last $HOURS_BACK hours (quick)"
+    else
+        echo "Mode: Last 10,000 lines (quick)"
+    fi
+else
+    echo "Mode: Full (current + previous week)"
+fi
+if [ -n "$URL_PATTERN" ]; then
+    echo "URL Pattern: $URL_PATTERN"
+fi
+if [ -n "$DATE_FILTER" ]; then
+    echo "Date Filter: $DATE_FILTER"
+fi
+if [ "$SHOW_BOTS" = true ]; then
+    echo "Bots: Included"
+else
+    echo "Bots: Excluded"
+fi
+echo "=============================================================================="
+echo ""
+
+# --- Step 1: Pull logs ---
+if [ "$QUICK_MODE" = true ]; then
+    if [ "$HOURS_BACK" -gt 0 ] 2>/dev/null; then
+        echo "Pulling last $HOURS_BACK hours of logs..."
+        ssh "$SSH_HOST" "
+            awk -v hours=$HOURS_BACK -v now=\$(date +%s) '
+            \$4 ~ /^\[/ {
+                cmd = \"date -d \"\$4\" +%s\"
+                cmd | getline ts
+                close(cmd)
+                if (ts >= now - hours*3600) print
+            }' ${LOG_BASE} 2>/dev/null | tail -10000
+        " > "$TMP_DIR/combined.log"
+    else
+        echo "Quick mode: pulling last 10,000 log lines..."
+        ssh "$SSH_HOST" "tail -10000 ${LOG_BASE} 2>/dev/null" > "$TMP_DIR/combined.log"
+    fi
+else
+    echo "Full mode: pulling current + previous week logs..."
+    ssh "$SSH_HOST" "
+        { cat ${LOG_BASE}; cat ${LOG_BASE}.1; } 2>/dev/null
+    " > "$TMP_DIR/combined.log"
+fi
+
+LINE_COUNT=$(wc -l < "$TMP_DIR/combined.log")
+echo "Lines pulled: $LINE_COUNT"
+
+# --- Step 2: Apply filters ---
+LOG_FILE="$TMP_DIR/combined.log"
+
+if [ -n "$DATE_FILTER" ]; then
+    echo "Filtering for date: $DATE_FILTER"
+    grep "$DATE_FILTER" "$LOG_FILE" > "$TMP_DIR/filtered.log" || true
+    LOG_FILE="$TMP_DIR/filtered.log"
+    echo "Lines after date filter: $(wc -l < "$LOG_FILE")"
+fi
+
+if [ -n "$URL_PATTERN" ]; then
+    echo "Filtering for URL pattern: $URL_PATTERN"
+    grep -E "$URL_PATTERN" "$LOG_FILE" > "$TMP_DIR/pattern-filtered.log" || true
+    LOG_FILE="$TMP_DIR/pattern-filtered.log"
+    echo "Lines after pattern filter: $(wc -l < "$LOG_FILE")"
+fi
+
+echo ""
+
+# --- Step 3: Extract unique IPs ---
+echo "Extracting unique IPs..."
+
+if [ "$SHOW_BOTS" = true ]; then
+    awk '{print $1}' "$LOG_FILE" | sort -u > "$TMP_DIR/ips.txt"
+else
+    grep -vE "$BOT_PATTERN" "$LOG_FILE" | awk '{print $1}' | sort -u > "$TMP_DIR/ips.txt"
+fi
+
+IP_COUNT=$(wc -l < "$TMP_DIR/ips.txt")
+echo "Unique IPs to check: $IP_COUNT"
+echo ""
+
+# --- Step 4: GeoIP filter ---
+echo "Running GeoIP lookup for country: $COUNTRY..."
+
+python3 - <<PYEOF
+import subprocess, json, re, sys
+
+with open('$TMP_DIR/ips.txt') as f:
+    ips = [l.strip() for l in f if l.strip()]
+
+if not ips:
+    print('No IPs to check.')
+    with open('$TMP_DIR/country-ips.txt', 'w') as f:
+        pass
+    sys.exit(0)
+
+hits = []
+chunk_size = 500
+for i in range(0, len(ips), chunk_size):
+    chunk = ','.join(ips[i:i+chunk_size])
+    try:
+        r = subprocess.run(['geoip2fast', chunk], capture_output=True, text=True, timeout=30)
+        for b in re.findall(r'\{[^{}]*\}', r.stdout, re.DOTALL):
+            try:
+                d = json.loads(b)
+                if d.get('country_code') == '$COUNTRY':
+                    hits.append(d['ip'])
+            except Exception:
+                pass
+    except subprocess.TimeoutExpired:
+        print(f'Warning: geoip2fast timeout on chunk {i//chunk_size + 1}')
+        continue
+
+with open('$TMP_DIR/country-ips.txt', 'w') as f:
+    f.write('\n'.join(hits))
+print(f'IPs from $COUNTRY: {len(hits)}')
+PYEOF
+
+if [ ! -s "$TMP_DIR/country-ips.txt" ]; then
+    echo "No IPs found for $COUNTRY."
+    exit 0
+fi
+
+echo ""
+
+# --- Step 5: Show results ---
+COUNTRY_IPS_FILE="$TMP_DIR/country-ips.txt"
+
+# Count visits
+TOTAL_VISITS=$(grep -cF -f "$COUNTRY_IPS_FILE" "$LOG_FILE" || echo 0)
+REAL_VISITS=$(grep -F -f "$COUNTRY_IPS_FILE" "$LOG_FILE" | grep -vE "$BOT_PATTERN|$ATTACK_PATTERN|$TOR_PATTERN|$ASSET_PATTERN" | grep -v ' 301\b\| 302\b\| 404\b\| 444\b' | wc -l)
+BOT_VISITS=$((TOTAL_VISITS - REAL_VISITS))
+
+echo "=== Summary ==="
+echo "Total requests from $COUNTRY IPs: $TOTAL_VISITS"
+echo "Real page visits (non-bot, non-attack): $REAL_VISITS"
+echo "Bot/scanner requests: $BOT_VISITS"
+echo ""
+
+# Show real visits
+echo "=== Real Page Visits from $COUNTRY IPs ==="
+echo ""
+
+grep -F -f "$COUNTRY_IPS_FILE" "$LOG_FILE" \
+  | grep -vE "$BOT_PATTERN|$ATTACK_PATTERN|$TOR_PATTERN" \
+  | grep -vE "$ASSET_PATTERN" \
+  | grep -v ' 301\b\| 302\b\| 404\b\| 444\b' \
+  | awk '{print $4, $1, $6, $7, $9}' \
+  | sort -t'[' -k1,1 \
+  | column -t
+
+echo ""
+
+# Top pages
+echo "=== Top Pages Visited by $COUNTRY IPs ==="
+grep -F -f "$COUNTRY_IPS_FILE" "$LOG_FILE" \
+  | grep -vE "$BOT_PATTERN|$ATTACK_PATTERN|$TOR_PATTERN" \
+  | grep -vE "$ASSET_PATTERN" \
+  | grep -v ' 301\b\| 302\b\| 404\b' \
+  | awk '{print $7}' \
+  | sort | uniq -c | sort -rn | head -20
+
+echo ""
+
+# Show IPs
+echo "=== $COUNTRY IPs ==="
+cat "$COUNTRY_IPS_FILE"
+
+echo ""
+echo "=============================================================================="

--- a/wp-cli/seo/README.md
+++ b/wp-cli/seo/README.md
@@ -20,6 +20,7 @@ wp-cli/seo/
 ├── schema-audit.sh           # Schema markup validation across key pages
 ├── blog-audit.sh             # Blog content categorization and quality analysis
 ├── orphan-pages-audit.sh     # Find pages not linked from navigation menus
+├── orphan-links-audit.sh     # Find pages nothing else links to in its content
 └── README.md                 # This file
 ```
 
@@ -293,17 +294,10 @@ cd /srv/www/example.com/current
 
 ### Important Note
 
-This script provides a **basic** orphaned page detection. For comprehensive analysis:
-
-1. **Recommended Tools:**
-   - Screaming Frog SEO Spider
-   - Ahrefs Site Audit
-   - Sitebulb
-
-2. **Full Detection Method:**
-   - Crawl the entire site
-   - Filter for pages with 0 internal links
-   - Export and compare with WordPress page inventory
+This script only looks at **navigation menus**. For the in-content view — pages
+nothing else links to — run `orphan-links-audit.sh` (section 6) alongside it.
+For a full external crawl, Screaming Frog SEO Spider, Ahrefs Site Audit, or
+Sitebulb still go further than either script.
 
 ### Output Files
 
@@ -316,6 +310,53 @@ This script provides a **basic** orphaned page detection. For comprehensive anal
 - Consider creating a sitemap page
 - Use breadcrumb navigation
 - Review and update navigation structure regularly
+
+---
+
+## 6. Orphan Links Audit
+
+**Script:** `orphan-links-audit.sh`
+
+Identifies published posts and pages that **no other content links to**. This is
+the inbound-link sibling of `orphan-pages-audit.sh` — the two answer different
+questions and are both worth running. A page can sit in the nav and still have
+zero in-content links, or be linked from a dozen posts while absent from every
+menu.
+
+### Features
+
+- Single SQL query — no crawl, no external tool
+- Counts inbound references per published post/page, keeps the zeroes
+- Runs locally or over SSH against production
+- CSV export with ID, title, type, date, and URL
+
+### Usage
+
+```bash
+# Against production over SSH
+./wp-cli/seo/orphan-links-audit.sh --host web@example.com
+
+# Locally, from a Bedrock site directory
+cd /srv/www/example.com/current
+./wp-cli/seo/orphan-links-audit.sh --path web/wp --output reports/seo
+```
+
+### Caveat
+
+Link detection is a substring match of each page's slug against other published
+`post_content`. A slug that appears as plain text counts as a link, and a page
+linked only by ID (or by a slug-less shortlink) reads as orphaned. Treat the
+output as a shortlist to review, not a verdict.
+
+### Output Files
+
+- `audits/orphan-links-[timestamp].csv` - Pages with zero inbound internal links
+
+### Recommendations
+
+- Work the list newest-first — recent posts are the ones most likely never linked
+- Add links from topically related posts, not from a generic index page
+- Re-run after a linking pass to confirm the count dropped
 
 ---
 

--- a/wp-cli/seo/orphan-links-audit.sh
+++ b/wp-cli/seo/orphan-links-audit.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Orphan Links Audit Script
+# Purpose: Find published posts/pages with zero internal links pointing at them
+# Output: CSV report of orphaned content
+#
+# This is the inbound-link sibling of orphan-pages-audit.sh. The two answer
+# different questions and are both worth running:
+#
+#   orphan-pages-audit.sh   pages missing from the navigation menus
+#   orphan-links-audit.sh   pages nothing else links to in its content (this one)
+#
+# A page can sit in the nav and still have zero in-content links, or be linked
+# from a dozen posts while absent from every menu.
+#
+# Usage: ./orphan-links-audit.sh [OPTIONS]
+#
+# Options:
+#   --host HOST       SSH user@host to run WP-CLI on (default: run locally)
+#   --site-path PATH  Site root on the server, for the SSH cd (default: /srv/www/<domain>/current)
+#   --path PATH       WordPress path for WP-CLI (default: web/wp for Bedrock)
+#   --output DIR      Output directory (default: audits)
+#   -h, --help        Show this help
+#
+# Requires: WP-CLI access to the WordPress installation (locally or over SSH)
+#
+# Caveat: link detection is a substring match of each page's slug against other
+# published post_content, so a slug that happens to appear as plain text counts
+# as a link, and a page linked only by ID (or by a slug-less shortlink) reads as
+# orphaned. Treat the output as a shortlist to review, not a verdict.
+#
+# @desc     Find published posts/pages that no other content links to internally
+# @category seo
+# @runs     local
+# @requires wp
+# @flag     --host       optional  {web@example.com}  SSH user@host to run WP-CLI on
+# @flag     --site-path  optional  {/srv/www/example.com/current}  Site root on the server
+# @flag     --path       optional  {web/wp}  WordPress path for WP-CLI
+# @flag     --output     optional  {audits}  Output directory
+# @example  wp-ops orphan-links-audit --host web@example.com
+# @example  wp-ops orphan-links-audit --path web/wp --output reports/seo
+# @doc      wp-cli/seo/README.md
+
+set -euo pipefail
+
+SSH_HOST=""
+SITE_PATH=""
+WP_PATH="web/wp"
+OUTPUT_DIR="audits"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)
+            SSH_HOST="$2"
+            shift 2
+            ;;
+        --site-path)
+            SITE_PATH="$2"
+            shift 2
+            ;;
+        --path)
+            WP_PATH="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $(basename "$0") [OPTIONS]"
+            echo "  --host HOST       SSH user@host to run WP-CLI on (default: run locally)"
+            echo "  --site-path PATH  Site root on the server for the SSH cd"
+            echo "  --path PATH       WordPress path for WP-CLI (default: web/wp)"
+            echo "  --output DIR      Output directory (default: audits)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Default the server-side site root to the domain implied by the SSH host.
+if [ -n "$SSH_HOST" ] && [ -z "$SITE_PATH" ]; then
+    SITE_PATH="/srv/www/${SSH_HOST#*@}/current"
+fi
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_FILE="$OUTPUT_DIR/orphan-links-$TIMESTAMP.csv"
+
+echo "========================================="
+echo "Orphan Links Audit"
+echo "========================================="
+if [ -n "$SSH_HOST" ]; then
+    echo "Target: $SSH_HOST:$SITE_PATH"
+else
+    echo "Target: local ($WP_PATH)"
+fi
+echo ""
+
+# Count how many other published posts reference each post's slug; keep the zeroes.
+read -r -d '' QUERY <<'SQL' || true
+SELECT
+    p.ID,
+    p.post_title,
+    p.post_type,
+    p.post_date,
+    p.post_status,
+    p.guid,
+    COUNT(DISTINCT l.ID) as internal_links
+FROM wp_posts p
+LEFT JOIN wp_posts l ON (
+    l.post_content LIKE CONCAT('%', p.post_name, '%')
+    AND l.ID != p.ID
+    AND l.post_status = 'publish'
+)
+WHERE p.post_type IN ('post', 'page')
+AND p.post_status = 'publish'
+GROUP BY p.ID
+HAVING internal_links = 0
+ORDER BY p.post_date DESC
+SQL
+
+echo "Analyzing internal links..."
+echo ""
+
+if [ -n "$SSH_HOST" ]; then
+    RAW=$(ssh "$SSH_HOST" "cd $SITE_PATH && wp db query \"$QUERY\" --path=$WP_PATH --skip-column-names")
+else
+    RAW=$(wp db query "$QUERY" --path="$WP_PATH" --skip-column-names)
+fi
+
+printf '%s\n' "$RAW" | awk -F'\t' '
+    BEGIN {print "ID,Title,Type,Date,Status,URL,Internal Links"}
+    NF {gsub(/,/, " ", $2); print $1","$2","$3","$4","$5","$6","$7}
+' > "$OUTPUT_FILE"
+
+ORPHAN_COUNT=$(tail -n +2 "$OUTPUT_FILE" | wc -l | xargs)
+
+echo "Audit complete."
+echo ""
+echo "Results:"
+echo "  Total orphaned by inbound links: $ORPHAN_COUNT"
+echo "  Output file: $OUTPUT_FILE"
+echo ""
+
+if [ "$ORPHAN_COUNT" -gt 0 ]; then
+    echo "Breakdown by content type:"
+    tail -n +2 "$OUTPUT_FILE" | cut -d',' -f3 | sort | uniq -c | sort -rn
+    echo ""
+fi
+
+echo "Next steps:"
+echo "1. Review $OUTPUT_FILE"
+echo "2. Categorize by topic/value"
+echo "3. Add internal links from relevant pages"
+echo ""


### PR DESCRIPTION
Adopts four commands from `seo-strategy/tools/scripts/`, generalized off the imagewize-specific hardcodes (SSH host, log path, repo-relative root). That repo had accumulated ~32 scripts, 16 of them forks of scripts already here; these four were the ones with no wp-ops equivalent, so they move up before the forks get deleted on the other side.

## New commands

**`svg-to-jpg`** / **`svg-to-png`** (`scripts/images/`) — render design SVGs next to their source via librsvg plus ImageMagick. Takes a directory or individual `.svg` files. `-w`/`-h` force output dimensions for a platform spec (e.g. Mastodon's 1920x1080), `-s` scales by a multiplier for high-DPI, and since the source is vector, upscaling is lossless. Prefer PNG for anything carrying text or a logo — JPG compression blurs fine text edges. `svg-to-png` gained `-w`/`-h`/`-s` in the move; it was native-size only before.

**`traffic-by-country`** (`scripts/monitoring/`) — pulls an Nginx access log over SSH, resolves every unique client IP through `geoip2fast`, and reports only the requests from one country, with bots, static assets, attack probes, Tor exits, and redirect/404 responses filtered out. Answers "did anyone from NL actually read the page after that outreach batch went out?" `--quick`/`--hours` bound how much log gets pulled; `--pattern` narrows to a URL regex.

**`orphan-links-audit`** (`wp-cli/seo/`) — finds published posts/pages that no other content links to, as a single SQL query. Inbound-link sibling of the existing `orphan-pages-audit`, which only checks navigation menus: a page can sit in the nav with zero in-content links, or be linked from a dozen posts while absent from every menu, so the two are worth running together. Runs locally or against production over `--host`.

Link detection there is a slug substring match against other published `post_content`, so a slug appearing as plain text counts as a link and a page linked only by ID reads as orphaned. The output is a shortlist to review rather than a verdict — the script header and the README section both say so.

## Also

- `wp-cli/seo/README.md` — the orphan-pages "Important Note" pointed at Screaming Frog/Ahrefs/Sitebulb for "filter for pages with 0 internal links". That is now `orphan-links-audit`, so the note points there first and keeps the external crawlers as the step beyond both scripts.
- Catalog regenerated (72 → 76 entries); test count expectations updated following the existing running-tally comment convention.
- CHANGELOG 4.1.0.

## Verification

- `go test ./...` passes.
- `go generate ./internal/catalog/` clean; all four commands resolve by bare name (`wp-ops svg-to-jpg`), and all four names are unique so there is no ambiguity fallback.
- `svg-to-jpg -w 1920 -h 1080` smoke-tested against a real Mastodon card SVG — 1920x1080 output, identical to the script it replaces.
- `traffic-by-country` and `orphan-links-audit` are unrun against a live server in this branch; both default their server-side paths from the `--host` domain Trellis-style.