### PR TITLE
Render the interactive picker inline, one screen per step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,111 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-08-05
+
+The interactive picker stops behaving like a separate application. It renders
+inline, keeps your scrollback, and shows one thing per screen instead of three
+at once — the differences benchmarked against `trellis-cli` in the new
+`docs/trellis-cli-comparison.md`.
+
+### Changed
+
+- **The picker renders inline instead of taking over the screen.** `RunPicker`
+  no longer passes `tea.WithAltScreen()`. The alternate screen buffer keeps no
+  scrollback of its own and discards everything drawn in it on exit, which is
+  what made a bare `wp-ops` read as a separate prompt rather than as a command
+  that printed something. Output from earlier commands now stays visible above
+  the picker, and the last frame stays in the buffer after it exits.
+
+  The picker caps itself at 20 rows (`maxInlineRows`) as a consequence: sized
+  to the full window it would have shoved the scrollback off-screen on launch
+  and left a window-height frame behind on exit, reintroducing the problem from
+  the other direction. Same bargain `fzf --height 40%` makes.
+
+- **The browse list is a single full-width column.** It was a bordered list
+  pane beside a bordered live-preview pane, and that layout could not survive
+  its own width arithmetic: rows were built as a 28-column name plus
+  `[platform]` plus `(server)` — about 43 columns — and rendered into a pane of
+  `width * 2/5`, so on any terminal narrower than ~118 columns every tagged row
+  wrapped and its tags landed in the left margin of the next line. The preview
+  pane lost the same fight horizontally, clipping flag help mid-word
+  (`Append broken-link resu`). Both were the two panes competing for one
+  terminal's width, so neither pane splits it now.
+
+  `[platform]` no longer appears per row — it was the quietest signal on screen
+  and the one most responsible for the overflow. `(server)` stays, right-aligned
+  into its own column, and yields to the description rather than overflowing
+  when the terminal is too narrow for both.
+
+- **Command details moved from a live preview to a post-selection block.**
+  Choosing a command now prints its full help at full terminal width — usage,
+  description, requirements, examples, arguments, options — directly above the
+  argument prompts, which is the moment the information is actually needed.
+  Long option descriptions soft-wrap with a hanging indent instead of being
+  clipped, so nothing is lost off the right edge.
+
+- **Usage lines name the command you typed, with its real arguments.**
+  `wp-ops db-backup --help` answered `Usage: wp-ops scripts/backup/db-backup
+  [args...]` — an internal key carrying directory separators no user types, and
+  a placeholder where the manifest already knew the positional names three
+  lines further down. It now answers
+  `Usage: wp-ops db-backup [site-name] [environment] [options]`, derived from
+  the same `@arg`/`@flag` data, so it cannot drift from what the command
+  documents.
+
+  This lands on `--help` for every executor type and on the picker's detail
+  block, because it lands on the shared `writeManifestHelpBody`:
+
+  ```
+  Usage: wp-ops database-backup <site> <env>          (Ansible playbook)
+  Usage: wp-ops scanner-targeted [path]               (WP-CLI PHP)
+  Usage: wp-ops dev [args...]                         (un-annotated Node)
+  ```
+
+  The name comes from a new `Entry.ShortName`, computed once by `catalog.Load`
+  rather than stored in `catalog.json`: it is a property of the catalog as a
+  whole, not of the discovered file, so persisting it would let it go stale the
+  moment a colliding command is added. A basename shared by two commands has no
+  unambiguous short form — dispatch reports those as ambiguous rather than
+  picking one — so those keep the full key and the usage line stays something
+  that resolves if pasted back. `convert-to-webp` is currently the catalog's
+  only collision.
+
+- **Detail sections are ordered for a bounded viewport.** Requirements and
+  examples precede the parameter tables, the reverse of `--help`'s ordering and
+  the same shape `trellis alias --help` uses. The block runs past its ~14 rows
+  for a real command, so what sits above the fold matters: "needs `ssh`", "runs
+  on the server", and a worked invocation decide whether and how to run the
+  thing, while the exhaustive per-parameter tables can afford to scroll
+  (`pgup`/`pgdn`, hinted in the footer only when there is something to scroll).
+
+- **The category screen opens with a usage line**,
+  `Usage: wp-ops [--help] [--version] <command> [<args>]`, as `trellis` does
+  above its command table. Without it the screen read as though arrow keys were
+  the only interface to 74 commands, when every row is also reachable as
+  `wp-ops <command>`.
+
+- **Key hints abbreviate rather than wrap** on terminals too narrow for the
+  full footer, and the detail viewport shrinks to its content — a command
+  declaring no arguments used to push the prompt nine blank lines down.
+
+### Fixed
+
+- **`truncate` counts runes, not bytes.** Descriptions now fill the width the
+  preview pane used to occupy and so get truncated far more often than the old
+  28-column name field ever was; several contain an em dash that a byte-indexed
+  cut would have split into a partial rune.
+
+### Added
+
+- **docs/trellis-cli-comparison.md** - what `trellis-cli` does at its entry
+  point and command surface, what wp-ops does, and which differences are worth
+  closing. Verified against both codebases rather than inferred: framework,
+  command counts, help ownership, flag handling, completions, and the two
+  interactive-prompt models. Also reviews `docs/cli-comparison.md`, whose
+  central recommendation (add a `--help` that prints an inline list) describes
+  behavior `root.go` has shipped for some time.
+
 ## [5.0.0] - 2026-08-05
 
 Implements Option C of `docs/category-organization.md`: the catalog now groups

--- a/docs/cli-comparison.md
+++ b/docs/cli-comparison.md
@@ -1,0 +1,355 @@
+# CLI Comparison: wp-ops vs trellis-cli
+
+This document compares the CLI architectures and user experiences of **wp-ops** (this repository) and **trellis-cli** (Root's official CLI for Trellis), focusing on the key difference in how they handle the no-arguments case.
+
+## Executive Summary
+
+| Aspect | wp-ops | trellis-cli |
+|--------|--------|-------------|
+| **No-arguments behavior** | Launches full-screen interactive picker (Bubble Tea TUI) | Shows inline help text with all commands |
+| **Terminal behavior** | Switches to alternate screen buffer (separate prompt) | Stays in current terminal window |
+| **Framework** | Cobra + Bubble Tea | HashiCorp CLI |
+| **Command discovery** | Dynamic from manifest files in repo | Static, defined in Go code |
+| **Interactivity** | Rich TUI with filtering, preview, guided prompts | Standard command-line flags and args |
+
+## Detailed Comparison
+
+### 1. Entry Point and Framework
+
+#### wp-ops
+
+```go
+// go/main.go
+func main() {
+    if err := cmd.Execute(); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+}
+```
+
+- **Framework**: [spf13/cobra](https://github.com/spf13/cobra) - A modern CLI framework for Go
+- **Structure**: Single root command with dynamically registered subcommands
+- **Pattern**: Commands are auto-discovered from manifest files embedded in the binary
+
+#### trellis-cli
+
+```go
+// main.go
+func main() {
+    c := cli.NewCLI("trellis", version)
+    c.Args = os.Args[1:]
+    // ... setup UI, load config, register commands ...
+    exitStatus, err := c.Run()
+    // ... handle errors, updates ...
+    os.Exit(exitStatus)
+}
+```
+
+- **Framework**: [hashicorp/cli](https://github.com/hashicorp/cli) - HashiCorp's CLI library
+- **Structure**: Static command registration via `map[string]cli.CommandFactory`
+- **Pattern**: Commands are explicitly defined in code, not discovered
+
+### 2. No-Arguments Behavior (The Key Difference)
+
+#### wp-ops: Interactive Picker (Full-Screen TUI)
+
+When `wp-ops` is run with no arguments:
+
+```go
+// go/cmd/root.go
+func rootRunE(cc *cobra.Command, args []string) error {
+    c := mustCatalog()
+    if len(args) == 0 {
+        if detect.IsTerminal(os.Stdin) && detect.IsTerminal(os.Stdout) {
+            os.Exit(runInteractive(c))  // Launches Bubble Tea picker
+            return nil
+        }
+        printCategorizedList(c)
+        return nil
+    }
+    // ... handle arguments ...
+}
+```
+
+The interactive picker is implemented using [Bubble Tea](https://github.com/charmbracelet/bubbletea):
+
+```go
+// go/internal/ui/picker.go
+func RunPicker(c *catalog.Catalog) (Result, error) {
+    m := New(c)
+    p := tea.NewProgram(m, tea.WithAltScreen())  // <-- Key line
+    final, err := p.Run()
+    if err != nil {
+        return Result{}, err
+    }
+    return final.(Model).result, nil
+}
+```
+
+**`tea.WithAltScreen()`** is the crucial difference. This tells Bubble Tea to:
+- Switch the terminal to an alternate screen buffer
+- Clear the current terminal content
+- Provide a clean, isolated UI experience
+- Exit the alternate screen when the program finishes
+
+This creates the "separate prompt" appearance shown in your screenshot.
+
+The picker has multiple stages:
+1. **Category selection** - Pick from organized categories (Monitoring, Backup, Content, etc.)
+2. **Browse commands** - Filterable list with live preview pane
+3. **Field prompting** - Guided argument collection for commands with @arg/@flag manifests
+
+**Visual appearance:**
+- Full-screen take-over
+- Styled with lipgloss (colors, borders, cursor highlighting)
+- Two-pane layout (command list + preview)
+- Footer with keyboard hints
+
+#### trellis-cli: Inline Help Text
+
+When `trellis` is run with no arguments or `--help`:
+
+```go
+// main.go
+c.HelpFunc = deprecatedCommandHelpFunc(deprecatedCommands, cli.BasicHelpFunc("trellis"))
+// ...
+exitStatus, err := c.Run()
+```
+
+The HashiCorp CLI library's `Run()` method handles this internally:
+- Prints usage line: `Usage: trellis [--version] [--help] <command> [<args>]`
+- Lists all available commands alphabetically
+- Shows synopsis for each command
+- Groups deprecated commands separately
+- Stays in the same terminal window
+
+**Visual appearance:**
+- Standard terminal output
+- No screen switching
+- Simple text formatting (no borders, colors from fatih/color)
+- Scrolls naturally with terminal buffer
+
+### 3. Terminal Buffer Behavior
+
+| Aspect | wp-ops (Bubble Tea) | trellis-cli (HashiCorp CLI) |
+|--------|-------------------|----------------------------|
+| **Alternate screen** | Yes (`tea.WithAltScreen()`) | No |
+| **Terminal state** | Switches to alternate buffer, clears screen | Stays in primary buffer |
+| **Scrollback** | Lost (alternate buffer doesn't preserve scrollback) | Preserved |
+| **Exit behavior** | Returns to previous terminal state | Continues in same window |
+| **Window title** | Can be set by Bubble Tea | Standard terminal title |
+
+### 4. Command Organization
+
+#### wp-ops: Dynamic Catalog
+
+Commands are discovered from manifest files embedded in the binary:
+
+```
+wp-ops/
+├── scripts/
+│   ├── backup/
+│   │   ├── db-backup.sh        (manifest: @category backup, @description ...)
+│   │   └── files-backup.sh
+├── trellis/
+│   ├── backup/
+│   │   └── database-backup.yml
+└── wp-cli/
+    ├── security/
+    │   └── admin-user-create.sh
+```
+
+The catalog is built at compile time from these manifests, creating:
+- Hidden commands for each full key (`scripts/backup/db-backup`)
+- Visible commands for each category (`backup`, `trellis`, etc.)
+- Display categories grouped by domain (Monitoring, Backup, Content, etc.)
+
+#### trellis-cli: Static Registration
+
+Commands are explicitly registered in `main.go`:
+
+```go
+c.Commands = map[string]cli.CommandFactory{
+    "alias": func() (cli.Command, error) {
+        return cmd.NewAliasCommand(ui, trellis), nil
+    },
+    "check": func() (cli.Command, error) {
+        return &cmd.CheckCommand{UI: ui, Trellis: trellis}, nil
+    },
+    "db": func() (cli.Command, error) {
+        return &cmd.NamespaceCommand{
+            HelpText:     "Usage: trellis db <subcommand> [<args>]",
+            SynopsisText: "Commands for database management",
+        }, nil
+    },
+    // ... 40+ more commands
+}
+```
+
+Namespace commands (like `db`, `vault`, `server`) use `NamespaceCommand` which just shows help:
+
+```go
+func (c *NamespaceCommand) Run(args []string) int {
+    return cli.RunResultHelp  // Just shows help, doesn't execute
+}
+```
+
+### 5. UI/UX Libraries
+
+#### wp-ops Dependencies
+
+```
+github.com/charmbracelet/bubbles v1.0.0     // Text input, viewport, etc.
+github.com/charmbracelet/bubbletea v1.3.10  // TUI framework
+github.com/charmbracelet/lipgloss v1.1.0   // Styling
+github.com/spf13/cobra v1.10.2             // CLI framework
+```
+
+#### trellis-cli Dependencies
+
+```
+github.com/hashicorp/cli v1.1.7          // CLI framework
+github.com/fatih/color v1.19.0         // Terminal colors
+```
+
+### 6. Why the Different Approaches?
+
+#### wp-ops: The Interactive Picker Rationale
+
+The wp-ops CLI has **hundreds of commands** across many categories. The interactive picker solves:
+
+1. **Discoverability** - With 70+ commands, a simple `--help` list would be overwhelming
+2. **Organization** - Commands are grouped by domain (not directory), making it easier to find related functionality
+3. **Guided workflow** - Commands with complex arguments get guided prompts
+4. **Filtering** - Type to search across all commands
+5. **Preview** - See command usage and description before selecting
+
+The trade-off is the alternate screen, which some users find disruptive.
+
+#### trellis-cli: The Simple Help Rationale
+
+The trellis-cli has **~40 top-level commands** with some nested subcommands. The simple approach works because:
+
+1. **Fewer commands** - The list fits comfortably on one screen
+2. **Traditional CLI expectations** - Users of HashiCorp tools (Vagrant, Terraform) expect this pattern
+3. **Composability** - Easy to pipe/grep the output
+4. **No dependencies** - No need for TUI libraries
+
+### 7. Strengths and Weaknesses
+
+#### wp-ops Interactive Picker
+
+**Strengths:**
+- Excellent for large command catalogs
+- Rich filtering and preview capabilities
+- Guided prompts for complex commands
+- Visually appealing and organized
+- Stays consistent with the repo's evolution from bash scripts with fzf
+
+**Weaknesses:**
+- Requires terminal support for alternate screens (some SSH sessions, CI environments)
+- Loses scrollback history
+- Can feel "heavy" for simple use cases
+- More complex codebase to maintain
+
+#### trellis-cli Simple Help
+
+**Strengths:**
+- Lightweight and fast
+- Works everywhere (SSH, CI, pipes, redirects)
+- Familiar to CLI users
+- Simple implementation
+- Scrollback preserved
+
+**Weaknesses:**
+- Scales poorly with many commands
+- No filtering or search
+- No guided prompts
+- Less visually organized
+
+### 8. Recommendations
+
+If you prefer the trellis-cli approach, you have several options:
+
+#### Option A: Add a `--help` alias for wp-ops
+
+Add a flag to skip the interactive picker:
+
+```bash
+wp-ops --help     # Show simple help (like trellis)
+wp-ops            # Launch interactive picker (current behavior)
+```
+
+Implementation would add a flag check in `rootRunE`:
+
+```go
+var noPickerFlag bool
+
+func init() {
+    rootCmd.Flags().BoolVar(&noPickerFlag, "no-picker", false, "Show help instead of interactive picker")
+}
+
+func rootRunE(cc *cobra.Command, args []string) error {
+    c := mustCatalog()
+    if len(args) == 0 {
+        if noPickerFlag || !detect.IsTerminal(os.Stdin) || !detect.IsTerminal(os.Stdout) {
+            printCategorizedList(c)
+            return nil
+        }
+        os.Exit(runInteractive(c))
+        return nil
+    }
+    // ...
+}
+```
+
+#### Option B: Environment Variable
+
+```bash
+WP_OPS_NO_PICKER=1 wp-ops    # Show simple help
+wp-ops                        # Launch interactive picker
+```
+
+#### Option C: Detect and Adapt
+
+Automatically use simple help when:
+- Not a TTY
+- Terminal width is too small
+- `NO_COLOR` environment variable is set
+- `TERM=dumb`
+
+#### Option D: Make Simple Help the Default
+
+Change the default behavior to show simple help, with a flag for the picker:
+
+```bash
+wp-ops            # Show simple help (new default)
+wp-ops --interactive  # Launch picker (opt-in)
+```
+
+This would be a breaking change but aligns with trellis-cli's philosophy.
+
+### 9. Code Architecture Comparison
+
+| Aspect | wp-ops | trellis-cli |
+|--------|--------|-------------|
+| **Command discovery** | Dynamic from filesystem manifests | Static in code |
+| **CLI framework** | Cobra | HashiCorp CLI |
+| **TUI framework** | Bubble Tea | None |
+| **Styling** | lipgloss | fatih/color |
+| **Command registration** | Auto-generated at startup | Manual in main.go |
+| **Argument parsing** | Delegated to underlying scripts | Handled by each command |
+| **Help generation** | Custom (picker + text fallbacks) | HashiCorp CLI built-in |
+| **Completions** | Cobra + custom logic | posener/complete |
+
+### 10. Conclusion
+
+The fundamental difference is **philosophical**:
+
+- **wp-ops**: "So many commands, you need a GUI" - Optimized for discoverability in a large ecosystem
+- **trellis-cli**: "Keep it simple" - Traditional CLI that trusts users to know what they want
+
+Both approaches are valid. The wp-ops interactive picker is more "modern" and user-friendly for large command sets, while trellis-cli's simplicity is more "Unix-like" and composable.
+
+If you want wp-ops to behave more like trellis-cli, **Option A** (adding a `--help` or `--no-picker` flag) would give you the best of both worlds without breaking existing user expectations.

--- a/docs/trellis-cli-comparison.md
+++ b/docs/trellis-cli-comparison.md
@@ -13,6 +13,16 @@ Compared against `trellis-cli` at `/Users/jasperfrumau/code/trellis-cli`
 > that its architecture summary is sound but its central recommendation
 > proposes a feature the CLI already ships.
 
+> **Status (2026-08-05): acted on in 5.1.0.** Section 6's Option 1 shipped —
+> the picker renders inline, capped at 20 rows — along with the single-column
+> browse list and post-selection detail block that came out of reviewing the
+> result. Rough edge #1 in §5 (the usage line naming an internal key) is fixed
+> everywhere — the picker and `wp-ops <command> --help` for every executor
+> type. Sections 1–5 describe the code **as it was before** that change and are
+> kept as the analysis that motivated it; §2's "Bare invocation (TTY)" row,
+> §1's `tea.WithAltScreen()` snippet, and §5's rough edge #1 no longer match
+> the code. Still open: §5's rough edge #2, the missing deprecation channel.
+
 ## 1. The one difference that produced the screenshots
 
 `trellis` with no arguments prints help to stdout and exits. `wp-ops` with no

--- a/docs/trellis-cli-comparison.md
+++ b/docs/trellis-cli-comparison.md
@@ -1,0 +1,265 @@
+# wp-ops CLI vs trellis-cli: entry point and command surface
+
+Why `trellis` with no arguments stays in your terminal and looks organized,
+what `wp-ops` does instead, and which of those differences are actually worth
+closing.
+
+Compared against `trellis-cli` at `/Users/jasperfrumau/code/trellis-cli`
+(module `github.com/roots/trellis-cli`, go 1.25) and this repo's Go CLI under
+`go/` (module `github.com/imagewize/wp-ops`, go 1.26.4).
+
+> A second comparison document, [`cli-comparison.md`](cli-comparison.md),
+> was written by Mistral. Section 8 below reviews it — the short version is
+> that its architecture summary is sound but its central recommendation
+> proposes a feature the CLI already ships.
+
+## 1. The one difference that produced the screenshots
+
+`trellis` with no arguments prints help to stdout and exits. `wp-ops` with no
+arguments takes over the screen.
+
+```go
+// go/cmd/root.go:65-74
+if len(args) == 0 {
+    if detect.IsTerminal(os.Stdin) && detect.IsTerminal(os.Stdout) {
+        os.Exit(runInteractive(c))   // Bubble Tea picker
+    }
+    printCategorizedList(c)          // plain text, piped/redirected only
+}
+```
+
+```go
+// go/internal/ui/picker.go:18
+p := tea.NewProgram(m, tea.WithAltScreen())
+```
+
+`tea.WithAltScreen()` switches the terminal to its alternate screen buffer.
+That is the entire reason the picker "feels like a separate prompt": the
+alternate buffer has no scrollback of its own, and everything drawn in it is
+discarded when the program exits. Nothing about Bubble Tea requires this —
+without the option the same picker renders inline, in the primary buffer,
+like `fzf --height` or `git rebase -i`'s status output.
+
+trellis-cli has no equivalent, because it has no TUI at all. `main.go:247`
+calls `c.Run()`; with no arguments `hashicorp/cli` falls through to its
+`HelpFunc` (`cli.BasicHelpFunc("trellis")`, wrapped in
+`deprecatedCommandHelpFunc` at `main.go:230`) and writes the command table to
+the UI writer, which is plain `os.Stdout` (`main.go:30-37`).
+
+**Worth being precise about:** the alternate screen is the only reason bare
+`wp-ops` behaves differently. `wp-ops --help` already prints exactly the
+trellis-style inline listing (`root.go:86`), and so does any non-TTY
+invocation.
+
+## 2. Verified side-by-side
+
+| | wp-ops | trellis-cli |
+|---|---|---|
+| CLI framework | `spf13/cobra` v1.10.2 | `hashicorp/cli` v1.1.7 |
+| Bare invocation (TTY) | Full-screen Bubble Tea picker | Command table, inline |
+| Bare invocation (piped) | Category summary text | Same command table |
+| `--help` | Category summary text | Same command table |
+| Command count | 74 entries (`go/internal/catalog/catalog.json`) | 46 registered factories — 23 top-level, 23 namespaced subcommands |
+| Grouping | 12 display categories, drilled into via `wp-ops <category>` | Noun namespaces (`db`, `vm`, `vault`, `server`, `key`, `galaxy`, `valet`, `xdebug-tunnel`) |
+| Command source | Generated at build time (`go:generate` → `catalog.json`, `//go:embed`) | Hand-written `map[string]cli.CommandFactory` in `main.go:61-227` |
+| Per-command help | Rendered from manifest metadata (`go/internal/exec/help.go`) | Hand-written `Help()` string per command (e.g. `cmd/deploy.go:129`) |
+| Flag parsing | None — `DisableFlagParsing`, argv passes through to the script | Stdlib `flag.FlagSet` per command (`cmd/deploy.go:30-34`) |
+| Completions | Cobra + custom `ValidArgsFunction` (`go/cmd/dispatch.go`) | `posener/complete` via `AutocompleteArgs()`/`AutocompleteFlags()` |
+| Interactive prompts | Bubble Tea field prompts inside the picker (`go/internal/ui/fields.go`) | `manifoldco/promptui`, inline, in 9 commands (`vault edit`, `key generate`, `server create`, `new`, …) |
+| Styling | `charmbracelet/lipgloss` | `fatih/color` + `theckman/yacspin` spinner (`cmd/spinner.go`) |
+| Extensibility | None | `trellis-*` executables on `PATH` auto-register as commands (`plugin/`, kubectl-style) |
+| Update check | None | Background goroutine, message printed after the command runs (`main.go:47-57`, `252-263`) |
+
+Two rows deserve emphasis because they cut against the usual framing:
+
+- **trellis-cli is not "non-interactive".** Nine of its commands prompt.
+  The difference is that every prompt is a line in the normal buffer, not a
+  screen.
+- **wp-ops's help is not thinner than trellis's.** It is generated rather
+  than hand-written, but `wp-ops db-backup --help` produces usage,
+  arguments, flags, requirements, examples, docs link, and script path — more
+  structured than most of trellis's prose help blocks.
+
+## 3. What actually makes trellis look organized
+
+Three properties, none of which is "it avoids a TUI":
+
+1. **Two-level noun namespaces.** `db`, `key`, `server`, `vault`, `vm`,
+   `galaxy`, `valet`, `xdebug-tunnel` are `NamespaceCommand` values whose
+   `Run()` returns `cli.RunResultHelp` (`cmd/namespace.go:12`) — they exist
+   only to hold subcommands and to keep the top-level list at 23 lines.
+   46 commands present as 23.
+2. **One screen, aligned, alphabetical.** `cli.BasicHelpFunc` pads every name
+   to a fixed column and prints one `Synopsis()` per line. Deprecated
+   commands are segregated into their own block at the bottom
+   (`help.go:12-47`), so `droplet` is visible without polluting the main list.
+3. **The output persists.** It scrolls into your buffer, so you can read the
+   list while typing the command it told you about. A full-screen picker has
+   to be re-entered to be re-read.
+
+`wp-ops --help` already does (2) and (3), and does (1) via display categories.
+Compare — this is the current output, 12 lines of commands for 74 commands:
+
+```
+wp-ops — WordPress Operations Tools
+
+  Monitoring             (17)  Log monitoring, uptime checks, and traffic analysis
+  Backup                 (10)  Database and file backups — Ansible and shell
+  ...
+Run 'wp-ops <category>' to see a category's commands (e.g. 'wp-ops backup')
+```
+
+That is denser than trellis's own landing page. The problem is not the text
+view; it is that the text view is not what a bare `wp-ops` shows.
+
+## 4. Where wp-ops is genuinely different by design
+
+These are real divergences, not gaps to close blindly:
+
+- **Generated vs hand-registered catalog.** wp-ops discovers commands by
+  walking the repo at build time (`go/internal/catalog/gen/main.go`) and
+  embeds the result. Adding a script with a manifest header gets you a
+  command for free; trellis-cli requires editing `main.go`. This is the
+  right trade for a repo whose commands *are* the scripts.
+- **Pass-through argv.** Every wp-ops command sets `DisableFlagParsing`
+  because the underlying shell/Ansible/PHP script owns its own flag grammar
+  (`go/cmd/dispatch.go:36`, `51`). trellis-cli owns its flags, so it can
+  validate them and offer flag completion. Neither is wrong; wp-ops is a
+  dispatcher, trellis-cli is an application.
+- **Categories are domains, not namespaces.** `wp-ops backup` is a view onto
+  commands scattered across `scripts/backup/`, `trellis/backup/`. trellis's
+  `db` is a real prefix of the command name. This is why wp-ops also supports
+  a bare basename with ambiguity resolution (`root.go:97-108`), which trellis
+  has no need for.
+
+## 5. Two small rough edges found while comparing
+
+Both are cheap to fix and both show up next to trellis's equivalents:
+
+1. **Help echoes the internal key, not what you typed.**
+   `wp-ops db-backup --help` prints `Usage: wp-ops scripts/backup/db-backup
+   [args...]`. trellis prints `Usage: trellis deploy [options] ENVIRONMENT
+   [SITE]`. Two issues: the full key is shown where the user typed a
+   basename, and `[args...]` is a placeholder where the manifest already
+   knows the real positional names (they are listed three lines below).
+   Rendering `Usage: wp-ops db-backup [site-name] [environment] [flags]` from
+   the same manifest data would close the gap entirely
+   (`go/internal/exec/help.go:48`).
+2. **No deprecation channel.** trellis segregates deprecated commands in help
+   rather than deleting them. wp-ops has hidden directory aliases
+   (`wp-ops trellis <playbook>`, `dispatch.go:71-82`) that are invisible
+   rather than labelled — a `@deprecated` manifest directive plus a footer
+   block would make the migration path visible.
+
+## 6. Options for the entry point
+
+Ordered by how much they change.
+
+### Option 1 — Drop the alternate screen (recommended)
+
+Delete `tea.WithAltScreen()` from `picker.go:18`. The picker then renders
+inline: it draws in the primary buffer, scrollback is preserved, and the
+final frame stays visible after selection. You keep filtering, the preview
+pane, and guided argument prompts; you lose the screen takeover.
+
+One caveat: an inline Bubble Tea program still redraws its own frame region,
+so a picker taller than the window will clip rather than scroll. The picker's
+category stage is 14 lines and the browse stage already windows its list
+(`model.go`'s `viewBrowse`), so this is a non-issue in practice — but it is
+worth capping the browse window height explicitly if this is done.
+
+Effort: one line, plus a manual pass over the three stages.
+
+### Option 2 — Make text the default, picker opt-in
+
+Bare `wp-ops` prints `printCategorizedList` (identical to `--help` and to the
+piped path today); the picker moves behind `wp-ops menu` or `wp-ops -i`.
+
+This is the most trellis-faithful outcome and removes the TTY branch in
+`rootRunE` entirely. It is a behavior change for anyone who types `wp-ops`
+expecting the picker, and it makes the picker's discoverability work only
+pay off for people who know to ask for it.
+
+Effort: small. `root.go:65-74` plus a new subcommand and README/completion
+updates.
+
+### Option 3 — Both: inline picker, text on `--help`, `--no-picker` escape hatch
+
+Option 1 plus an explicit opt-out flag and/or `WP_OPS_NO_PICKER` env var for
+scripts and constrained terminals.
+
+The env var is largely redundant — the TTY check at `root.go:70` already
+covers pipes, redirects, and CI — but an explicit flag is useful for
+"I want the list, in a terminal, right now" without remembering that `--help`
+is the way to get it.
+
+**Recommendation: Option 1, and consider Option 3's flag as a follow-up.**
+The user-visible complaint is the screen takeover and the lost scrollback,
+not the picker itself. Option 1 fixes exactly that and costs one line. Option
+2 throws away the picker's real value — 74 commands is well past what an
+alphabetical list serves — to fix a problem that is really about terminal
+buffer management. If, after living with an inline picker for a while, the
+text view still feels better, Option 2 remains available and is no harder
+then than now.
+
+## 7. What not to copy
+
+- **Static command registration.** trellis's `map[string]cli.CommandFactory`
+  is 170 lines of boilerplate. The generated catalog is strictly better for
+  this repo.
+- **Per-command flag parsing.** Would mean re-declaring every script's flags
+  in Go and keeping them in sync. The manifest already documents them; the
+  script already parses them.
+- **`hashicorp/cli`.** Cobra is the more actively maintained choice and the
+  completion machinery already depends on it. The framework is not what
+  produced the difference in the screenshots.
+
+Worth copying eventually, on the other hand: the plugin discovery model
+(`plugin/finder.go` — any `wp-ops-*` executable on `PATH` becomes a command)
+if per-project commands ever become a need.
+
+## 8. Notes on `cli-comparison.md` (the Mistral document)
+
+The architectural read is accurate. `tea.WithAltScreen()` is correctly
+identified as the mechanism, the framework comparison is right, and the
+strengths/weaknesses tables are fair. Specific corrections:
+
+**Its main recommendation already ships.** Section 8's Option A proposes
+adding a `--help` that prints simple help instead of the picker, with sample
+code adding a `noPickerFlag`. `root.go:85-86` already handles `--help`/`-h`
+by calling `printCategorizedList`, and `root.go:70` already falls back to the
+same output when stdin or stdout is not a TTY. Its Option C ("detect and
+adapt — not a TTY") is likewise already implemented at that same line. Only
+Options B and D describe work that does not exist yet.
+
+**Its Option A code would break the CLI.** The snippet calls
+`rootCmd.Flags().BoolVar(...)` and then reads `noPickerFlag` in `rootRunE`.
+Root sets `DisableFlagParsing: true` (`root.go:53`) precisely so that
+unrecognized flags destined for the underlying script are not intercepted, so
+a registered flag would never be populated. The comment block at
+`root.go:45-52` explains why. This is the kind of detail worth catching
+before the suggestion reaches a branch.
+
+**Counts and dependencies are off in places.** "hundreds of commands" and
+"70+" appear for wp-ops, where the catalog holds exactly 74; trellis-cli is
+described as "~40 top-level commands" where it is 23 top-level and 46 total.
+Its dependency list for trellis-cli names only `hashicorp/cli` and
+`fatih/color`, omitting `promptui`, `yacspin`, `posener/complete`, and
+`go-isatty` — the omission matters, because `promptui` is what disproves the
+document's framing of trellis-cli as the non-interactive option.
+
+**"Built at compile time" and "auto-generated at startup" both appear.**
+Sections 4 and 9 contradict each other. Compile time is correct:
+`//go:generate` writes `catalog.json`, `//go:embed` bakes it into the binary,
+and `catalog.go:1-4` states that no filesystem scan happens at runtime.
+
+**It treats the trade-off as picker-vs-text.** The alternate screen and the
+picker are separable — that is the whole content of Option 1 above, and it
+does not appear anywhere in the document's four options. Framing the choice
+as "keep the TUI or match trellis" makes the cheapest fix invisible.
+
+**Missing context.** [`cli-ux-plan.md`](cli-ux-plan.md) Phase F already
+analysed this exact question in 2026-08, explicitly benchmarking against
+`trellis`'s two-level structure, and shipped three of its four options in
+PR #146 — including the category-select stage visible in the screenshot.
+A comparison written without that history re-proposes work already done.

--- a/go/internal/catalog/catalog.go
+++ b/go/internal/catalog/catalog.go
@@ -73,6 +73,34 @@ type Entry struct {
 	// this human-facing split must not leak into it.
 	DisplayCategory string `json:"display_category"`
 	Annotated       bool   `json:"annotated"`
+	// ShortName is the shortest form that unambiguously resolves to this
+	// entry: its basename ("db-backup") when no other command shares it, and
+	// the full key otherwise. Computed by Load rather than stored in
+	// catalog.json — it is a property of the catalog as a whole, not of the
+	// file gen discovered, so persisting it would let it go stale the moment
+	// a colliding command is added. Read it through CommandName.
+	ShortName string `json:"-"`
+}
+
+// CommandName is what to call this entry when addressing a user: the name
+// they can actually type. Falls back to the full key for an Entry built
+// outside Load (tests, and the picker's hand-built models) — longer, but
+// never wrong, since a full key always resolves.
+func (e Entry) CommandName() string {
+	if e.ShortName != "" {
+		return e.ShortName
+	}
+	return e.Key
+}
+
+// basename is the last "/"-separated segment of a command key. Keys are
+// always repo-relative and always use "/", so this deliberately does not go
+// through path/filepath, whose separator is platform-dependent.
+func basename(key string) string {
+	if i := strings.LastIndex(key, "/"); i >= 0 {
+		return key[i+1:]
+	}
+	return key
 }
 
 // RequiresString joins Requires the way bash's manifest_get "requires"
@@ -98,6 +126,21 @@ func Load() (*Catalog, error) {
 	var entries []Entry
 	if err := json.Unmarshal(catalogJSON, &entries); err != nil {
 		return nil, fmt.Errorf("catalog: embedded catalog.json is corrupt: %w", err)
+	}
+
+	// A basename shared by two commands in different categories (dispatch.go
+	// reports those as ambiguous rather than picking one) can't stand in for
+	// either, so only the unique ones become a ShortName.
+	basenameCount := make(map[string]int, len(entries))
+	for _, e := range entries {
+		basenameCount[basename(e.Key)]++
+	}
+	for i := range entries {
+		if b := basename(entries[i].Key); basenameCount[b] == 1 {
+			entries[i].ShortName = b
+		} else {
+			entries[i].ShortName = entries[i].Key
+		}
 	}
 
 	c := &Catalog{
@@ -176,11 +219,10 @@ func (c *Catalog) CommandsInDisplay(category string) []Entry {
 // FindByBasename returns every entry whose key's final path segment matches
 // basename — the set candidate list for ambiguous short-form resolution
 // (e.g. "wp-ops db-backup" when only "scripts/backup/db-backup" exists).
-func (c *Catalog) FindByBasename(basename string) []Entry {
+func (c *Catalog) FindByBasename(name string) []Entry {
 	var out []Entry
 	for _, e := range c.Entries {
-		segs := strings.Split(e.Key, "/")
-		if segs[len(segs)-1] == basename {
+		if basename(e.Key) == name {
 			out = append(out, e)
 		}
 	}

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -215,3 +215,37 @@ func TestCommandsInDisplayPreservesCategoryForJSON(t *testing.T) {
 		t.Error("no @platform wordpress backup command — a non-Trellis site has no backup path")
 	}
 }
+
+// TestLoad_ShortNameUniqueBasenames pins the name every user-facing usage
+// line is built from: the basename when it resolves to exactly one command,
+// the full key when it does not. A collision has no unambiguous short form —
+// dispatch reports those as ambiguous rather than picking one — so printing
+// the basename would produce a usage line that errors if pasted back.
+func TestLoad_ShortNameUniqueBasenames(t *testing.T) {
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for _, e := range c.Entries {
+		if e.ShortName == "" {
+			t.Fatalf("%s: ShortName is empty; Load must populate it", e.Key)
+		}
+
+		matches := c.FindByBasename(e.ShortName)
+		switch {
+		case e.ShortName == e.Key:
+			// Fell back to the key, so the basename must genuinely collide.
+			base := e.Key[strings.LastIndex(e.Key, "/")+1:]
+			if n := len(c.FindByBasename(base)); n < 2 && base != e.Key {
+				t.Errorf("%s: fell back to the full key but %q resolves to %d command(s), not several",
+					e.Key, base, n)
+			}
+		case len(matches) != 1:
+			t.Errorf("%s: ShortName %q resolves to %d commands, want exactly 1",
+				e.Key, e.ShortName, len(matches))
+		case matches[0].Key != e.Key:
+			t.Errorf("%s: ShortName %q resolves to %s", e.Key, e.ShortName, matches[0].Key)
+		}
+	}
+}

--- a/go/internal/exec/ansible_test.go
+++ b/go/internal/exec/ansible_test.go
@@ -25,7 +25,9 @@ func TestFormatHelp_AnnotatedPlaybook(t *testing.T) {
 	help := FormatHelp(e, "/srv/trellis-project")
 
 	for _, want := range []string{
-		"Usage: wp-ops trellis/backup/database-backup [args...]",
+		// Real positionals under the name a user types, not the catalog key
+		// with an "[args...]" placeholder — see UsageLine.
+		"Usage: wp-ops database-backup <site> <env>",
 		e.Description,
 		"Arguments:",
 		"site",

--- a/go/internal/exec/help.go
+++ b/go/internal/exec/help.go
@@ -32,6 +32,102 @@ func PreviewBody(e catalog.Entry) string {
 	return b.String()
 }
 
+// UsageLine renders a real usage line — "Usage: wp-ops db-backup [site-name]
+// [environment] [options]" — from a command's declared @arg/@flag manifest,
+// under whatever name the caller wants the command to answer to. name is a
+// parameter rather than derived from e because the right answer differs by
+// caller: the picker shows the basename a user can actually type, while a
+// context that can't guarantee the basename is unambiguous must fall back to
+// the full key.
+//
+// This is the shape trellis-cli's per-command Help() hand-writes ("Usage:
+// trellis deploy [options] ENVIRONMENT [SITE]"); here it's derived, so it
+// can't drift from the arguments the command actually documents.
+func UsageLine(e catalog.Entry, name string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Usage: wp-ops %s", name)
+
+	for _, a := range e.Args {
+		if a.Required {
+			fmt.Fprintf(&b, " <%s>", a.Name)
+		} else {
+			fmt.Fprintf(&b, " [%s]", a.Name)
+		}
+	}
+	if len(e.Flags) > 0 {
+		b.WriteString(" [options]")
+	}
+	// Nothing declared (un-annotated commands, and annotated ones that take
+	// no arguments) still accepts a free-text argv — the picker's final
+	// prompt passes it straight through — so say so rather than implying the
+	// command takes nothing.
+	if len(e.Args) == 0 && len(e.Flags) == 0 {
+		b.WriteString(" [args...]")
+	}
+	return b.String()
+}
+
+// DetailBody renders the block the picker shows once a command is chosen:
+// the same manifest material as --help, but headed by UsageLine's real usage
+// rather than the "<full-key> [args...]" placeholder, and without the
+// Script: trailer (an implementation detail at the moment someone is about
+// to answer "site-url:"). Requires/platform/server-side facts collapse onto
+// one meta line — they used to be per-row tags in the browse list, where
+// they wrapped and broke the column alignment at any realistic pane width.
+func DetailBody(e catalog.Entry, name string) string {
+	var b strings.Builder
+	b.WriteString(UsageLine(e, name))
+	b.WriteString("\n\n")
+
+	if e.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", e.Description)
+	}
+
+	// Requirements come before the parameter blocks, not after them as
+	// --help orders things: the picker shows this in a viewport roughly 14
+	// rows tall, and a command with several options pushes whatever trails
+	// them below the fold. "Needs curl" and "runs on the server" are the two
+	// facts that decide whether to run the command at all, so they belong
+	// above the material you scroll through, not after it.
+	var meta []string
+	if len(e.Requires) > 0 {
+		meta = append(meta, "Requires: "+e.RequiresString())
+	}
+	if e.Platform != "" {
+		meta = append(meta, "Platform: "+e.Platform)
+	}
+	if e.RunsOn == "server" {
+		meta = append(meta, "Runs on the server")
+	}
+	if len(meta) > 0 {
+		fmt.Fprintf(&b, "%s\n\n", strings.Join(meta, " · "))
+	}
+
+	// Examples precede the parameter tables, as they do in trellis-cli's
+	// hand-written help ("$ trellis alias --skip-local" sits above Options).
+	// Same fold argument as the meta line: a worked invocation is the most
+	// actionable thing here for someone about to type an argument, and the
+	// exhaustive per-parameter tables are what can afford to scroll.
+	if len(e.Examples) > 0 {
+		fmt.Fprintln(&b, "Examples:")
+		for _, ex := range e.Examples {
+			fmt.Fprintf(&b, "  %s\n", ex)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	writeParamBlock(&b, "Arguments:", e.Args)
+	// "Options:" rather than --help's "Flags:", matching the heading
+	// trellis-cli uses and the one `--help` output conventionally carries.
+	writeParamBlock(&b, "Options:", e.Flags)
+
+	if e.Doc != "" {
+		fmt.Fprintf(&b, "Docs: %s\n", e.Doc)
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
 // writeManifestHelpBody renders the shared body of print_manifest_help
 // (wp-ops:352): usage line, description, arguments, flags, requires, the
 // server-side note, examples, docs, and the script path. FormatHelp

--- a/go/internal/exec/help.go
+++ b/go/internal/exec/help.go
@@ -34,18 +34,15 @@ func PreviewBody(e catalog.Entry) string {
 
 // UsageLine renders a real usage line — "Usage: wp-ops db-backup [site-name]
 // [environment] [options]" — from a command's declared @arg/@flag manifest,
-// under whatever name the caller wants the command to answer to. name is a
-// parameter rather than derived from e because the right answer differs by
-// caller: the picker shows the basename a user can actually type, while a
-// context that can't guarantee the basename is unambiguous must fall back to
-// the full key.
+// naming the command the way a user would type it (Entry.CommandName) rather
+// than by its internal catalog key.
 //
 // This is the shape trellis-cli's per-command Help() hand-writes ("Usage:
 // trellis deploy [options] ENVIRONMENT [SITE]"); here it's derived, so it
 // can't drift from the arguments the command actually documents.
-func UsageLine(e catalog.Entry, name string) string {
+func UsageLine(e catalog.Entry) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Usage: wp-ops %s", name)
+	fmt.Fprintf(&b, "Usage: wp-ops %s", e.CommandName())
 
 	for _, a := range e.Args {
 		if a.Required {
@@ -74,9 +71,9 @@ func UsageLine(e catalog.Entry, name string) string {
 // to answer "site-url:"). Requires/platform/server-side facts collapse onto
 // one meta line — they used to be per-row tags in the browse list, where
 // they wrapped and broke the column alignment at any realistic pane width.
-func DetailBody(e catalog.Entry, name string) string {
+func DetailBody(e catalog.Entry) string {
 	var b strings.Builder
-	b.WriteString(UsageLine(e, name))
+	b.WriteString(UsageLine(e))
 	b.WriteString("\n\n")
 
 	if e.Description != "" {
@@ -135,13 +132,13 @@ func DetailBody(e catalog.Entry, name string) string {
 // the executor-specific trailer bash appends after it.
 func writeManifestHelpBody(b *strings.Builder, e catalog.Entry) {
 	if !e.Annotated {
-		fmt.Fprintf(b, "Usage: wp-ops %s [args...]\n\n", e.Key)
+		fmt.Fprintf(b, "%s\n\n", UsageLine(e))
 		fmt.Fprintf(b, "Description: %s\n\n", e.Description)
 		fmt.Fprintf(b, "Script: %s\n", e.ScriptPath)
 		return
 	}
 
-	fmt.Fprintf(b, "Usage: wp-ops %s [args...]\n\n", e.Key)
+	fmt.Fprintf(b, "%s\n\n", UsageLine(e))
 
 	if e.Description != "" {
 		fmt.Fprintf(b, "%s\n\n", e.Description)

--- a/go/internal/exec/help_test.go
+++ b/go/internal/exec/help_test.go
@@ -11,6 +11,7 @@ import (
 func helpTestEntry() catalog.Entry {
 	return catalog.Entry{
 		Key:         "scripts/monitoring/404-checker",
+		ShortName:   "404-checker",
 		ScriptPath:  "scripts/monitoring/404-checker.sh",
 		Description: "Check a site's internal links for broken responses",
 		Annotated:   true,
@@ -30,19 +31,22 @@ func helpTestEntry() catalog.Entry {
 // required arguments in angle brackets, optional in square, and a single
 // "[options]" standing in for the flag list rather than spelling it out.
 func TestUsageLine_RequiredAndOptional(t *testing.T) {
-	got := UsageLine(helpTestEntry(), "404-checker")
+	got := UsageLine(helpTestEntry())
 	want := "Usage: wp-ops 404-checker <site-url> [depth] [options]"
 	if got != want {
 		t.Errorf("UsageLine() = %q, want %q", got, want)
 	}
 }
 
-// TestUsageLine_UsesGivenName is the whole reason name is a parameter: the
-// picker shows the basename a user can type, not the internal catalog key.
-func TestUsageLine_UsesGivenName(t *testing.T) {
+// TestUsageLine_FallsBackToKey — a basename shared by two commands has no
+// unambiguous short form (dispatch reports those as ambiguous rather than
+// picking one), so Load leaves ShortName as the full key and the usage line
+// prints something that still resolves.
+func TestUsageLine_FallsBackToKey(t *testing.T) {
 	e := helpTestEntry()
-	if got := UsageLine(e, e.Key); !strings.Contains(got, "wp-ops scripts/monitoring/404-checker ") {
-		t.Errorf("UsageLine() with full key = %q, want it to use the key verbatim", got)
+	e.ShortName = e.Key
+	if got := UsageLine(e); !strings.Contains(got, "wp-ops scripts/monitoring/404-checker ") {
+		t.Errorf("UsageLine() with a colliding basename = %q, want the full key", got)
 	}
 }
 
@@ -50,7 +54,7 @@ func TestUsageLine_UsesGivenName(t *testing.T) {
 // ones taking nothing: both still forward a free-text argv, so the usage
 // line has to say so rather than implying the command accepts no arguments.
 func TestUsageLine_NoDeclaredParams(t *testing.T) {
-	got := UsageLine(catalog.Entry{Key: "mcp-server/dev"}, "dev")
+	got := UsageLine(catalog.Entry{Key: "mcp-server/dev", ShortName: "dev"})
 	want := "Usage: wp-ops dev [args...]"
 	if got != want {
 		t.Errorf("UsageLine() = %q, want %q", got, want)
@@ -67,7 +71,7 @@ func TestUsageLine_NoDeclaredParams(t *testing.T) {
 func TestDetailBody_SectionOrder(t *testing.T) {
 	e := helpTestEntry()
 	e.Examples = []string{"wp-ops 404-checker https://example.com"}
-	body := DetailBody(e, "404-checker")
+	body := DetailBody(e)
 
 	requires := strings.Index(body, "Requires: curl")
 	examples := strings.Index(body, "Examples:")
@@ -92,7 +96,7 @@ func TestDetailBody_MetaLineCarriesRowTags(t *testing.T) {
 	e.Platform = "trellis"
 	e.RunsOn = "server"
 
-	body := DetailBody(e, "404-checker")
+	body := DetailBody(e)
 	for _, want := range []string{"Requires: curl", "Platform: trellis", "Runs on the server"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("DetailBody() missing %q:\n%s", want, body)
@@ -104,7 +108,7 @@ func TestDetailBody_MetaLineCarriesRowTags(t *testing.T) {
 // implementation detail at the moment someone is about to type "site-url:",
 // and the block competes for a bounded number of rows.
 func TestDetailBody_OmitsScriptPath(t *testing.T) {
-	if body := DetailBody(helpTestEntry(), "404-checker"); strings.Contains(body, "404-checker.sh") {
+	if body := DetailBody(helpTestEntry()); strings.Contains(body, "404-checker.sh") {
 		t.Errorf("DetailBody() leaked the script path:\n%s", body)
 	}
 }

--- a/go/internal/exec/help_test.go
+++ b/go/internal/exec/help_test.go
@@ -1,0 +1,110 @@
+package exec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+	"github.com/imagewize/wp-ops/go/internal/manifest"
+)
+
+func helpTestEntry() catalog.Entry {
+	return catalog.Entry{
+		Key:         "scripts/monitoring/404-checker",
+		ScriptPath:  "scripts/monitoring/404-checker.sh",
+		Description: "Check a site's internal links for broken responses",
+		Annotated:   true,
+		Platform:    "any",
+		Requires:    []string{"curl"},
+		Args: []manifest.Param{
+			{Name: "site-url", RequiredRaw: "required", Required: true, Default: "https://example.com", Description: "Site to check"},
+			{Name: "depth", RequiredRaw: "optional", Description: "How deep to crawl"},
+		},
+		Flags: []manifest.Param{
+			{Name: "--mode", RequiredRaw: "optional", Choices: []string{"global", "spider"}, Description: "Crawl mode"},
+		},
+	}
+}
+
+// TestUsageLine_RequiredAndOptional pins the trellis-shaped usage line:
+// required arguments in angle brackets, optional in square, and a single
+// "[options]" standing in for the flag list rather than spelling it out.
+func TestUsageLine_RequiredAndOptional(t *testing.T) {
+	got := UsageLine(helpTestEntry(), "404-checker")
+	want := "Usage: wp-ops 404-checker <site-url> [depth] [options]"
+	if got != want {
+		t.Errorf("UsageLine() = %q, want %q", got, want)
+	}
+}
+
+// TestUsageLine_UsesGivenName is the whole reason name is a parameter: the
+// picker shows the basename a user can type, not the internal catalog key.
+func TestUsageLine_UsesGivenName(t *testing.T) {
+	e := helpTestEntry()
+	if got := UsageLine(e, e.Key); !strings.Contains(got, "wp-ops scripts/monitoring/404-checker ") {
+		t.Errorf("UsageLine() with full key = %q, want it to use the key verbatim", got)
+	}
+}
+
+// TestUsageLine_NoDeclaredParams covers un-annotated commands and annotated
+// ones taking nothing: both still forward a free-text argv, so the usage
+// line has to say so rather than implying the command accepts no arguments.
+func TestUsageLine_NoDeclaredParams(t *testing.T) {
+	got := UsageLine(catalog.Entry{Key: "mcp-server/dev"}, "dev")
+	want := "Usage: wp-ops dev [args...]"
+	if got != want {
+		t.Errorf("UsageLine() = %q, want %q", got, want)
+	}
+}
+
+// TestDetailBody_SectionOrder pins the ordering the picker depends on. The
+// detail viewport is roughly 14 rows and a real command runs past it, so what
+// sits above the fold matters: requirements ("needs curl", "runs on the
+// server") decide whether to run the command at all, and a worked example is
+// the most actionable thing for someone about to type an argument. The
+// exhaustive per-parameter tables are what can afford to scroll — the reverse
+// of --help's ordering, and the same shape trellis-cli's help uses.
+func TestDetailBody_SectionOrder(t *testing.T) {
+	e := helpTestEntry()
+	e.Examples = []string{"wp-ops 404-checker https://example.com"}
+	body := DetailBody(e, "404-checker")
+
+	requires := strings.Index(body, "Requires: curl")
+	examples := strings.Index(body, "Examples:")
+	args := strings.Index(body, "Arguments:")
+	opts := strings.Index(body, "Options:")
+
+	if requires < 0 || examples < 0 || args < 0 || opts < 0 {
+		t.Fatalf("DetailBody() missing a section:\n%s", body)
+	}
+	if !(requires < examples && examples < args && args < opts) {
+		t.Errorf("DetailBody() sections out of order (requires=%d examples=%d args=%d options=%d):\n%s",
+			requires, examples, args, opts, body)
+	}
+}
+
+// TestDetailBody_MetaLineCarriesRowTags covers the facts that moved here
+// when the browse list dropped its per-row "[platform]" and "(server)"
+// tags — they overflowed the row and broke the column alignment, so this
+// block is now the only place they are stated.
+func TestDetailBody_MetaLineCarriesRowTags(t *testing.T) {
+	e := helpTestEntry()
+	e.Platform = "trellis"
+	e.RunsOn = "server"
+
+	body := DetailBody(e, "404-checker")
+	for _, want := range []string{"Requires: curl", "Platform: trellis", "Runs on the server"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("DetailBody() missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestDetailBody_OmitsScriptPath — the script's location on disk is an
+// implementation detail at the moment someone is about to type "site-url:",
+// and the block competes for a bounded number of rows.
+func TestDetailBody_OmitsScriptPath(t *testing.T) {
+	if body := DetailBody(helpTestEntry(), "404-checker"); strings.Contains(body, "404-checker.sh") {
+		t.Errorf("DetailBody() leaked the script path:\n%s", body)
+	}
+}

--- a/go/internal/exec/wpcli_test.go
+++ b/go/internal/exec/wpcli_test.go
@@ -61,7 +61,9 @@ func TestFormatWPCLIHelp_EvalFile(t *testing.T) {
 	help := FormatWPCLIHelp(e, "/srv/www/example.com/current", "")
 
 	for _, want := range []string{
-		"Usage: wp-ops wp-cli/security/scanner-targeted [args...]",
+		// Real positionals under the name a user types, not the catalog key
+		// with an "[args...]" placeholder — see UsageLine.
+		"Usage: wp-ops scanner-targeted [path]",
 		e.Description,
 		"Arguments:",
 		"Requires: wp",

--- a/go/internal/ui/model.go
+++ b/go/internal/ui/model.go
@@ -240,8 +240,7 @@ func (m *Model) syncDetail() {
 	if m.selected.Key == "" {
 		return
 	}
-	body := wrapBlock(
-		wpexec.DetailBody(m.selected, m.displayName(m.selected)), m.detail.Width)
+	body := wrapBlock(wpexec.DetailBody(m.selected), m.detail.Width)
 	m.detail.SetContent(body)
 	m.detail.Height = detailHeight(body, m.viewportHeight())
 	m.detail.YOffset = 0
@@ -293,24 +292,6 @@ func wrapBlock(s string, width int) string {
 	return strings.Join(out, "\n")
 }
 
-// displayName is what to call a command in its usage line: the bare basename
-// a user can type, unless two commands in different categories share it (say
-// a scripts/ and a trellis/ "database-backup"), in which case only the full
-// key is unambiguous — and printing a usage line that would hit dispatch.go's
-// "ambiguous command" error would be worse than printing a longer one.
-func (m Model) displayName(e catalog.Entry) string {
-	base := filepath.Base(e.Key)
-	seen := 0
-	for _, other := range m.all {
-		if filepath.Base(other.Key) == base {
-			seen++
-		}
-	}
-	if seen > 1 {
-		return e.Key
-	}
-	return base
-}
 
 func (m *Model) cursorEntry() int {
 	if m.cursor >= len(m.filtered) {

--- a/go/internal/ui/model.go
+++ b/go/internal/ui/model.go
@@ -73,21 +73,35 @@ var (
 	dimStyle            = lipgloss.NewStyle().Faint(true)
 	cursorStyle         = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("212"))
 	serverTag           = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	platformTag         = lipgloss.NewStyle().Faint(true)
 	errorStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
 	noteStyle           = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	borderedPane        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	footerStyle         = dimStyle
 	categoryHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("245"))
-	minListWidth        = 34
 	minPaneHeight       = 10
+	// Name-column bounds for the browse list. The column sizes to the longest
+	// visible basename so short categories don't get a gutter of dead space,
+	// clamped so a single 40-character outlier can't push every description
+	// off the right edge.
+	minNameWidth = 16
+	maxNameWidth = 30
+	// fallbackWidth stands in for the terminal width until the first
+	// tea.WindowSizeMsg lands, so the opening frame isn't laid out for a
+	// zero-width screen and then reflowed a moment later.
+	fallbackWidth = 100
+	// maxInlineRows caps how tall the picker draws. RunPicker renders inline
+	// (no alt screen), so a picker sized to the full window would shove the
+	// whole scrollback off-screen on launch and leave a window-height frame
+	// behind on exit — the very thing dropping the alt screen was meant to
+	// avoid. 20 rows keeps the list useful while leaving prior output
+	// visible above it, same bargain `fzf --height 40%` makes.
+	maxInlineRows = 20
 )
 
 // Model is the Bubble Tea model backing the interactive picker. It replaces
 // both fzf_menu() and interactive_command_menu() (open decision #3 in
 // docs/m4-go-cli-completion.md): a category-select stage (Phase F, option 3)
-// leading into a filterable, scrollable list with a live preview pane,
-// followed by guided per-field prompting on selection.
+// leading into a filterable list, followed by a full-width help block and
+// guided per-field prompting on selection.
 type Model struct {
 	all      []catalog.Entry
 	filtered []catalog.Entry
@@ -103,7 +117,7 @@ type Model struct {
 	// row in stageCategory.
 	browseCategory string
 
-	preview viewport.Model
+	detail viewport.Model
 
 	stage    stage
 	selected catalog.Entry
@@ -130,7 +144,7 @@ func New(c *catalog.Catalog) Model {
 		all:        c.Entries,
 		categories: buildCategoryOptions(c),
 		stage:      stageCategory,
-		preview:    viewport.New(40, minPaneHeight),
+		detail:     viewport.New(fallbackWidth, minPaneHeight),
 		input:      textinput.New(),
 	}
 	m.input.Prompt = "> "
@@ -174,7 +188,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
-		m.resizePreview()
+		m.resizeDetail()
 		return m, nil
 
 	case tea.KeyMsg:
@@ -190,35 +204,112 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) resizePreview() {
-	listWidth := minListWidth
-	if m.width > 0 {
-		listWidth = m.width * 2 / 5
-		if listWidth < minListWidth {
-			listWidth = minListWidth
-		}
+// viewportHeight is the number of terminal rows the picker allows itself,
+// as opposed to m.height (the rows the terminal has). The two differed not
+// at all under the alt screen, which the picker owned outright; inline it
+// gets a slice, so every height calculation reads this instead of m.height.
+// A zero m.height means no tea.WindowSizeMsg has arrived yet — fall back to
+// the cap rather than to zero, so the first frame isn't drawn at minimum
+// size and then jumped to full size a moment later.
+func (m Model) viewportHeight() int {
+	if m.height <= 0 || m.height > maxInlineRows {
+		return maxInlineRows
 	}
-	previewWidth := m.width - listWidth - 6
-	if previewWidth < 20 {
-		previewWidth = 20
-	}
-	previewHeight := m.height - 6
-	if previewHeight < minPaneHeight {
-		previewHeight = minPaneHeight
-	}
-	m.preview.Width = previewWidth
-	m.preview.Height = previewHeight
-	m.syncPreview()
+	return m.height
 }
 
-func (m *Model) syncPreview() {
-	if len(m.filtered) == 0 {
-		m.preview.SetContent("No matches.")
+// resizeDetail sizes the detail viewport shown on the prompt stages. It gets
+// the full terminal width now that nothing renders beside it — the old
+// two-pane split gave it m.width*3/5 minus borders, which is what truncated
+// flag help mid-word.
+func (m *Model) resizeDetail() {
+	width := m.width
+	if width <= 0 {
+		width = fallbackWidth
+	}
+	m.detail.Width = width
+	m.syncDetail()
+}
+
+// syncDetail loads the selected command's help block into the detail
+// viewport. Unlike the live preview it replaces, this runs once per
+// selection rather than on every cursor move: the block is only shown after
+// Enter, so re-rendering it while the user is still scrolling the list would
+// be work nobody sees.
+func (m *Model) syncDetail() {
+	if m.selected.Key == "" {
 		return
 	}
-	e := m.filtered[m.cursorEntry()]
-	m.preview.SetContent(wpexec.PreviewBody(e))
-	m.preview.YOffset = 0
+	body := wrapBlock(
+		wpexec.DetailBody(m.selected, m.displayName(m.selected)), m.detail.Width)
+	m.detail.SetContent(body)
+	m.detail.Height = detailHeight(body, m.viewportHeight())
+	m.detail.YOffset = 0
+}
+
+// detailHeight sizes the viewport to its content, up to the rows the inline
+// picker can spend. A viewport shorter than its fixed Height still renders
+// the remaining rows as blanks, so a command declaring no arguments used to
+// push the prompt nine empty lines down the screen.
+func detailHeight(body string, budget int) int {
+	// 6 covers the blank line, prompt, and footer rendered beneath it.
+	max := budget - 6
+	if max < minPaneHeight {
+		max = minPaneHeight
+	}
+	if lines := strings.Count(body, "\n") + 1; lines < max {
+		return lines
+	}
+	return max
+}
+
+// wrapBlock soft-wraps a help block to width, hanging-indenting the
+// continuation of any line that was itself indented — so an option whose
+// description runs long stays visibly attached to its "--flag" rather than
+// resuming in column 0 where the next option's name belongs.
+//
+// Wrapping at all is the point: the viewport clips instead, and losing the
+// end of the sentence that explains what an option does is precisely the
+// failure this screen was added to fix.
+func wrapBlock(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		indent := ""
+		if strings.HasPrefix(line, "  ") {
+			indent = "    "
+		}
+		wrapped := lipgloss.NewStyle().Width(width - len(indent)).Render(line)
+		for i, part := range strings.Split(wrapped, "\n") {
+			part = strings.TrimRight(part, " ")
+			if i > 0 {
+				part = indent + strings.TrimLeft(part, " ")
+			}
+			out = append(out, part)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// displayName is what to call a command in its usage line: the bare basename
+// a user can type, unless two commands in different categories share it (say
+// a scripts/ and a trellis/ "database-backup"), in which case only the full
+// key is unambiguous — and printing a usage line that would hit dispatch.go's
+// "ambiguous command" error would be worse than printing a longer one.
+func (m Model) displayName(e catalog.Entry) string {
+	base := filepath.Base(e.Key)
+	seen := 0
+	for _, other := range m.all {
+		if filepath.Base(other.Key) == base {
+			seen++
+		}
+	}
+	if seen > 1 {
+		return e.Key
+	}
+	return base
 }
 
 func (m *Model) cursorEntry() int {
@@ -310,22 +401,12 @@ func (m Model) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor > 0 {
 			m.cursor--
 		}
-		m.syncPreview()
 		return m, nil
 
 	case tea.KeyDown, tea.KeyCtrlN:
 		if m.cursor < len(m.filtered)-1 {
 			m.cursor++
 		}
-		m.syncPreview()
-		return m, nil
-
-	case tea.KeyPgUp:
-		m.preview.HalfViewUp()
-		return m, nil
-
-	case tea.KeyPgDown:
-		m.preview.HalfViewDown()
 		return m, nil
 
 	case tea.KeyBackspace:
@@ -355,7 +436,6 @@ func (m *Model) applyFilter() {
 	m.filtered = filterEntries(pool, string(m.filterQuery))
 	m.cursor = 0
 	m.listTop = 0
-	m.syncPreview()
 }
 
 func filterByCategory(all []catalog.Entry, category string) []catalog.Entry {
@@ -377,6 +457,9 @@ func (m Model) beginPrompting() Model {
 	m.collected = nil
 	m.errMsg = ""
 	m.note = ""
+	// The help block is loaded here, at the moment of selection, rather than
+	// tracked live while browsing — this is the only stage that shows it.
+	m.syncDetail()
 
 	if len(m.fields) == 0 {
 		m.stage = stageFreeText
@@ -414,6 +497,17 @@ func (m Model) updatePrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyEnter:
 		return m.submitPrompt()
+
+	// The help block above the prompt can outrun its viewport for a command
+	// with many options, so keep the scroll keys the browse stage no longer
+	// needs. textinput ignores PgUp/PgDn, so nothing is taken from typing.
+	case tea.KeyPgUp:
+		m.detail.HalfPageUp()
+		return m, nil
+
+	case tea.KeyPgDown:
+		m.detail.HalfPageDown()
+		return m, nil
 	}
 
 	var cmd tea.Cmd
@@ -469,7 +563,13 @@ func (m Model) View() string {
 
 func (m Model) viewCategory() string {
 	var b strings.Builder
-	b.WriteString(headerStyle.Render("wp-ops — interactive picker"))
+	b.WriteString(headerStyle.Render("wp-ops — WordPress Operations Tools"))
+	b.WriteString("\n\n")
+	// Same opening line trellis prints above its command table. The picker
+	// is not the only way in — every row here is also reachable as
+	// `wp-ops <command>` — and without this the screen reads as if arrow
+	// keys were the only interface to 74 commands.
+	b.WriteString(dimStyle.Render("Usage: wp-ops [--help] [--version] <command> [<args>]"))
 	b.WriteString("\n\n")
 
 	for i, opt := range m.categories {
@@ -482,35 +582,53 @@ func (m Model) viewCategory() string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\n" + footerStyle.Render("↑/↓ move · enter select · esc quit"))
+	b.WriteString("\n" + m.footer("↑/↓ move · enter select · esc quit", "↑/↓ · enter · esc"))
 	return b.String()
 }
 
+// viewBrowse renders the command list as a single full-width column — name,
+// then description, the two-column shape trellis prints for its own commands.
+//
+// It used to be a bordered list pane beside a bordered live-preview pane.
+// That layout could not survive its own width arithmetic: rows were built as
+// a 28-column name plus "[platform]" plus "(server)" (~43 columns) and
+// rendered into a pane of m.width*2/5, so on any terminal under ~118 columns
+// lipgloss wrapped every tagged row and the tags landed in the left margin of
+// the next line. The preview pane lost the same fight horizontally, clipping
+// descriptions and flag help mid-word. Both problems were the two panes
+// competing for one terminal's width, so the fix is to stop splitting it:
+// the list gets the full width here, and everything the preview used to show
+// moves to the post-selection detail block (viewPrompt), where it also gets
+// the full width. See docs/trellis-cli-comparison.md §5.
 func (m Model) viewBrowse() string {
-	var list strings.Builder
+	var b strings.Builder
+
 	crumb := "All categories"
 	if m.browseCategory != "" {
 		crumb = catalog.CategoryDisplayNames[m.browseCategory]
 	}
-	fmt.Fprintf(&list, "wp-ops > %s > %s\n\n", crumb, string(m.filterQuery))
+	fmt.Fprintf(&b, "%s > %s > %s\n\n",
+		headerStyle.Render("wp-ops"), crumb, string(m.filterQuery))
 
-	listWidth := minListWidth
-	if m.width > 0 {
-		listWidth = m.width * 2 / 5
-		if listWidth < minListWidth {
-			listWidth = minListWidth
-		}
-	}
-
-	visible := m.height - 8
+	visible := m.viewportHeight() - 6
 	if visible < 5 {
 		visible = 5
 	}
 	start, end := m.scrollWindow(visible)
 
 	if len(m.filtered) == 0 {
-		list.WriteString(dimStyle.Render("No matches."))
+		b.WriteString(dimStyle.Render("No matches."))
+		b.WriteString("\n")
 	}
+
+	nameW := m.nameColumnWidth(start, end)
+	descW := m.width
+	if descW <= 0 {
+		descW = fallbackWidth
+	}
+	// 2 for the cursor gutter, 2 for the gap after the name column.
+	descW -= nameW + 4
+
 	// lastCat starts empty so the window's first visible row always gets a
 	// header, even mid-scroll — reorients the user after paging rather than
 	// assuming they remember which category they scrolled into. Skipped
@@ -520,37 +638,86 @@ func (m Model) viewBrowse() string {
 	for i := start; i < end; i++ {
 		e := m.filtered[i]
 		if m.browseCategory == "" && e.DisplayCategory != lastCat {
-			list.WriteString(categoryHeaderStyle.Render(catalog.CategoryDisplayNames[e.DisplayCategory]))
-			list.WriteString("\n")
+			b.WriteString(categoryHeaderStyle.Render(catalog.CategoryDisplayNames[e.DisplayCategory]))
+			b.WriteString("\n")
 			lastCat = e.DisplayCategory
 		}
-		line := fmt.Sprintf("%-28s", truncate(filepath.Base(e.Key), 28))
-		// Option C2 (docs/category-organization.md): the picker groups by
-		// domain, which puts a Trellis playbook next to a plain-WP script
-		// under the same header — so "will this run against my site" is
-		// precisely the question the row can't otherwise answer. Faint, so
-		// it stays subordinate to (server), which is the louder warning.
-		if e.Platform != "" {
-			line += " " + platformTag.Render("["+e.Platform+"]")
-		}
-		if e.RunsOn == "server" {
-			line += " " + serverTag.Render("(server)")
-		}
+
+		name := truncate(filepath.Base(e.Key), nameW)
+		row := fmt.Sprintf("%-*s  %s", nameW, name, m.describeRow(e, descW))
 		if i == m.cursorEntry() {
-			list.WriteString(cursorStyle.Render("> " + line))
+			b.WriteString(cursorStyle.Render("> " + row))
 		} else {
-			list.WriteString("  " + line)
+			b.WriteString("  " + row)
 		}
-		list.WriteString("\n")
+		b.WriteString("\n")
 	}
 
-	listPane := borderedPane.Width(listWidth).Render(list.String())
-	previewPane := borderedPane.Render(m.preview.View())
+	b.WriteString("\n")
+	b.WriteString(m.footer(
+		"type to filter · ↑/↓ move · enter select · esc back · ctrl+c quit",
+		"↑/↓ · enter · esc back"))
+	return b.String()
+}
 
-	body := lipgloss.JoinHorizontal(lipgloss.Top, listPane, previewPane)
-	footer := footerStyle.Render("type to filter · ↑/↓ move · pgup/pgdn scroll preview · enter run · esc back · ctrl+c quit")
+// footer renders the key hints, falling back to an abbreviated form when the
+// full one would wrap. A wrapped footer is the same class of defect the row
+// layout was rewritten to remove — hints spilling into the next line read as
+// broken output, not as a dense terminal UI.
+func (m Model) footer(full, short string) string {
+	width := m.width
+	if width <= 0 {
+		width = fallbackWidth
+	}
+	hints := full
+	if len([]rune(hints)) > width {
+		hints = short
+	}
+	return footerStyle.Render(truncate(hints, width))
+}
 
-	return headerStyle.Render("wp-ops — interactive picker") + "\n" + body + "\n" + footer
+// describeRow renders a row's description column, right-aligning the
+// "(server)" warning within it when the width allows. Platform ("[trellis]",
+// "[wordpress]") deliberately no longer appears per row: it was the quietest
+// signal on the screen and the one most responsible for overflowing the row,
+// and DetailBody now states it in full a keystroke later, before anything
+// runs. "(server)" stays because "this will not run against your local site"
+// is worth knowing while still scanning the list.
+func (m Model) describeRow(e catalog.Entry, width int) string {
+	tag := ""
+	if e.RunsOn == "server" {
+		tag = " (server)"
+	}
+	descW := width - len(tag)
+	if descW < 12 {
+		// Too narrow to carry both; the description wins.
+		descW, tag = width, ""
+	}
+	if descW < 1 {
+		return ""
+	}
+	desc := fmt.Sprintf("%-*s", descW, truncate(e.Description, descW))
+	if tag == "" {
+		return strings.TrimRight(desc, " ")
+	}
+	return desc + serverTag.Render(tag)
+}
+
+// nameColumnWidth sizes the name column to the longest basename actually on
+// screen, within [minNameWidth, maxNameWidth]. Measuring the visible window
+// rather than the whole catalog keeps a narrow category (say Sync, whose
+// longest name is 11 characters) from inheriting Monitoring's gutter.
+func (m Model) nameColumnWidth(start, end int) int {
+	w := minNameWidth
+	for i := start; i < end && i < len(m.filtered); i++ {
+		if n := len(filepath.Base(m.filtered[i].Key)); n > w {
+			w = n
+		}
+	}
+	if w > maxNameWidth {
+		w = maxNameWidth
+	}
+	return w
 }
 
 // scrollWindow keeps the cursor within a `visible`-row window over the
@@ -572,28 +739,37 @@ func (m Model) scrollWindow(visible int) (start, end int) {
 	return start, end
 }
 
+// truncate shortens s to at most n display cells, ellipsizing when it cuts.
+// Counts runes rather than bytes: descriptions now fill the width the preview
+// pane used to occupy, so they get truncated far more often than the old
+// 28-column name field ever was, and a byte-indexed cut through the em dash
+// several of them contain would emit a partial rune.
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	return string(r[:n-1]) + "…"
 }
 
+// viewPrompt renders the chosen command's full help block above the argument
+// prompt: usage line, description, arguments, options, requirements — the
+// shape `trellis <command> --help` prints, at full terminal width. Showing it
+// here rather than in a preview pane during browsing is what lets the browse
+// list be a plain list, and means the help is on screen at the moment it's
+// actually needed: while typing the values it documents.
 func (m Model) viewPrompt() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\n", headerStyle.Render(m.selected.Key))
-	if m.selected.Description != "" {
-		fmt.Fprintf(&b, "%s\n", dimStyle.Render(m.selected.Description))
-	}
-	b.WriteString("\n")
 
-	if m.stage == stageFields {
-		f := m.fields[m.fieldIdx]
-		if f.param.Description != "" {
-			fmt.Fprintf(&b, "  %s\n", dimStyle.Render(f.param.Description))
-		}
-	}
+	b.WriteString(m.detail.View())
+	b.WriteString("\n\n")
 
+	// No per-field description line here any more: it repeated verbatim what
+	// the Arguments/Options block two lines above already says, which was
+	// tolerable when the prompt screen showed nothing but the command name.
 	b.WriteString(m.input.View())
 	b.WriteString("\n")
 
@@ -604,6 +780,10 @@ func (m Model) viewPrompt() string {
 		fmt.Fprintf(&b, "\n%s\n", noteStyle.Render(m.note))
 	}
 
-	b.WriteString("\n" + footerStyle.Render("enter confirm · esc back to list · ctrl+c quit"))
+	full := "enter confirm · esc back to list · ctrl+c quit"
+	if m.detail.TotalLineCount() > m.detail.Height {
+		full = "pgup/pgdn scroll help · " + full
+	}
+	b.WriteString("\n" + m.footer(full, "enter · esc back"))
 	return b.String()
 }

--- a/go/internal/ui/model_test.go
+++ b/go/internal/ui/model_test.go
@@ -26,9 +26,9 @@ func testCatalogEntries() []catalog.Entry {
 // path without the real embedded catalog.
 func newTestCategoryModel() Model {
 	return Model{
-		all:     testCatalogEntries(),
-		stage:   stageCategory,
-		preview: viewport.New(40, 10),
+		all:    testCatalogEntries(),
+		stage:  stageCategory,
+		detail: viewport.New(fallbackWidth, minPaneHeight),
 	}
 }
 

--- a/go/internal/ui/picker.go
+++ b/go/internal/ui/picker.go
@@ -13,9 +13,19 @@ import (
 // can run the selected command with the picker's terminal control released
 // first — same reasoning as fzf_menu exiting before execute_command runs
 // (wp-ops:1993-1997).
+//
+// Deliberately *not* tea.WithAltScreen: the picker renders inline, in the
+// terminal's primary buffer, the way `fzf --height` does. The alternate
+// screen buffer keeps no scrollback of its own and discards everything
+// drawn in it on exit, which is what made a bare `wp-ops` read as "a
+// separate prompt" rather than a command that printed something — see
+// docs/trellis-cli-comparison.md §1, where `trellis`'s staying-in-the-
+// buffer behavior is the whole difference being closed. Inline rendering
+// is why Model caps its own height at maxInlineRows instead of filling
+// the window (model.go's viewportHeight).
 func RunPicker(c *catalog.Catalog) (Result, error) {
 	m := New(c)
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m)
 	final, err := p.Run()
 	if err != nil {
 		return Result{}, err

--- a/go/internal/ui/view_test.go
+++ b/go/internal/ui/view_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+
+	"github.com/imagewize/wp-ops/go/internal/catalog"
+)
+
+func browseModel(width int, entries []catalog.Entry) Model {
+	m := Model{
+		all:      entries,
+		filtered: entries,
+		stage:    stageBrowse,
+		width:    width,
+		height:   40,
+		detail:   viewport.New(width, minPaneHeight),
+	}
+	return m
+}
+
+func longRowEntries() []catalog.Entry {
+	return []catalog.Entry{
+		{Key: "scripts/monitoring/updown-webhook-handler", DisplayCategory: "monitoring", RunsOn: "server", Platform: "trellis",
+			Description: "Analyze Nginx logs on the server when updown.io reports downtime for a site"},
+		{Key: "scripts/monitoring/ttfb-test", DisplayCategory: "monitoring", Platform: "any",
+			Description: "Measure TTFB for a URL over several requests and write a report"},
+	}
+}
+
+// TestViewBrowse_RowsFitTerminalWidth is the regression test for the layout
+// bug this view was rewritten to fix. Rows used to be built as a 28-column
+// name plus "[platform]" plus "(server)" — about 43 columns — and rendered
+// into a pane of m.width*2/5, so on any terminal narrower than ~118 columns
+// lipgloss wrapped every tagged row and the tags landed in the left margin
+// of the following line. No row may exceed the terminal width, at any width.
+func TestViewBrowse_RowsFitTerminalWidth(t *testing.T) {
+	for _, width := range []int{60, 80, 100, 140} {
+		m := browseModel(width, longRowEntries())
+		for _, line := range strings.Split(m.viewBrowse(), "\n") {
+			if n := len([]rune(stripANSI(line))); n > width {
+				t.Errorf("width %d: row of %d cells overflows:\n%q", width, n, line)
+			}
+		}
+	}
+}
+
+// TestViewBrowse_ServerTagSurvivesNarrowTerminal — "(server)" is the one row
+// tag kept from the old layout, because "this will not run against your
+// local site" is worth knowing while still scanning the list. It has to
+// still be there at a normal width, and it has to yield to the description
+// rather than overflow when the terminal is too narrow for both.
+func TestViewBrowse_ServerTagSurvivesNarrowTerminal(t *testing.T) {
+	if out := browseModel(100, longRowEntries()).viewBrowse(); !strings.Contains(out, "(server)") {
+		t.Errorf("viewBrowse() at 100 cols dropped the (server) tag:\n%s", out)
+	}
+
+	m := browseModel(30, longRowEntries())
+	for _, line := range strings.Split(m.viewBrowse(), "\n") {
+		if n := len([]rune(stripANSI(line))); n > 30 {
+			t.Errorf("width 30: row of %d cells overflows:\n%q", n, line)
+		}
+	}
+}
+
+// TestViewBrowse_NoPlatformTag pins the deliberate removal: platform was the
+// quietest signal on the screen and the one most responsible for overflowing
+// the row. DetailBody states it a keystroke later, before anything runs.
+func TestViewBrowse_NoPlatformTag(t *testing.T) {
+	out := browseModel(140, longRowEntries()).viewBrowse()
+	for _, tag := range []string{"[trellis]", "[any]", "[wordpress]"} {
+		if strings.Contains(out, tag) {
+			t.Errorf("viewBrowse() still renders the %s row tag:\n%s", tag, out)
+		}
+	}
+}
+
+// TestNameColumnWidth_SizesToVisibleRows keeps a narrow category from
+// inheriting the widest category's gutter, while clamping so one long
+// outlier can't push every description off the right edge.
+func TestNameColumnWidth_SizesToVisibleRows(t *testing.T) {
+	short := []catalog.Entry{{Key: "scripts/sync/rsync-theme"}}
+	if got := browseModel(100, short).nameColumnWidth(0, 1); got != minNameWidth {
+		t.Errorf("nameColumnWidth() with a short name = %d, want the %d floor", got, minNameWidth)
+	}
+
+	long := []catalog.Entry{{Key: "scripts/misc/" + strings.Repeat("x", 60)}}
+	if got := browseModel(100, long).nameColumnWidth(0, 1); got != maxNameWidth {
+		t.Errorf("nameColumnWidth() with a 60-char name = %d, want the %d ceiling", got, maxNameWidth)
+	}
+}
+
+// TestWrapBlock_HangingIndent — an option whose description runs long must
+// stay visibly attached to its "--flag" instead of resuming in column 0,
+// where the next option's name belongs.
+func TestWrapBlock_HangingIndent(t *testing.T) {
+	in := "Options:\n  --mode             optional  " + strings.Repeat("word ", 30)
+	lines := strings.Split(wrapBlock(in, 60), "\n")
+
+	if len(lines) < 3 {
+		t.Fatalf("wrapBlock() did not wrap: %q", lines)
+	}
+	for i, line := range lines[2:] {
+		if !strings.HasPrefix(line, "    ") {
+			t.Errorf("continuation line %d lacks the hanging indent: %q", i+2, line)
+		}
+	}
+}
+
+// TestWrapBlock_NoTruncation is the point of wrapping at all: the viewport
+// clips instead, and losing the end of the sentence explaining what an
+// option does is the failure the detail block exists to fix.
+func TestWrapBlock_NoTruncation(t *testing.T) {
+	in := "  --output           optional  Append broken-link results to this file"
+	out := wrapBlock(in, 40)
+	if strings.Contains(out, "…") {
+		t.Errorf("wrapBlock() truncated instead of wrapping: %q", out)
+	}
+	if !strings.Contains(strings.Join(strings.Fields(out), " "), "results to this file") {
+		t.Errorf("wrapBlock() lost the end of the line: %q", out)
+	}
+}
+
+// TestDetailHeight_ShrinksToContent — a viewport shorter than its fixed
+// Height still renders the remaining rows as blanks, so a command declaring
+// no arguments used to push the prompt nine empty lines down the screen.
+func TestDetailHeight_ShrinksToContent(t *testing.T) {
+	short := "one\ntwo\nthree"
+	if got := detailHeight(short, maxInlineRows); got != 3 {
+		t.Errorf("detailHeight(3-line body) = %d, want 3", got)
+	}
+
+	long := strings.Repeat("line\n", 40)
+	if got := detailHeight(long, maxInlineRows); got != maxInlineRows-6 {
+		t.Errorf("detailHeight(40-line body) = %d, want the %d budget", got, maxInlineRows-6)
+	}
+}
+
+// TestTruncate_RuneAware — descriptions now fill the width the preview pane
+// used to occupy, so they get truncated far more often than the old
+// 28-column name field ever was, and several contain an em dash that a
+// byte-indexed cut would split into a partial rune.
+func TestTruncate_RuneAware(t *testing.T) {
+	got := truncate("backups — Ansible and shell", 12)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate() = %q, want an ellipsis", got)
+	}
+	if n := len([]rune(got)); n != 12 {
+		t.Errorf("truncate() returned %d runes, want 12: %q", n, got)
+	}
+	if strings.ContainsRune(got, '�') {
+		t.Errorf("truncate() split a multi-byte rune: %q", got)
+	}
+}
+
+// stripANSI removes lipgloss's color escapes so row widths can be measured
+// in the cells a terminal actually paints.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}


### PR DESCRIPTION
`wp-ops` with no arguments took over the terminal and showed three things at once. `trellis` stays in your buffer and shows one. This closes that gap without giving up the picker — 74 commands is past what an alphabetical list serves.

Written up in `docs/trellis-cli-comparison.md`, verified against `trellis-cli` rather than inferred.

## The entry point

The picker no longer passes `tea.WithAltScreen()`. The alternate screen buffer keeps no scrollback of its own and discards everything drawn in it on exit, which is what made a bare `wp-ops` read as a separate prompt rather than as a command that printed something. It now renders in the primary buffer, capped at 20 rows — sized to the full window it would shove the scrollback off-screen on launch and leave a window-height frame behind on exit, reintroducing the problem from the other direction.

## The layout

The browse list is a single full-width column. The old two-pane layout could not survive its own width arithmetic: rows were a 28-column name plus `[platform]` plus `(server)` — about 43 columns — rendered into a pane of `width * 2/5`, so on any terminal narrower than ~118 columns every tagged row wrapped and its tags landed in the next line's left margin. The preview pane lost the same fight horizontally, clipping flag help mid-word (`Append broken-link resu`). Both were the two panes competing for one terminal's width, so neither splits it now.

Command details moved to a post-selection block at full width — usage, description, requirements, examples, arguments, options — directly above the argument prompts, which is when the information is actually needed. Requirements and examples precede the parameter tables, as `trellis alias --help` orders them: the block runs past its viewport for a real command, so what sits above the fold should be what decides whether and how to run it. Long option help soft-wraps with a hanging indent instead of being clipped.

## Usage lines

`wp-ops db-backup --help` answered `Usage: wp-ops scripts/backup/db-backup [args...]` — an internal key carrying directory separators no user types, and a placeholder where the manifest already knew the positional names printed three lines below. Now:

```
Usage: wp-ops db-backup [site-name] [environment] [options]   (shell)
Usage: wp-ops database-backup <site> <env>                    (Ansible playbook)
Usage: wp-ops scanner-targeted [path]                         (WP-CLI PHP)
Usage: wp-ops dev [args...]                                   (un-annotated Node)
```

Derived from the same `@arg`/`@flag` data, so it cannot drift from what the command documents. The name comes from a new `Entry.ShortName`, computed by `catalog.Load` rather than stored in `catalog.json` — it is a property of the catalog as a whole, so persisting it would let it go stale the moment a colliding command is added. A shared basename has no unambiguous short form, so those keep the full key and the line stays something that resolves if pasted back (`convert-to-webp` is the catalog's only collision).

## Testing

`go build`, `go vet`, `go test ./go/...` pass. New coverage:

- `go/internal/ui/view_test.go` — row overflow at 30/60/80/100/140 columns (the regression test for the wrapping bug), no platform tag, hanging-indent wrapping, viewport height, rune-safe truncation
- `go/internal/exec/help_test.go` — usage-line shapes, ambiguity fallback, section ordering
- `go/internal/catalog/catalog_test.go` — every `ShortName` resolves to exactly one command or is a genuine collision

Two existing tests pinned the old `[args...]` placeholder and now assert the real usage line.

Verified by hand in Warp across all three stages and at narrow widths.

## Still open

`docs/trellis-cli-comparison.md` §5 rough edge #2: no deprecation channel. The hidden directory aliases (`wp-ops trellis <playbook>`) are invisible rather than labelled, where trellis segregates deprecated commands into their own help block.