### PR TITLE
Fix trellis-updater's hardcoded PROJECT, resolve TRELLIS_DIR instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2026-08-04
+
+### Fixed
+
+- **trellis/updater/trellis-updater.sh** - the script hardcoded
+  `PROJECT="site.com"` and instructed you to edit the file before running. That
+  is impossible through the CLI: `wp-ops` executes scripts from a
+  version-stamped cache directory (`~/Library/Caches/wp-ops/assets-<version>/`)
+  that is replaced on every upgrade, so any edit is silently discarded. The
+  command was effectively unusable as installed.
+
+  It now resolves `trellis/` from `$TRELLIS_DIR` — the same variable the
+  playbook commands use — falling back to `detect_trellis_dir()` /
+  `confirm_trellis_dir()`, the pair already used by `scripts/backup/db-pull.sh`
+  and mirroring `go/internal/detect`. `PROJECT` and `PROJECT_DIR` are derived
+  from the resolved directory rather than assumed to live under `~/code`.
+
+  This matters beyond convenience: the naive "walk up until you see a trellis/"
+  approach picks up an unrelated sibling checkout — from `~/code/seo-strategy`
+  it would find `~/code/trellis` and rsync into the wrong project. The shared
+  helper guards against that (a parent holding `trellis/` is trusted only when
+  you started there, or came up through its own Bedrock site), stops at `$HOME`,
+  and refuses to guess non-interactively since the operation overwrites
+  `trellis/`.
+
 ## [4.2.0] - 2026-08-04
 
 ### Added

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -2746,8 +2746,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/updater/trellis-updater",
-      "wp-ops trellis/updater/trellis-updater --yes"
+      "TRELLIS_DIR=~/code/example.com/trellis wp-ops trellis-updater",
+      "wp-ops trellis-updater --yes"
     ],
     "manifest_category": "updater",
     "display_category": "trellis",

--- a/trellis/updater/trellis-updater.sh
+++ b/trellis/updater/trellis-updater.sh
@@ -8,7 +8,14 @@
 # for secrets and custom config. Also flags upstream changes to excluded
 # files so you don't miss fixes worth cherry-picking.
 #
-# Edit the PROJECT variable below before running.
+# The trellis/ directory is taken from $TRELLIS_DIR, the same variable the
+# playbook commands use. If it isn't set, this walks up from the current
+# directory the way `detect.TrellisDir` does -- so running from inside a trellis
+# repo, or from the project root above it, just works.
+#
+# Editing this file to set a project is no longer required, and would not have
+# survived anyway when run through `wp-ops`, which executes it from a
+# version-stamped cache directory that is replaced on every upgrade.
 #
 # Options:
 #   --yes, -y      Skip the confirmation prompt before overwriting trellis/
@@ -18,8 +25,8 @@
 # @runs     local
 # @requires git
 # @flag     --yes  optional  {}  Skip the confirmation prompt before overwriting trellis/
-# @example  wp-ops trellis/updater/trellis-updater
-# @example  wp-ops trellis/updater/trellis-updater --yes
+# @example  TRELLIS_DIR=~/code/example.com/trellis wp-ops trellis-updater
+# @example  wp-ops trellis-updater --yes
 # @doc      trellis/updater/README.md
 
 set -e  # Exit on error
@@ -33,20 +40,100 @@ for arg in "$@"; do
   esac
 done
 
-# Set your project slug here like example.com
-PROJECT="site.com"
+# Resolve the trellis/ directory. $TRELLIS_DIR wins, matching the playbook
+# commands; otherwise walk up from the current directory. Two shapes count as a
+# hit, the same two detect.TrellisDir recognizes: the directory *is* trellis/
+# (ansible.cfg + group_vars/ sit directly in it), or it contains one.
+# Walks up from the current directory looking for a Trellis project. Two shapes
+# count: the directory *is* trellis/ (ansible.cfg + group_vars/ inside it), or a
+# parent holds trellis/ansible.cfg — the latter trusted only when we started in
+# that parent, or the directory walked up through is that parent's own Bedrock
+# site (web/wp/), so a sibling checkout that merely happens to sit near an
+# unrelated trellis/ isn't picked up by accident.
+# Same implementation as scripts/backup/db-pull.sh; mirrors
+# go/internal/detect.TrellisDir.
+detect_trellis_dir() {
+    local start="$PWD"
+    local dir="$start"
+    local previous="$start"
 
-# Paths based on project
-PROJECT_DIR=~/code/$PROJECT
-TRELLIS_DIR=$PROJECT_DIR/trellis
+    while [[ -n "$dir" && "$dir" != "/" && "$dir" != "$HOME" ]]; do
+        if [[ -f "$dir/ansible.cfg" && -d "$dir/group_vars" ]]; then
+            echo "$dir"
+            return 0
+        fi
+
+        if [[ -f "$dir/trellis/ansible.cfg" ]]; then
+            if [[ "$dir" == "$start" || -d "$previous/web/wp" ]]; then
+                echo "$dir/trellis"
+                return 0
+            fi
+        fi
+
+        previous="$dir"
+        dir="$(dirname "$dir")"
+    done
+
+    return 1
+}
+
+# Confirms an auto-detected TRELLIS_DIR before using it — this backs a
+# destructive operation (it rsyncs over trellis/), so a non-interactive session
+# refuses to guess rather than silently proceeding.
+# Mirrors go/internal/detect.Confirm.
+confirm_trellis_dir() {
+    local detected="$1"
+
+    if [[ ! -t 0 || ! -t 1 ]]; then
+        echo "TRELLIS_DIR is not set." >&2
+        echo "" >&2
+        echo "Detected a candidate at $detected, but wp-ops won't assume it" >&2
+        echo "non-interactively. Set it explicitly:" >&2
+        echo "" >&2
+        echo "  export TRELLIS_DIR=$detected" >&2
+        echo "" >&2
+        return 1
+    fi
+
+    echo "TRELLIS_DIR is not set."
+    echo "Detected from the current directory: $detected"
+    echo ""
+    read -p "Use it for this command? [y/N] " -n 1 -r
+    echo ""
+
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        return 0
+    fi
+
+    echo "Cancelled. Set it explicitly instead:"
+    echo ""
+    echo "  export TRELLIS_DIR=/path/to/your/project"
+    echo ""
+    return 1
+}
+
+if [ -z "${TRELLIS_DIR:-}" ]; then
+    if detected=$(detect_trellis_dir); then
+        confirm_trellis_dir "$detected" || exit 1
+        TRELLIS_DIR="$detected"
+    else
+        echo "ERROR: TRELLIS_DIR is not set and no Trellis project was found." >&2
+        echo "  Run this from inside a Trellis project, or set it explicitly:" >&2
+        echo "    export TRELLIS_DIR=/path/to/your/trellis" >&2
+        exit 1
+    fi
+fi
+
+PROJECT_DIR="$(cd "$TRELLIS_DIR/.." && pwd)"
+PROJECT="$(basename "$PROJECT_DIR")"
 BACKUP_DIR=~/trellis-backup-$(date +%Y%m%d_%H%M%S)
 TEMP_DIR=~/trellis-temp
 DIFF_DIR=~/trellis-diff
 
 # Verify project exists
-if [ ! -d "$PROJECT_DIR" ]; then
-  echo "ERROR: Project directory not found: $PROJECT_DIR"
-  echo "Please update the PROJECT variable in this script"
+if [ ! -d "$TRELLIS_DIR" ]; then
+  echo "ERROR: Trellis directory not found: $TRELLIS_DIR"
+  echo "Set TRELLIS_DIR to your trellis/ directory"
   exit 1
 fi
 


### PR DESCRIPTION
`trellis-updater.sh` hardcoded `PROJECT="site.com"` and instructed you to edit the file before running:

```bash
# Set your project slug here like example.com
PROJECT="site.com"
```

That cannot work through the CLI. `wp-ops` executes scripts from a version-stamped cache directory (`~/Library/Caches/wp-ops/assets-<version>/`) which is replaced on every upgrade, so the edit is silently discarded. The command was effectively unusable as installed — which is how this surfaced: consolidating imagewize.com's scripts onto wp-ops meant deleting a fork that had `PROJECT="imagewize.com"` baked in, and the upstream replacement couldn't stand in for it.

## Changes

- Resolve `trellis/` from **`$TRELLIS_DIR`** — the same variable the playbook commands already use via `resolveTrellisDir()`
- Fall back to `detect_trellis_dir()` / `confirm_trellis_dir()`, copied from `scripts/backup/db-pull.sh` and mirroring `go/internal/detect`
- Derive `PROJECT` / `PROJECT_DIR` from the resolved directory instead of assuming `~/code/<project>`

## Why the shared helper rather than a simple upward walk

A naive "walk up until you see a `trellis/`" picks up unrelated sibling checkouts. From `~/code/seo-strategy` it finds `~/code/trellis` and reports `PROJECT=code` — the updater would then rsync into the wrong project. I hit exactly that while testing before switching to the existing helper.

The shared implementation guards against it: a parent holding `trellis/` is trusted only when you started in that parent or walked up through its own Bedrock site (`web/wp/`), the walk stops at `$HOME`, and `confirm_trellis_dir` refuses to guess non-interactively — appropriate here, since the operation rsyncs over `trellis/`.

## Verification

| From | Result |
|---|---|
| `~/code/imagewize.com/trellis` | detects it, prompts for confirmation |
| `~/code/imagewize.com` | detects `…/trellis` |
| `~/code/imagewize.com/site` | detects `…/trellis` via the Bedrock-site rule |
| `~/code/seo-strategy` | **refuses** — no longer grabs `~/code/trellis` |
| `TRELLIS_DIR` set explicitly | resolves `PROJECT=imagewize.com` |

`bash -n` clean, catalog regenerated (the `@example` lines changed), `go test ./...` passes.