### PR TITLE
Rename the WebP converters and correct README drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.1.1] - 2026-08-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The two `convert-to-webp` commands were renamed to `jpg-to-webp` and
+  `png-to-webp`**, in `scripts/images/` and `scripts/patterns/` respectively.
+  They were the catalog's only basename collision, which meant they were the
+  only two commands `wp-ops <name>` could not resolve and the only two whose
+  usage line still printed a full key with directory separators
+  (`Usage: wp-ops scripts/patterns/convert-to-webp [input-file] [options]`) —
+  5.1.0's short-name work correctly declines to abbreviate an ambiguous name.
+  Renaming removes the ambiguity at its source rather than teaching the CLI to
+  paper over it, and the new names say which format each one consumes, which
+  the shared name never did: one center-crops a JPG to the Facebook OG ratio
+  via `cwebp`, the other batch-converts `pattern-*.png` screenshots via
+  `sharp`. Every basename in the catalog is now unique, so every usage line
+  names a command that resolves if pasted back.
+
+  Callers and docs were updated with them (`screenshot-patterns.sh`, both
+  `README.md` files, `docs/nginx/image-optimization/RESIZE-AND-CONVERSION.md`).
+  Any script invoking the old filenames needs the same rename.
+
 ## [5.1.0] - 2026-08-05
 
 The interactive picker stops behaving like a separate application. It renders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `README.md` files, `docs/nginx/image-optimization/RESIZE-AND-CONVERSION.md`).
   Any script invoking the old filenames needs the same rename.
 
+### Fixed
+
+- **`README.md` documented a `bedrock` category that no longer exists.** 5.0.0
+  moved that tree under `docs/` and dropped `bedrock` from `catalog.Categories`,
+  so the documented `wp-ops bedrock wp-cli-pattern-validate …` answered
+  `Unknown command or category: bedrock`. The command itself was never removed —
+  it lives under `wp-cli/content-creation/` and resolves as
+  `wp-ops wp-cli-pattern-validate`.
+
+- **`README.md` still described the picker's live preview pane**, which 5.1.0
+  deleted. Details print as a post-selection block above the argument prompts
+  now, and the picker renders inline rather than taking over the screen.
+
+- **Three stale counts in `README.md`**: nine backup commands (ten since
+  `wp-db-backup`), 39 scripts (42), and five MCP tools (six — `url_audit` was
+  missing from the list, though `mcp-server/README.md` already documented it).
+  The intro also still said commands group "by subdirectory", which the
+  paragraph twenty-five lines below it contradicted with the domain grouping
+  5.0.0 introduced.
+
 ## [5.1.0] - 2026-08-05
 
 The interactive picker stops behaving like a separate application. It renders

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This is a collection of tools, scripts, and documentation for WordPress operatio
     - `scripts/sync/rsync-theme.sh` - Theme synchronization
   - `scripts/images/` - Image resizing and conversion
     - `scripts/images/batch-resize.sh` - Batch image resize with center-crop
-    - `scripts/images/convert-to-webp.sh` - Convert JPG images to WebP format
+    - `scripts/images/jpg-to-webp.sh` - Convert JPG images to WebP format
   - `scripts/patterns/` - WordPress block pattern screenshot toolkit (Playwright + sharp)
     - `scripts/patterns/screenshot-patterns.sh` - Create temp WP page, screenshot pattern, delete page, convert to WebP
   - `scripts/misc/` - Miscellaneous utilities

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ wp-ops is a CLI for WordPress operations — deployments, database and files bac
 
 ## wp-ops CLI
 
-The single entry point for everything in this repo — a single binary that auto-discovers commands across every category, groups them by subdirectory, and renders real `--help`, guided prompts, and shell completions from each command's manifest.
+The single entry point for everything in this repo — a single binary that auto-discovers commands across every category, groups them by domain, and renders real `--help`, guided prompts, and shell completions from each command's manifest.
 
 ```bash
 # Recommended: Homebrew
@@ -46,7 +46,7 @@ wp-ops doctor                # check dependencies and environment
 wp-ops <command> --where     # print the path to a command's script
 ```
 
-Categories group by **domain**, not by directory: `wp-ops backup` lists all nine
+Categories group by **domain**, not by directory: `wp-ops backup` lists all ten
 backup commands whether they're Ansible playbooks under `trellis/` or shell scripts
 under `scripts/`. The directory names still work as aliases (`wp-ops trellis
 database-backup`), they're just no longer how the catalog presents itself.
@@ -59,7 +59,7 @@ in front of you.
 
 The scripts, playbooks, and guides are embedded in the binary, so once it's on your PATH nothing else needs to stay around — you can delete the clone after building.
 
-`wp-ops` with no arguments opens an interactive picker: categories first, then a fuzzy-filterable command list with a live preview pane (usage, args, examples) — no `fzf` dependency.
+`wp-ops` with no arguments opens an interactive picker: categories first, then a fuzzy-filterable command list, then the chosen command's full help (usage, requirements, examples, args) printed above its argument prompts — no `fzf` dependency. It renders inline rather than taking over the screen, so earlier output stays visible above it and the last frame stays in your scrollback after it exits.
 
 Run `wp-ops doctor` first — it reports which of the external tools these scripts rely on (WP-CLI, Ansible, ImageMagick, `gh`, `cwebp`, Node, …) are actually installed, so you find out before a command fails partway through.
 
@@ -77,10 +77,10 @@ no prompt to confirm a detected guess:
 export TRELLIS_DIR=/path/to/your/trellis
 wp-ops trellis database-backup -e site=example.com -e env=production
 
-# WP-CLI scripts (wp-ops wp-cli|bedrock <script>) need a real WordPress/Bedrock install
+# WP-CLI scripts (wp-ops wp-cli <script>) need a real WordPress/Bedrock install
 export WP_SITE_DIR=/path/to/your/bedrock-site
 wp-ops wp-cli scanner-wrapper
-wp-ops bedrock wp-cli-pattern-validate web/app/themes/your-theme/patterns/ --fix
+wp-ops wp-cli-pattern-validate web/app/themes/your-theme/patterns/ --fix
 ```
 
 Detection deliberately only matches a project you're actually standing inside, so an
@@ -157,7 +157,7 @@ cat "$(wp-ops docs -l age-verification | head -1)"
 
 ## Scripts
 
-39 standalone Bash/PHP/Python/Node utilities — full docs, flags, and examples in [scripts/README.md](scripts/README.md).
+42 standalone Bash/PHP/Python/Node utilities — full docs, flags, and examples in [scripts/README.md](scripts/README.md).
 
 | Category | Includes | Docs |
 |------|-------------|------|
@@ -169,7 +169,7 @@ cat "$(wp-ops docs -l age-verification | head -1)"
 
 ## MCP Server
 
-Exposes wp-ops operations as [MCP](https://modelcontextprotocol.io) tools, so Claude (and other MCP-compatible clients) can call them directly instead of running the underlying scripts by hand. Scaffold stage — five tools so far (`security_scan`, `db_backup`, `wp_cli`, `redirect_audit`, `schema_audit`), more planned. See [mcp-server/README.md](mcp-server/README.md) for tool details, setup, transports (stdio/Streamable HTTP), and Docker usage.
+Exposes wp-ops operations as [MCP](https://modelcontextprotocol.io) tools, so Claude (and other MCP-compatible clients) can call them directly instead of running the underlying scripts by hand. Scaffold stage — six tools so far (`security_scan`, `db_backup`, `wp_cli`, `redirect_audit`, `schema_audit`, `url_audit`), more planned. See [mcp-server/README.md](mcp-server/README.md) for tool details, setup, transports (stdio/Streamable HTTP), and Docker usage.
 
 ## WordPress Utilities
 

--- a/docs/nginx/image-optimization/RESIZE-AND-CONVERSION.md
+++ b/docs/nginx/image-optimization/RESIZE-AND-CONVERSION.md
@@ -224,22 +224,22 @@ This approach:
 - Converts to WebP in one step
 - No intermediate files created
 
-### Using the convert-to-webp.sh Script
+### Using the jpg-to-webp.sh Script
 
-For convenience, use the [`scripts/images/convert-to-webp.sh`](../../../scripts/images/convert-to-webp.sh) script which wraps this workflow:
+For convenience, use the [`scripts/images/jpg-to-webp.sh`](../../../scripts/images/jpg-to-webp.sh) script which wraps this workflow:
 
 ```bash
 # Basic usage (800x419 default, 1.91:1 aspect ratio for Facebook OG)
-./scripts/images/convert-to-webp.sh input.jpg
+./scripts/images/jpg-to-webp.sh input.jpg
 
 # Custom output filename
-./scripts/images/convert-to-webp.sh input.jpg featured-image.webp
+./scripts/images/jpg-to-webp.sh input.jpg featured-image.webp
 
 # Custom dimensions and quality
-./scripts/images/convert-to-webp.sh input.jpg featured-image.webp 90 1200 630
+./scripts/images/jpg-to-webp.sh input.jpg featured-image.webp 90 1200 630
 ```
 
-See the [scripts README](../../../scripts/README.md#convert-to-webpsh) for full documentation.
+See the [scripts README](../../../scripts/README.md#jpg-to-webpsh) for full documentation.
 
 ## Converting to AVIF
 

--- a/docs/wp-ops-recommendations.md
+++ b/docs/wp-ops-recommendations.md
@@ -26,7 +26,7 @@ Back up a Trellis site database with WP-CLI, gzip it, and prune backups older th
 Bare-basename resolution across the whole catalog already exists in both CLIs —
 bash `wp-ops:2262-2281`, Go `go/cmd/root.go:95-104` — with ambiguity detection and
 did-you-mean suggestions. Every script the earlier draft proposed annotating
-(`db-backup`, `site-backup`, `batch-resize`, `convert-to-webp`,
+(`db-backup`, `site-backup`, `batch-resize`, `jpg-to-webp`,
 `make-square-webp`, `page-creation`) already resolves by short name.
 
 `@key` would also have registered each alias as a second `COMMAND_FILE` entry,
@@ -192,7 +192,7 @@ should stay where they are.
 | `traffic-analysis.sh` | imagewize.com | **Skip** — superseded by `scripts/monitoring/traffic-monitor.sh` |
 | `backup-db.sh` | imagewize.com | **Skip** — superseded by `scripts/backup/db-backup.sh` |
 | `capture-pattern-screenshots*.sh`, `center-*`, `trim-*` | imagewize.com | **Skip** — superseded by `scripts/patterns/screenshot-patterns.sh` |
-| `convert-images.sh` | imagewize.com | **Skip** — theme-specific; `scripts/images/convert-to-webp.sh` covers it |
+| `convert-images.sh` | imagewize.com | **Skip** — theme-specific; `scripts/images/jpg-to-webp.sh` covers it |
 | `sync-min.sh` | imagewize.com | **Skip** — specific to the `min` package checkout; `bedrock/local-package-development/` documents the general pattern |
 | `run-remote-audits.sh`, `init-client-repo.sh` | seo-strategy | **Skip** — workflow glue tied to the seo-strategy repo layout |
 

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -479,9 +479,9 @@
   },
   {
     "category": "scripts",
-    "key": "scripts/images/convert-to-webp",
+    "key": "scripts/images/jpg-to-webp",
     "description": "Convert a JPG to WebP with center-crop (Facebook OG ratio by default)",
-    "script_path": "scripts/images/convert-to-webp.sh",
+    "script_path": "scripts/images/jpg-to-webp.sh",
     "runs_on": "local",
     "runs": "local",
     "requires": [
@@ -530,7 +530,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/images/convert-to-webp input.jpg output.webp 82 800 419"
+      "wp-ops jpg-to-webp input.jpg output.webp 82 800 419"
     ],
     "manifest_category": "images",
     "platform": "any",
@@ -1731,9 +1731,9 @@
   },
   {
     "category": "scripts",
-    "key": "scripts/patterns/convert-to-webp",
+    "key": "scripts/patterns/png-to-webp",
     "description": "Convert PNG pattern screenshots to WebP using sharp",
-    "script_path": "scripts/patterns/convert-to-webp.js",
+    "script_path": "scripts/patterns/png-to-webp.js",
     "runs_on": "local",
     "runs": "local",
     "requires": [
@@ -1791,7 +1791,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/patterns/convert-to-webp --all --dir=./screenshots --quality=90"
+      "wp-ops png-to-webp --all --dir=./screenshots --quality=90"
     ],
     "manifest_category": "content",
     "platform": "any",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ scripts/
 │   └── git-log-oneline.sh      # Show recent git commits as one-liners
 ├── images/                      # Image resizing and conversion
 │   ├── batch-resize.sh         # Batch resize and center-crop images for featured images
-│   ├── convert-to-webp.sh      # JPG to WebP conversion with center-crop (Facebook OG)
+│   ├── jpg-to-webp.sh          # JPG to WebP conversion with center-crop (Facebook OG)
 │   ├── make-square-webp.sh     # Pad an image onto a square canvas and export as WebP
 │   ├── openverse_search.py     # Search Openverse for CC-licensed images
 │   ├── openverse_download.py   # Download Openverse image URLs, optionally converting to WebP
@@ -58,7 +58,7 @@ scripts/
 ├── patterns/                    # WordPress block pattern screenshot toolkit
 │   ├── screenshot-patterns.sh  # End-to-end: create temp WP page, screenshot, delete, convert to WebP
 │   ├── screenshot-url.js       # Generic Playwright URL/element screenshot primitive
-│   ├── convert-to-webp.js      # Sharp-based PNG to WebP converter
+│   ├── png-to-webp.js          # Sharp-based PNG to WebP converter
 │   ├── trim-screenshots.sh     # Trim whitespace from a directory of pattern screenshots (ImageMagick)
 │   ├── center-screenshots.sh   # Center screenshots on a fixed canvas (ImageMagick)
 │   └── README.md               # Setup and usage docs
@@ -95,7 +95,7 @@ scripts/
 ./scripts/woocommerce/create-product-variations.sh
 
 # Convert JPG to WebP for Facebook OG / featured image (800x419, center crop)
-./scripts/images/convert-to-webp.sh image.jpg
+./scripts/images/jpg-to-webp.sh image.jpg
 
 # Pad an image onto a square canvas and export as WebP
 ./scripts/images/make-square-webp.sh logo.png logo-square.webp
@@ -296,7 +296,7 @@ Processing 3/3: screenshot3.png
 Batch resize complete. Processed 3 file(s).
 ```
 
-### convert-to-webp.sh
+### jpg-to-webp.sh
 
 Converts a JPG to WebP at 800×419 (1.91:1 Facebook Open Graph ratio) using a center crop so non-standard source images aren't distorted. Quality and dimensions are configurable.
 
@@ -311,13 +311,13 @@ sudo apt-get install imagemagick webp  # Ubuntu/Debian
 
 ```bash
 # Defaults: 800x419, quality 82
-./scripts/images/convert-to-webp.sh featured.jpg
+./scripts/images/jpg-to-webp.sh featured.jpg
 
 # Custom output filename
-./scripts/images/convert-to-webp.sh featured.jpg hero.webp
+./scripts/images/jpg-to-webp.sh featured.jpg hero.webp
 
 # Custom quality and dimensions
-./scripts/images/convert-to-webp.sh featured.jpg hero.webp 90 1200 630
+./scripts/images/jpg-to-webp.sh featured.jpg hero.webp 90 1200 630
 ```
 
 #### Output
@@ -435,7 +435,7 @@ brew install imagemagick   # only needed for trim-screenshots.sh / center-screen
   Trellis VM, or a remote server over SSH.
 - **`screenshot-url.js`** — the generic Playwright capture primitive underneath it;
   screenshots any URL (element selector or full page), independent of WordPress.
-- **`convert-to-webp.js`** — standalone sharp-based PNG → WebP converter, single file
+- **`png-to-webp.js`** — standalone sharp-based PNG → WebP converter, single file
   or `--all` batch mode.
 - **`trim-screenshots.sh`** / **`center-screenshots.sh`** — ImageMagick post-processing
   for a directory of `pattern-*.webp` files (trim whitespace, or trim + center on a

--- a/scripts/images/jpg-to-webp.sh
+++ b/scripts/images/jpg-to-webp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # JPG to WebP conversion with center-crop, for Facebook OG-ratio featured images
 #
-# Usage: ./convert-to-webp.sh <input.jpg> [output.webp] [quality] [width] [height]
+# Usage: ./jpg-to-webp.sh <input.jpg> [output.webp] [quality] [width] [height]
 #
 # @desc     Convert a JPG to WebP with center-crop (Facebook OG ratio by default)
 # @category images
@@ -13,7 +13,7 @@
 # @arg      quality optional  {82}  WebP quality
 # @arg      width   optional  {800}  Output width
 # @arg      height  optional  {419}  Output height
-# @example  wp-ops scripts/images/convert-to-webp input.jpg output.webp 82 800 419
+# @example  wp-ops jpg-to-webp input.jpg output.webp 82 800 419
 set -e
 
 INPUT="${1:-}"

--- a/scripts/patterns/README.md
+++ b/scripts/patterns/README.md
@@ -67,15 +67,15 @@ node screenshot-url.js http://example.test/pattern/ --out=pattern.png \
   --selector=".my-pattern-wrapper,.entry-content > *:first-child"
 ```
 
-### convert-to-webp.js
+### png-to-webp.js
 
 Standalone PNG → WebP converter (sharp-based), used by `screenshot-patterns.sh` but
 usable on its own for any directory of screenshots.
 
 ```bash
-node convert-to-webp.js pattern-hero-dark.png
-node convert-to-webp.js --all --dir=./screenshots
-node convert-to-webp.js --all --dir=./screenshots --output-dir=./webp --quality=90
+node png-to-webp.js pattern-hero-dark.png
+node png-to-webp.js --all --dir=./screenshots
+node png-to-webp.js --all --dir=./screenshots --output-dir=./webp --quality=90
 ```
 
 ### trim-screenshots.sh / center-screenshots.sh

--- a/scripts/patterns/png-to-webp.js
+++ b/scripts/patterns/png-to-webp.js
@@ -7,8 +7,8 @@
  * optimized WebP using sharp.
  *
  * Usage:
- *   node convert-to-webp.js <input-file> [options]
- *   node convert-to-webp.js --all --dir=<screenshots-dir> [options]
+ *   node png-to-webp.js <input-file> [options]
+ *   node png-to-webp.js --all --dir=<screenshots-dir> [options]
  *
  * Options:
  *   --all                  Convert every pattern-*.png file in --dir
@@ -18,9 +18,9 @@
  *   --dry-run              Show what would be done without writing files
  *
  * Examples:
- *   node convert-to-webp.js pattern-hero-dark.png
- *   node convert-to-webp.js --all --dir=./screenshots --output-dir=./webp
- *   node convert-to-webp.js --all --dir=./screenshots --quality=90
+ *   node png-to-webp.js pattern-hero-dark.png
+ *   node png-to-webp.js --all --dir=./screenshots --output-dir=./webp
+ *   node png-to-webp.js --all --dir=./screenshots --quality=90
  *
  * @desc     Convert PNG pattern screenshots to WebP using sharp
  * @category content
@@ -33,7 +33,7 @@
  * @flag     --output-dir   optional  {./webp}  Output directory (default: same as source)
  * @flag     --quality      optional  {85}  WebP quality 1-100
  * @flag     --dry-run      optional  {}  Show what would be done without writing files
- * @example  wp-ops scripts/patterns/convert-to-webp --all --dir=./screenshots --quality=90
+ * @example  wp-ops png-to-webp --all --dir=./screenshots --quality=90
  * @doc      scripts/patterns/README.md
  */
 

--- a/scripts/patterns/screenshot-patterns.sh
+++ b/scripts/patterns/screenshot-patterns.sh
@@ -147,7 +147,7 @@ fi
 
 log_header "Converting to WebP"
 log_header "────────────────────────────────────────────────────"
-node "$SCRIPT_DIR/convert-to-webp.js" --all --dir="$OUTPUT_DIR"
+node "$SCRIPT_DIR/png-to-webp.js" --all --dir="$OUTPUT_DIR"
 
 echo ""
 log_success "Successfully processed: $SCREENSHOT_COUNT pattern(s)"


### PR DESCRIPTION
## Why

`wp-ops png-to-webp --help` (then `scripts/patterns/convert-to-webp`) printed a usage line no user could type:

```
Usage: wp-ops scripts/patterns/convert-to-webp [input-file] [options]
```

That looked like 5.1.0's short-name work had missed a case. It hadn't. `Entry.ShortName` deliberately declines to abbreviate a basename shared by two commands, because the abbreviation wouldn't resolve — and `convert-to-webp` was the catalog's only such collision:

```
scripts/images/convert-to-webp    (.sh, cwebp)  Convert a JPG to WebP with center-crop
scripts/patterns/convert-to-webp  (.js, sharp)  Convert PNG pattern screenshots to WebP
```

So these were the only two commands `wp-ops <name>` refused to resolve, and the only two whose usage line still carried directory separators.

## What changed

**The rename.** `jpg-to-webp` and `png-to-webp`. This removes the ambiguity at its source rather than teaching `ShortName` to emit a `patterns/convert-to-webp` suffix form that dispatch would then have to learn to resolve. The new names also carry the distinction the shared one hid — one center-crops a JPG to the Facebook OG ratio via `cwebp`, the other batch-converts `pattern-*.png` screenshots via `sharp`.

Every basename in the catalog is now unique, so every usage line names a command that resolves if pasted back:

```
Usage: wp-ops jpg-to-webp <input> [output] [quality] [width] [height]
Usage: wp-ops png-to-webp [input-file] [options]
```

**README corrections.** Six stale claims, found while checking whether the rename had left anything behind. One is a real bug for anyone copy-pasting: `wp-ops bedrock <script>` answers `Unknown command or category` — 5.0.0's Option D moved that tree under `docs/` and dropped `bedrock` from `catalog.Categories`. The command itself survived and resolves as `wp-ops wp-cli-pattern-validate`.

The rest is drift: the picker's live preview pane went away in 5.1.0, the intro's "groups them by subdirectory" contradicted the domain-grouping paragraph twenty-five lines below it, and three counts were behind (backup commands 9 → 10, scripts 39 → 42, MCP tools 5 → 6, with `url_audit` missing from the list though `mcp-server/README.md` already documented it).

## Verification

- `go build ./...` and `go test ./...` pass
- Catalog regenerated — 74 commands, zero remaining basename collisions
- Both `--help` outputs checked against the built binary
- Each README fix checked against the code, not by inspection: `wp-ops backup --help` lists exactly 10, `server.ts` has 6 `server.tool(` registrations, `wp-ops bedrock --help` errors, `model.go:573` confirms the preview pane is gone
- `bash -n` / `node --check` on both renamed scripts and on `screenshot-patterns.sh`, their only in-repo caller

## Breaking

Anything outside this repo invoking `scripts/images/convert-to-webp.sh` or `scripts/patterns/convert-to-webp.js` by filename needs the same rename.
