### PR TITLE
Add vibe as an AI backend for release-theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2026-08-04
+
+### Added
+
+- **scripts/release/release-theme.sh** - Mistral Vibe joins claude and codex as
+  an AI backend (`--ai=vibe`, `VIBE_COMMAND`, `VIBE_CLI_ARGS`). This existed only
+  in the imagewize.com fork of the script and was never upstreamed, so it would
+  have been lost when that fork was deleted. `create-pr.sh` already supported
+  vibe; `release-theme.sh` did not.
+
+  Vibe takes the prompt as an argument rather than on stdin and writes its own
+  errors to stdout, so its branch does not capture stderr separately the way the
+  claude and codex branches do. Default args are `-p` unless `VIBE_CLI_ARGS` is
+  set.
+
+### Known inconsistency
+
+`scripts/release/release-plugin.sh` is release-theme's sibling and still offers
+only claude and codex. Nothing depended on vibe there, so it was left alone
+rather than changed speculatively — worth aligning if vibe becomes a regular
+part of the release flow.
+
 ## [4.1.0] - 2026-08-04
 
 ### Added

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -2017,10 +2017,11 @@
         "required": false,
         "choices": [
           "claude",
-          "codex"
+          "codex",
+          "vibe"
         ],
         "description": "AI CLI to use (default: claude, or the only one installed)",
-        "raw": "--ai        optional  {claude|codex}  AI CLI to use (default: claude, or the only one installed)"
+        "raw": "--ai        optional  {claude|codex|vibe}  AI CLI to use (default: claude, or the only one installed)"
       }
     ],
     "examples": [

--- a/scripts/release/release-theme.sh
+++ b/scripts/release/release-theme.sh
@@ -5,7 +5,7 @@
 # Supports both demo/ and site/ Bedrock installations
 #
 # Usage:
-#   ./release-theme.sh <theme-name> <version> [--commit] [--ai=claude|codex]
+#   ./release-theme.sh <theme-name> <version> [--commit] [--ai=claude|codex|vibe]
 #   ./release-theme.sh elayne 1.2.5          # Demo site theme
 #   ./release-theme.sh nynaeve 1.0.0 --commit # Main site theme
 #
@@ -18,7 +18,7 @@
 # 6. Optionally commits changes with standardized message
 #
 # Requirements:
-# - claude or codex CLI installed and authenticated
+# - claude, codex, or vibe CLI installed and authenticated
 # - git repository with main branch
 #
 # @desc     Bump theme version and generate an AI changelog entry (Claude or Codex)
@@ -28,7 +28,7 @@
 # @arg      theme-name  required  {elayne}  Theme slug (demo/ or site/ Bedrock installation)
 # @arg      version     required  {1.2.5}  New theme version
 # @flag     --commit    optional  {}  Auto-commit the version bump and changelog
-# @flag     --ai        optional  {claude|codex}  AI CLI to use (default: claude, or the only one installed)
+# @flag     --ai        optional  {claude|codex|vibe}  AI CLI to use (default: claude, or the only one installed)
 # @example  wp-ops scripts/release/release-theme nynaeve 1.0.0 --commit
 
 set -e  # Exit on error
@@ -43,6 +43,7 @@ NC='\033[0m' # No Color
 # CLI command names can be overridden via environment if needed
 CLAUDE_COMMAND=${CLAUDE_COMMAND:-claude}
 CODEX_COMMAND=${CODEX_COMMAND:-codex}
+VIBE_COMMAND=${VIBE_COMMAND:-vibe}
 
 # Parse options
 AUTO_COMMIT=false
@@ -64,7 +65,7 @@ while [ $# -gt 0 ]; do
             AI_TOOL_SPECIFIED=true
             shift
         else
-            echo -e "${RED}Error: --ai requires a value (claude or codex).${NC}"
+            echo -e "${RED}Error: --ai requires a value (claude, codex or vibe).${NC}"
             exit 1
         fi
         ;;
@@ -77,8 +78,8 @@ done
 set -- "${ARGS[@]}"
 
 AI_TOOL=$(echo "$AI_TOOL" | tr '[:upper:]' '[:lower:]')
-if [ "$AI_TOOL" != "claude" ] && [ "$AI_TOOL" != "codex" ]; then
-    echo -e "${RED}Error: Unsupported AI tool '$AI_TOOL'. Use 'claude' or 'codex'.${NC}"
+if [ "$AI_TOOL" != "claude" ] && [ "$AI_TOOL" != "codex" ] && [ "$AI_TOOL" != "vibe" ]; then
+    echo -e "${RED}Error: Unsupported AI tool '$AI_TOOL'. Use 'claude', 'codex', or 'vibe'.${NC}"
     exit 1
 fi
 
@@ -86,9 +87,10 @@ fi
 AVAILABLE_AI_TOOLS=()
 command -v "$CLAUDE_COMMAND" &> /dev/null && AVAILABLE_AI_TOOLS+=("claude")
 command -v "$CODEX_COMMAND" &> /dev/null && AVAILABLE_AI_TOOLS+=("codex")
+command -v "$VIBE_COMMAND" &> /dev/null && AVAILABLE_AI_TOOLS+=("vibe")
 
 if [ ${#AVAILABLE_AI_TOOLS[@]} -eq 0 ]; then
-    echo -e "${RED}Error: No AI CLI found (checked for '$CLAUDE_COMMAND' and '$CODEX_COMMAND').${NC}"
+    echo -e "${RED}Error: No AI CLI found (checked for '$CLAUDE_COMMAND', '$CODEX_COMMAND', and '$VIBE_COMMAND').${NC}"
     exit 1
 fi
 
@@ -126,10 +128,16 @@ if [ "$AI_TOOL" = "codex" ] && ! command -v "$CODEX_COMMAND" &> /dev/null; then
     exit 1
 fi
 
+if [ "$AI_TOOL" = "vibe" ] && ! command -v "$VIBE_COMMAND" &> /dev/null; then
+    echo -e "${RED}Error: Vibe CLI is required but not installed${NC}"
+    echo "Install with: npm install -g @vibehq/vibe"
+    exit 1
+fi
+
 # Check if theme name argument is provided
 if [ -z "$1" ]; then
     echo -e "${RED}Error: Theme name and version required${NC}"
-    echo "Usage: $0 <theme-name> <version> [--commit] [--ai=claude|codex]"
+    echo "Usage: $0 <theme-name> <version> [--commit] [--ai=claude|codex|vibe]"
     echo "Example: $0 elayne 1.2.5"
     echo "Example: $0 moiraine 2.1.0 --commit --ai=codex"
     exit 1
@@ -138,7 +146,7 @@ fi
 # Check if version argument is provided
 if [ -z "$2" ]; then
     echo -e "${RED}Error: Version number required${NC}"
-    echo "Usage: $0 <theme-name> <version> [--commit] [--ai=claude|codex]"
+    echo "Usage: $0 <theme-name> <version> [--commit] [--ai=claude|codex|vibe]"
     echo "Example: $0 elayne 1.2.5"
     exit 1
 fi
@@ -279,6 +287,21 @@ if [ "$AI_TOOL" = "codex" ]; then
         AI_RESPONSE=$(cat "$AI_TMP_OUTPUT")
     fi
     rm -f "$AI_TMP_OUTPUT"
+elif [ "$AI_TOOL" = "vibe" ]; then
+    AI_COMMAND="$VIBE_COMMAND"
+    AI_ARGS=()
+    if [ -n "${VIBE_CLI_ARGS:-}" ]; then
+        # shellcheck disable=SC2206
+        AI_ARGS=($VIBE_CLI_ARGS)
+    else
+        AI_ARGS=(-p)
+    fi
+    # Vibe takes the prompt as an argument rather than on stdin, and writes its
+    # own errors to stdout, so there is no separate stderr capture here.
+    set +e
+    AI_RESPONSE=$("$AI_COMMAND" "${AI_ARGS[@]}" "$AI_PROMPT" --output text 2>&1)
+    AI_EXIT_CODE=$?
+    set -e
 else
     AI_COMMAND="$CLAUDE_COMMAND"
     AI_ARGS=()


### PR DESCRIPTION
`--ai=vibe` existed only in the imagewize.com fork of `release-theme.sh` and was never upstreamed. That fork is being deleted as part of consolidating imagewize.com's scripts onto wp-ops, so this ports the capability up first rather than losing it.

`create-pr.sh` already supported vibe (20 references); `release-theme.sh` supported only claude and codex.

## Changes

- `VIBE_COMMAND` / `VIBE_CLI_ARGS` environment overrides, matching the existing claude/codex pattern
- `vibe` accepted by `--ai=`, included in auto-detection and the interactive picker, and covered by the "CLI is required but not installed" guard
- A dispatch branch for vibe in the AI-invocation block

Vibe takes the prompt as an argument rather than on stdin, and writes its own errors to stdout, so its branch does not capture stderr separately the way the claude and codex branches do. Default args are `-p` unless `VIBE_CLI_ARGS` is set. Both behaviours are carried over verbatim from the fork, which has been in use.

## Verification

After the port, a comment-stripped diff between the imagewize.com fork and this file leaves **one** differing line — the fork's older `--ai requires a value (claude or codex)` error string, which is now the more accurate `(claude, codex or vibe)`. Upstream is otherwise a strict superset.

- `bash -n` clean
- `go generate ./internal/catalog/` regenerated (the `@flag` line changed)
- `go test ./...` passes

## Known inconsistency

`release-plugin.sh` is release-theme's sibling and still offers only claude and codex. Nothing depended on vibe there, so it was left alone rather than changed speculatively — worth aligning if vibe becomes a regular part of the release flow.