### PR TITLE
Name commands by what you type, in examples as well as usage lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-08-05
+
+### Fixed
+
+- **Every `Examples:` block named the internal key rather than the command
+  you type.** 5.1.0 fixed the usage line for every command and every executor,
+  but it fixed it by changing the code that *generates* it. Example lines are
+  not generated — they are prose copied verbatim out of each script's
+  `@example` annotation — so they were never touched, and `--help` printed a
+  correct `Usage: wp-ops scanner-targeted` three rows above
+  `wp-ops wp-cli/security/scanner-targeted`. 42 of the 71 commands that carry
+  examples were affected, 47 lines in total; both render paths showed it, since
+  `exec.DetailBody` (the picker) and `exec.writeManifestHelpBody` (`--help`)
+  each print the string unchanged.
+
+  The path forms still resolved, so nothing was broken for anyone who pasted
+  one — they were wrong in that they taught the long form as the command's
+  name. One was genuinely broken: `wp-cli-pattern-validate`'s example still
+  named `bedrock/wp-cli-config/`, a category 5.0.0 retired, so the line it
+  told you to type answered `Unknown command or category`. That is the same
+  class of bug 5.1.1 fixed in `README.md`, missed then because nobody thought
+  to grep the *scripts* for the retired category name.
+
+- **`TestExamplesNameTheCommand` now pins this.** The catalog validated its
+  own structure but not its prose: `ShortName` is guaranteed to resolve and
+  CI already guards the generated catalog against drift, but every one of
+  those checks was about the *key*. The `Examples` field travelled from a
+  shell comment onto the user's screen without a single assertion that the
+  thing it told them to type exists. The new test extracts the token after
+  `wp-ops` — skipping `VAR=value` environment prefixes — and requires it to
+  equal the entry's `ShortName`, so a rename now fails in the same pull
+  request that makes it, which is the only moment the fix is cheap. Left
+  unenforced deliberately: that an example mentions only its own command,
+  since `check-deny-ips` legitimately pipes into `check-ips`.
+
+- **Server-side and Ansible guidance printed internal keys**, which no sweep
+  of the scripts could reach: the macOS access-log hint, the
+  missing-argument error, and the unannotated-playbook fallback all formatted
+  `e.Key` directly and now read through `CommandName()`. The ambiguity
+  message and `search` listing keep printing full keys, where the path is
+  the point.
+
+- **The backup hints were stale twice over.** `serverside.go`,
+  `scripts/backup/db-backup.sh` and `scripts/backup/site-backup.sh` all
+  suggested `wp-ops trellis/backup/database-pull -e site=… -e env=…` — the
+  path form *and* the `-e` syntax the playbooks stopped accepting when they
+  moved to positional arguments. They now print
+  `wp-ops database-pull example.com production`.
+
+- **`trellis/security/check-deny-ips.sh` invoked `check-ips` by full key.**
+  Not a hint but a real code path, and the one place a future rename would
+  have broken execution rather than a comment.
+
+- **`docs/trellis-cli-comparison.md` §5** asserted in the present tense that
+  `wp-ops db-backup --help` prints a full key, contradicting its own status
+  header four sections above; and two `trellis/security/README.md`
+  invocations used the path form. Documents that quote the path form *as the
+  problem being analysed* were left alone.
+
 ## [5.1.1] - 2026-08-05
 
 ### Changed

--- a/docs/example-line-drift.md
+++ b/docs/example-line-drift.md
@@ -1,0 +1,392 @@
+# Example lines still name internal keys: inventory and fix
+
+> **Status (2026-08-05): implemented in 5.1.2.** Option 3 shipped as the
+> three commits §6 recommends — the test, the 47-line sweep, and the four Go
+> sites — plus the `docs/trellis-cli-comparison.md` fix. §7's open question
+> (`search` vs `list` naming) is deliberately still open. Prose below is
+> preserved as written, so it describes the pre-fix state; measured against
+> `main` at 3a53555 (5.1.1).
+> **Problem:** `wp-ops scanner-targeted --help` prints a correct usage line
+> and then an `Examples:` block that reads
+> `wp-ops wp-cli/security/scanner-targeted`. 5.1.0 and 5.1.1 fixed the usage
+> line for every command and every executor, but they fixed it by changing the
+> code that *generates* it. Example lines are not generated — they are prose
+> copied verbatim out of each script's `@example` annotation — so they were
+> never touched. **42 of the 71 commands that carry examples** still print at
+> least one path-style invocation, 47 lines in total.
+> **Conclusion:** Sweep the 47 lines once, fix the four remaining Go call
+> sites that still format `e.Key` into user-facing text, and add a test in the
+> `catalog` package that fails when an example's command token is not the
+> entry's `ShortName`. The test is what makes the sweep stick; without it this
+> recurs at the next rename, exactly as it did at 5.1.1's.
+> **Related:** [trellis-cli-comparison.md](trellis-cli-comparison.md) §5
+> (where the usage-line problem was first written up),
+> [category-organization.md](category-organization.md),
+> [wp-ops-recommendations.md](wp-ops-recommendations.md)
+
+---
+
+## 1. What you are seeing
+
+The clearest form of it is the picker's post-selection detail block, where the
+two lines sit six rows apart and disagree:
+
+```
+Usage: wp-ops find-and-replace-files <filename> [source-file] [options]
+
+Find (and optionally replace) multiple copies of a file across projects
+
+Requires: find · Platform: any
+
+Examples:
+  wp-ops scripts/misc/find-and-replace-files -l -s create-pr.sh
+```
+
+The usage line is 5.1.0's generated one. The example under it is the 2024-era
+annotation. Both render paths are affected — `exec.DetailBody` (the picker,
+above) and `exec.writeManifestHelpBody` (`--help`) each carry their own copy
+of the same three-line `for _, ex := range e.Examples` loop
+(`help.go:108-113` and `help.go:159-164`), printing the string unchanged. So
+anywhere examples appear, they appear in the long form.
+
+More real output from the current binary:
+
+```
+$ wp-ops scanner-targeted --help
+Usage: wp-ops scanner-targeted [args...]
+...
+Examples:
+  wp-ops wp-cli/security/scanner-targeted        ← names an internal key
+
+$ wp-ops check-ips --help
+Examples:
+  wp-ops trellis/security/check-ips 1.2.3.4 5.6.7.8
+
+$ wp-ops convert-screenshot-for-claude --help
+Examples:
+  wp-ops scripts/misc/convert-screenshot-for-claude .playwright/screenshots/test.png
+```
+
+The path forms still *work* — `Lookup` resolves a full key, and always has —
+so nothing is broken for someone who pastes one. They are wrong in that they
+teach the long form as the name of the command, three lines under a usage line
+that just taught the short one.
+
+One is genuinely broken rather than merely long:
+
+```
+$ wp-ops wp-cli-pattern-validate --help
+Examples:
+  wp-ops bedrock/wp-cli-config/wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix
+
+$ wp-ops bedrock/wp-cli-config/wp-cli-pattern-validate --fix
+Unknown command or category: bedrock/wp-cli-config/wp-cli-pattern-validate
+```
+
+5.0.0 moved that tree under `docs/` and dropped the `bedrock` category. The
+command survived the move and resolves as `wp-ops wp-cli-pattern-validate`;
+its example still names the path it had two majors ago. This is the same class
+of bug 5.1.1 fixed in `README.md` — the `bedrock` category documented after
+its removal — and it was missed because nobody thought to grep the *scripts*
+for the retired category name.
+
+## 2. Why 5.1.0 and 5.1.1 did not catch this
+
+Two different mechanisms produce the two blocks, and only one was migrated.
+
+| | Usage line | Examples block |
+| --- | --- | --- |
+| Source | Computed at render time | Verbatim string from the source file |
+| Code | `exec.UsageLine(e)` → `e.CommandName()` → `ShortName` | `manifest.go:210` appends `@example` value; `help.go:110`/`161` prints it unchanged |
+| Effect of 5.1.0's short-name work | Every command, every executor, all at once | None |
+| Effect of a rename | Follows automatically | Silently goes stale |
+
+`ShortName` is computed in `catalog.Load` from basename uniqueness across the
+whole catalog (`catalog.go:134-143`), so the usage line cannot be wrong by
+construction — which is precisely why 5.1.0's fix was one small change and
+`TestLoad_ShortNameUniqueBasenames` can pin it. The example block has no such
+invariant. It is a comment in a shell script, and a comment is only as correct
+as the last person to read it.
+
+That asymmetry also explains 5.1.1's webp rename. Renaming
+`scripts/images/convert-to-webp` → `jpg-to-webp` fixed both files' usage lines
+for free. Their `@example` lines had to be edited by hand — and were, because
+that rename was the whole subject of the PR. Nothing generalizes that to the
+41 other commands nobody was looking at.
+
+## 3. The measured inventory
+
+Counted from `go/internal/catalog/catalog.json` (the generated catalog, so
+this is exactly what the binary prints), plus `grep` over the Go sources.
+
+### A. `@example` annotations — 42 entries, 47 lines
+
+The bulk of it. These are the lines the user sees.
+
+| Top-level directory | Entries with a stale example |
+| --- | ---: |
+| `scripts/` | 27 |
+| `wp-cli/` | 13 |
+| `trellis/` | 2 |
+| **Total** | **42** of 71 entries that carry examples |
+
+Notably clean: **all 10 `trellis/backup/` and `trellis/monitoring/`
+playbooks**, every `scripts/images/svg-*` command, and the `wp-cli/seo/`
+commands added most recently (`noindex-expired-posts`, `orphan-links-audit`).
+The clean set is the recently-authored set — this is drift, not a convention
+nobody ever followed. The `.yml` playbooks are clean because their examples
+were rewritten wholesale when the Ansible executor moved from `-e site=…` to
+positional arguments.
+
+Full list in [Appendix A](#appendix-a-the-47-lines).
+
+### B. Go call sites still formatting `e.Key` into user-facing text — 4
+
+These are not covered by a sweep of the scripts; they need code changes.
+
+| Site | Emits | Note |
+| --- | --- | --- |
+| `go/cmd/serverside.go:171` | `wp-ops %s /path/to/access.log` ← `e.Key` | Reached on macOS for the access-log commands |
+| `go/cmd/serverside.go:155-156` | `wp-ops trellis/backup/database-pull -e site=example.com -e env=production` | **Wrong twice**: path form, and `-e site=` is no longer the argument syntax — the playbook takes positionals (`wp-ops database-pull example.com production`) |
+| `go/internal/exec/ansible.go:231` | `Usage: wp-ops %s %s` ← `e.Key` | Missing-argument error path |
+| `go/internal/exec/ansible.go:287` | `Usage: wp-ops %s -e site=<site> …` ← `e.Key` | Unannotated fallback. Dead today (0 of 74 entries are unannotated) but it is the branch a newly-added, not-yet-annotated playbook lands in |
+
+`go/cmd/dispatch.go:362,365` and `go/cmd/search.go:68` also print `e.Key`, but
+correctly: the first is the ambiguity message, whose entire job is to show the
+disambiguating full names, and the second is a search listing where the path
+is the useful discriminator. Leave both. (`go/cmd/list.go:127` already prints
+`filepath.Base(e.Key)`, which is the inconsistency that makes `search` output
+look odd next to `list` output — worth a follow-up, out of scope here.)
+
+### C. Shell scripts printing invocation hints — 4 lines
+
+| Site | Line |
+| --- | --- |
+| `scripts/backup/db-backup.sh:56` | `echo "  wp-ops trellis/backup/database-backup -e site=… -e env=…"` |
+| `scripts/backup/site-backup.sh:45-46` | same shape, `database-pull` / `files-pull` |
+| `trellis/security/check-deny-ips.sh:67` | `echo "$IPS" \| xargs wp-ops trellis/security/check-ips` |
+
+The first two carry the same doubled staleness as `serverside.go:155` — path
+form *and* retired `-e` syntax. The third is not a hint but a **real runtime
+invocation**: it works, but it is the one place where a future rename of
+`check-ips` breaks an actual code path rather than a comment.
+
+### D. Markdown — 2 live, 4 historical
+
+Live and worth fixing:
+
+- `trellis/security/README.md:183, 234`
+- `docs/trellis-cli-comparison.md:150` — asserts `wp-ops db-backup --help`
+  prints `Usage: wp-ops scripts/backup/db-backup`, which stopped being true in
+  5.1.0. That document's own status header says rough edge #1 is fixed, so
+  this line contradicts the header four sections above it.
+
+Leave alone: `docs/wp-ops-recommendations.md` (lines 15-22, 56, 78, 220-228)
+and `docs/go-mcp-parity.md:43` quote the path form *as the problem being
+analyzed*. Rewriting them would destroy the record. `CHANGELOG.md` likewise.
+
+## 4. Root cause, stated once
+
+**The catalog validates its own structure but not its prose.** `catalog.Load`
+guarantees `ShortName` resolves. `TestLoad_ShortNameUniqueBasenames` pins that
+guarantee. CI even guards the catalog against drift
+(`.github/workflows/go-build.yml:58` regenerates and `git diff --exit-code`s
+it). But every one of those checks is about the *key*. The `Examples` field
+travels from a shell comment, through `manifest.go:210`, into `catalog.json`,
+out through `help.go:110`, and onto the user's screen without a single
+assertion that the thing it tells them to type exists.
+
+A secondary finding, which argues for putting the check in Go rather than in a
+shell one-liner: my first two `grep -rnE` passes over the scripts silently
+missed `scripts/git/create-pr.sh`, which has two stale lines. Only counting
+from `catalog.json` produced the number that matches reality. A grep-based
+audit of this is not trustworthy; a test over the loaded catalog is.
+
+## 5. Options
+
+### Option 1 — sweep the 47 lines, done
+
+Edit the annotations, regenerate, ship.
+
+Fixes today's output, costs an hour, guards nothing. The next command rename
+reintroduces it in exactly the way 5.1.1's rename would have, had its two
+`@example` lines not happened to be the subject of that PR. **Insufficient
+alone.**
+
+### Option 2 — normalize in the generator
+
+Have `catalog/gen` rewrite the command token of each `@example` to the entry's
+short name as it builds `catalog.json`.
+
+Attractive: examples become unwrongable, and a rename propagates to them for
+free the same way it already propagates to usage lines. Two problems, and the
+second is decisive:
+
+1. `ShortName` deliberately is not stored in `catalog.json` — it is a property
+   of the catalog as a whole, computed in `Load`, "so persisting it would let
+   it go stale the moment a colliding command is added" (`catalog.go:78-81`).
+   Normalizing at generation time would bake exactly the value that comment
+   refuses to bake.
+2. It fixes the screen and leaves the source file lying. These headers are
+   read directly at least as often as through `--help` — `head -40
+   some-script.sh` is how you read a script you are about to modify. Silent
+   rewriting means the file and the output disagree forever, and the file is
+   what the next author copies when adding a command.
+
+**Rejected**, but it is the right instinct: the fix should make wrongness
+impossible rather than merely absent.
+
+### Option 3 — validate in the catalog package, sweep once (recommended)
+
+Add to `go/internal/catalog/catalog_test.go`, alongside the test that already
+pins `ShortName`:
+
+```go
+// TestExamplesNameTheCommand pins the other half of what a user reads.
+// UsageLine is generated from ShortName so it cannot be wrong; an @example
+// is prose, and prose goes stale at every rename. An example whose command
+// token is not this entry's ShortName either names an internal key the
+// usage line three lines above just contradicted, or — as
+// wp-cli-pattern-validate's did between 5.0.0 and 5.1.1 — names a category
+// that no longer exists at all.
+func TestExamplesNameTheCommand(t *testing.T) { ... }
+```
+
+It extracts the token after `wp-ops`, skipping any leading `VAR=value`
+environment prefixes (`scripts/patterns/screenshot-patterns`'s example is
+`PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops
+screenshot-patterns hero-dark`), and asserts it equals `e.ShortName`.
+
+Why this shape:
+
+- **It runs already.** CI runs `go test ./...` and regenerates the catalog on
+  any change under `scripts/`, `trellis/`, `wp-cli/`, `mcp-server/`, or
+  `docs/` (`go-build.yml:14-30`). No new infrastructure, no new workflow step,
+  no pre-commit hook to install.
+- **It fires at the right moment.** Renaming a script changes its key, which
+  changes `ShortName`, which fails the test in the same PR as the rename —
+  which is the only moment the fix is cheap.
+- **It is also the audit.** Run it today and it names all 42 entries. It is
+  the checklist for the sweep and the guard afterward, and there is no window
+  where the guard exists but the sweep has not landed, because the test is red
+  until it does.
+- **It works post-`Load`,** so it reads the real `ShortName` without
+  persisting it — respecting the constraint that rules out Option 2.
+
+Deliberately *not* enforced by the test: that an example references only its
+own command. `check-deny-ips` legitimately mentions `check-ips`, and a rule
+against cross-references would either ban that or need a whitelist. The
+first-token rule covers the actual bug and stays a five-line assertion.
+
+## 6. Recommendation
+
+Option 3, as three commits.
+
+1. **`Add a test pinning @example lines to the command's short name`** — the
+   test alone, red. Small, and it states the invariant in one place.
+2. **`Name commands by what you type in every @example`** — the 47-line sweep
+   plus `go generate ./...`, turning it green. Mechanical; one commit is
+   correct here despite the atomic-commit rule, because it is one change
+   applied 47 times.
+3. **`Stop printing internal keys in ansible and server-side guidance`** — the
+   four Go sites from §B (`e.Key` → `e.CommandName()`), the two backup hints
+   corrected to positional Ansible syntax, `check-deny-ips.sh:67`, and the two
+   `trellis/security/README.md` lines.
+
+Then fix `docs/trellis-cli-comparison.md:150` as part of 3 or as a fourth
+one-line commit, and leave the historical documents alone.
+
+Expected end state: `wp-ops <anything> --help` names a command that resolves,
+in the usage line and in every example, enforced by a test rather than by
+whoever remembers.
+
+## 7. Open question worth settling in the same pass
+
+`search` prints full keys (`search.go:68`) and `list` prints bare basenames
+(`list.go:127`), so the same command appears under two different names
+depending on how you found it. Neither is wrong on its own terms — search
+results benefit from the disambiguating path, browse results from brevity —
+but `CommandName()` now exists as the answer to "what do I call this," and two
+of the three listings do not use it. Worth deciding, but it is a UX call
+rather than a correctness one, and this document does not need to make it.
+
+---
+
+## Appendix A: the 47 lines
+
+42 entries. Where a file appears twice it has two example lines.
+
+```
+scripts/git/create-pr.sh:27,28
+scripts/git/gh-traffic.sh:18
+scripts/git/git-log-oneline.sh:32
+scripts/images/batch-resize.sh:42
+scripts/images/make-square-webp.sh:15
+scripts/images/openverse_download.py:16
+scripts/images/openverse_search.py:17
+scripts/misc/convert-screenshot-for-claude.sh:28
+scripts/misc/find-and-replace-files.sh:36
+scripts/misc/post-count.sh:53
+scripts/monitoring/404-checker.sh:25,26
+scripts/monitoring/cf7-smoke-test.js:26
+scripts/monitoring/redirect-check.sh:12
+scripts/monitoring/remote-ttfb-ua.sh:24
+scripts/monitoring/server-monitor.sh:20
+scripts/monitoring/ttfb-test.sh:22
+scripts/patterns/center-screenshots.sh:21
+scripts/patterns/screenshot-patterns.sh:38     ← has an env-var prefix
+scripts/patterns/screenshot-url.js:38
+scripts/patterns/trim-screenshots.sh:19
+scripts/release/deploy-plugin-wporg.sh:66
+scripts/release/release-plugin.sh:31
+scripts/release/release-theme.sh:33
+scripts/release/upload-release-asset.sh:23
+scripts/sync/rsync-package-to-site.sh:49
+scripts/sync/rsync-theme.sh:37
+scripts/woocommerce/create-product-variations.sh:28,29
+trellis/security/check-deny-ips.sh:24,25
+trellis/security/check-ips.sh:19
+wp-cli/content-creation/import-page-draft.sh:36,37
+wp-cli/content-creation/page-creation.sh:24
+wp-cli/content-creation/wp-cli-pattern-validate.php:50   ← names retired `bedrock/`
+wp-cli/diagnostics/diagnostic-transients.php:13
+wp-cli/diagnostics/list-posts-count.sh:9
+wp-cli/security/scanner-general.php:41
+wp-cli/security/scanner-targeted.php:35
+wp-cli/security/scanner-wrapper.php:21
+wp-cli/seo/blog-audit.sh:25
+wp-cli/seo/orphan-pages-audit.sh:25
+wp-cli/seo/page-audit.sh:25
+wp-cli/seo/redirect-audit.sh:27
+wp-cli/seo/schema-audit.sh:24
+```
+
+`go/internal/manifest/testdata/{db-backup.sh,database-backup.yml,redirect-audit.sh}`
+also carry path-style examples. Those are parser fixtures, not commands — the
+manifest parser must keep accepting the form. Leave them, and keep them out of
+any sweep regex.
+
+## Appendix B: reproducing the count
+
+Do not grep the scripts — it under-reports (§4). Count from the generated
+catalog:
+
+```bash
+cd go && go generate ./...
+python3 - <<'PY'
+import json, re
+entries = json.load(open('internal/catalog/catalog.json'))
+token = re.compile(r'^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*wp-ops\s+(\S+)')
+lines = 0
+for e in entries:
+    bad = [x for x in (e.get('examples') or [])
+           if (m := token.match(x)) and '/' in m.group(1)]
+    if bad:
+        lines += len(bad)
+        print(e['key'])
+print('stale entries:', sum(1 for _ in ()), 'lines:', lines)
+PY
+```
+
+At 3a53555 this prints 42 keys and `lines: 47`. After the sweep it should
+print nothing — and once the test from §5 exists, this script is redundant.

--- a/docs/trellis-cli-comparison.md
+++ b/docs/trellis-cli-comparison.md
@@ -146,8 +146,9 @@ These are real divergences, not gaps to close blindly:
 
 Both are cheap to fix and both show up next to trellis's equivalents:
 
-1. **Help echoes the internal key, not what you typed.**
-   `wp-ops db-backup --help` prints `Usage: wp-ops scripts/backup/db-backup
+1. **Help echoes the internal key, not what you typed.** *(Fixed in 5.1.0 —
+   past tense below describes the state at the time of comparison.)*
+   `wp-ops db-backup --help` printed `Usage: wp-ops scripts/backup/db-backup
    [args...]`. trellis prints `Usage: trellis deploy [options] ENVIRONMENT
    [SITE]`. Two issues: the full key is shown where the user typed a
    basename, and `[args...]` is a placeholder where the manifest already

--- a/go/cmd/serverside.go
+++ b/go/cmd/serverside.go
@@ -146,8 +146,8 @@ func printServerSideGuidance(w io.Writer, e catalog.Entry) {
 		fmt.Fprintln(w, "That leaves the archive on the server. To back up *and* retrieve a copy")
 		fmt.Fprintln(w, "to this machine in one step, use the Ansible playbooks instead:")
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production")
-		fmt.Fprintln(w, "  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production")
+		fmt.Fprintln(w, "  wp-ops database-pull example.com production")
+		fmt.Fprintln(w, "  wp-ops files-pull    example.com production")
 		return
 	}
 
@@ -168,7 +168,7 @@ func printServerSideGuidance(w io.Writer, e catalog.Entry) {
 
 	if hasGNUDate() {
 		fmt.Fprintln(w, "Already have a log file on this machine? Pass its path and it runs here:")
-		fmt.Fprintf(w, "  wp-ops %s /path/to/access.log\n", e.Key)
+		fmt.Fprintf(w, "  wp-ops %s /path/to/access.log\n", e.CommandName())
 	} else {
 		fmt.Fprintln(w, "The SSH route above is unaffected by what's installed here — date and")
 		fmt.Fprintln(w, "gawk both resolve on the server. Only running it against a log copied")

--- a/go/cmd/serverside_test.go
+++ b/go/cmd/serverside_test.go
@@ -187,8 +187,11 @@ func TestPrintServerSideGuidanceVariants(t *testing.T) {
 			wantContain: []string{
 				"writes the archive to /srv/backups/<site>",
 				"ssh web@example.com 'bash -s' < scripts/backup/site-backup.sh",
-				"wp-ops trellis/backup/database-pull",
-				"wp-ops trellis/backup/files-pull",
+				// Short names and positional arguments, matching what the
+				// playbooks actually accept — the old assertion pinned both
+				// the internal key and the retired `-e site=` syntax.
+				"wp-ops database-pull example.com production",
+				"wp-ops files-pull    example.com production",
 				"example.com",
 			},
 			wantAbsent: []string{"gawk"},

--- a/go/internal/catalog/catalog.json
+++ b/go/internal/catalog/catalog.json
@@ -301,8 +301,8 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/git/create-pr --ai=claude",
-      "wp-ops scripts/git/create-pr main \"Add new feature\" --no-ai"
+      "wp-ops create-pr --ai=claude",
+      "wp-ops create-pr main \"Add new feature\" --no-ai"
     ],
     "manifest_category": "git",
     "platform": "any",
@@ -354,7 +354,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/git/gh-traffic imagewize/nynaeve --quiet"
+      "wp-ops gh-traffic imagewize/nynaeve --quiet"
     ],
     "manifest_category": "git",
     "platform": "any",
@@ -382,7 +382,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/git/git-log-oneline 20"
+      "wp-ops git-log-oneline 20"
     ],
     "manifest_category": "git",
     "platform": "any",
@@ -470,7 +470,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/images/batch-resize -w 1200 -H 630 *.png"
+      "wp-ops batch-resize -w 1200 -H 630 *.png"
     ],
     "manifest_category": "images",
     "platform": "any",
@@ -600,7 +600,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/images/make-square-webp input.webp output.webp --left-pad 200 --size 2000"
+      "wp-ops make-square-webp input.webp output.webp --left-pad 200 --size 2000"
     ],
     "manifest_category": "images",
     "platform": "any",
@@ -674,7 +674,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/images/openverse_download --url https://example.com/img.jpg --convert-webp"
+      "wp-ops openverse_download --url https://example.com/img.jpg --convert-webp"
     ],
     "manifest_category": "images",
     "platform": "any",
@@ -758,7 +758,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/images/openverse_search sunset --license cc0 --limit 10"
+      "wp-ops openverse_search sunset --license cc0 --limit 10"
     ],
     "manifest_category": "images",
     "platform": "any",
@@ -916,7 +916,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/misc/convert-screenshot-for-claude .playwright/screenshots/test.png"
+      "wp-ops convert-screenshot-for-claude .playwright/screenshots/test.png"
     ],
     "manifest_category": "misc",
     "platform": "any",
@@ -992,7 +992,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/misc/find-and-replace-files -l -s create-pr.sh"
+      "wp-ops find-and-replace-files -l -s create-pr.sh"
     ],
     "manifest_category": "misc",
     "platform": "any",
@@ -1068,7 +1068,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/misc/post-count --ssh web@example.com --year 2026"
+      "wp-ops post-count --ssh web@example.com --year 2026"
     ],
     "manifest_category": "misc",
     "platform": "wordpress",
@@ -1132,8 +1132,8 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/404-checker https://example.com",
-      "wp-ops scripts/monitoring/404-checker --mode spider https://example.com"
+      "wp-ops 404-checker https://example.com",
+      "wp-ops 404-checker --mode spider https://example.com"
     ],
     "manifest_category": "monitoring",
     "platform": "any",
@@ -1240,7 +1240,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/cf7-smoke-test https://example.com/contact/ --name \"QA Bot\""
+      "wp-ops cf7-smoke-test https://example.com/contact/ --name \"QA Bot\""
     ],
     "manifest_category": "monitoring",
     "platform": "wordpress",
@@ -1347,7 +1347,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/redirect-check https://example.com/old-page/"
+      "wp-ops redirect-check https://example.com/old-page/"
     ],
     "manifest_category": "monitoring",
     "platform": "any",
@@ -1384,7 +1384,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/remote-ttfb-ua web@example.com https://example.com/"
+      "wp-ops remote-ttfb-ua web@example.com https://example.com/"
     ],
     "manifest_category": "monitoring",
     "platform": "any",
@@ -1474,7 +1474,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/server-monitor web@example.com"
+      "wp-ops server-monitor web@example.com"
     ],
     "manifest_category": "monitoring",
     "platform": "any",
@@ -1640,7 +1640,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/monitoring/ttfb-test https://example.com"
+      "wp-ops ttfb-test https://example.com"
     ],
     "manifest_category": "monitoring",
     "platform": "any",
@@ -1722,7 +1722,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/patterns/center-screenshots ./screenshots 900 600"
+      "wp-ops center-screenshots ./screenshots 900 600"
     ],
     "manifest_category": "content",
     "platform": "any",
@@ -1820,7 +1820,7 @@
       }
     ],
     "examples": [
-      "PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops scripts/patterns/screenshot-patterns hero-dark"
+      "PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops screenshot-patterns hero-dark"
     ],
     "manifest_category": "content",
     "platform": "wordpress",
@@ -1898,7 +1898,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/patterns/screenshot-url http://example.test/my-page/ --out=pattern.png"
+      "wp-ops screenshot-url http://example.test/my-page/ --out=pattern.png"
     ],
     "manifest_category": "content",
     "platform": "any",
@@ -1935,7 +1935,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/patterns/trim-screenshots ./screenshots 900"
+      "wp-ops trim-screenshots ./screenshots 900"
     ],
     "manifest_category": "content",
     "platform": "any",
@@ -2035,7 +2035,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/release/deploy-plugin-wporg warder-cookie-consent --build \"npm ci \u0026\u0026 npx webpack\""
+      "wp-ops deploy-plugin-wporg warder-cookie-consent --build \"npm ci \u0026\u0026 npx webpack\""
     ],
     "manifest_category": "release",
     "platform": "any",
@@ -2083,7 +2083,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/release/release-plugin 2.5.3 --commit"
+      "wp-ops release-plugin 2.5.3 --commit"
     ],
     "manifest_category": "release",
     "platform": "any",
@@ -2140,7 +2140,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/release/release-theme nynaeve 1.0.0 --commit"
+      "wp-ops release-theme nynaeve 1.0.0 --commit"
     ],
     "manifest_category": "release",
     "platform": "any",
@@ -2184,7 +2184,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/release/upload-release-asset imagewize/warder-cookie-consent v1.3.1"
+      "wp-ops upload-release-asset imagewize/warder-cookie-consent v1.3.1"
     ],
     "manifest_category": "release",
     "platform": "any",
@@ -2241,7 +2241,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/sync/rsync-package-to-site theme my-theme"
+      "wp-ops rsync-package-to-site theme my-theme"
     ],
     "manifest_category": "sync",
     "platform": "any",
@@ -2268,7 +2268,7 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/sync/rsync-theme --dry-run"
+      "wp-ops rsync-theme --dry-run"
     ],
     "manifest_category": "sync",
     "platform": "any",
@@ -2296,8 +2296,8 @@
       }
     ],
     "examples": [
-      "wp-ops scripts/woocommerce/create-product-variations",
-      "wp-ops scripts/woocommerce/create-product-variations --dry-run"
+      "wp-ops create-product-variations",
+      "wp-ops create-product-variations --dry-run"
     ],
     "manifest_category": "misc",
     "platform": "trellis",
@@ -2820,8 +2820,8 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/security/check-deny-ips",
-      "wp-ops trellis/security/check-deny-ips --full"
+      "wp-ops check-deny-ips",
+      "wp-ops check-deny-ips --full"
     ],
     "manifest_category": "security",
     "platform": "trellis",
@@ -2850,7 +2850,7 @@
       }
     ],
     "examples": [
-      "wp-ops trellis/security/check-ips 1.2.3.4 5.6.7.8"
+      "wp-ops check-ips 1.2.3.4 5.6.7.8"
     ],
     "manifest_category": "security",
     "platform": "trellis",
@@ -2944,8 +2944,8 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/content-creation/import-page-draft draft.html 7673",
-      "wp-ops wp-cli/content-creation/import-page-draft draft.html 7673 example.com both template-no-header.blade.php"
+      "wp-ops import-page-draft draft.html 7673",
+      "wp-ops import-page-draft draft.html 7673 example.com both template-no-header.blade.php"
     ],
     "manifest_category": "content",
     "platform": "trellis",
@@ -2990,7 +2990,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/content-creation/page-creation about-page-content.html \"About\" about"
+      "wp-ops page-creation about-page-content.html \"About\" about"
     ],
     "manifest_category": "content",
     "platform": "trellis",
@@ -3064,7 +3064,7 @@
       }
     ],
     "examples": [
-      "wp-ops bedrock/wp-cli-config/wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix"
+      "wp-ops wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix"
     ],
     "manifest_category": "content",
     "platform": "wordpress",
@@ -3083,7 +3083,7 @@
     ],
     "doc": "wp-cli/diagnostics/README.md",
     "examples": [
-      "wp-ops wp-cli/diagnostics/diagnostic-transients"
+      "wp-ops diagnostic-transients"
     ],
     "manifest_category": "diagnostics",
     "platform": "wordpress",
@@ -3102,7 +3102,7 @@
     ],
     "doc": "wp-cli/diagnostics/README.md",
     "examples": [
-      "wp-ops wp-cli/diagnostics/list-posts-count"
+      "wp-ops list-posts-count"
     ],
     "manifest_category": "diagnostics",
     "platform": "trellis",
@@ -3210,7 +3210,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/security/scanner-general"
+      "wp-ops scanner-general"
     ],
     "manifest_category": "security",
     "platform": "wordpress",
@@ -3239,7 +3239,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/security/scanner-targeted"
+      "wp-ops scanner-targeted"
     ],
     "manifest_category": "security",
     "platform": "wordpress",
@@ -3268,7 +3268,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/security/scanner-wrapper"
+      "wp-ops scanner-wrapper"
     ],
     "manifest_category": "security",
     "platform": "wordpress",
@@ -3313,7 +3313,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/seo/blog-audit --path web/wp --output reports/seo"
+      "wp-ops blog-audit --path web/wp --output reports/seo"
     ],
     "manifest_category": "seo",
     "platform": "wordpress",
@@ -3496,7 +3496,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/seo/orphan-pages-audit --path web/wp --output reports/seo"
+      "wp-ops orphan-pages-audit --path web/wp --output reports/seo"
     ],
     "manifest_category": "seo",
     "platform": "wordpress",
@@ -3541,7 +3541,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/seo/page-audit --path web/wp --output reports/seo"
+      "wp-ops page-audit --path web/wp --output reports/seo"
     ],
     "manifest_category": "seo",
     "platform": "wordpress",
@@ -3585,7 +3585,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/seo/redirect-audit --url https://example.com --verbose"
+      "wp-ops redirect-audit --url https://example.com --verbose"
     ],
     "manifest_category": "seo",
     "platform": "wordpress",
@@ -3632,7 +3632,7 @@
       }
     ],
     "examples": [
-      "wp-ops wp-cli/seo/schema-audit https://example.com --pages /,/services/,/contact/"
+      "wp-ops schema-audit https://example.com --pages /,/services/,/contact/"
     ],
     "manifest_category": "seo",
     "platform": "wordpress",

--- a/go/internal/catalog/catalog_test.go
+++ b/go/internal/catalog/catalog_test.go
@@ -249,3 +249,54 @@ func TestLoad_ShortNameUniqueBasenames(t *testing.T) {
 		}
 	}
 }
+
+// exampleCommandToken returns the token an @example tells the reader to type:
+// the word after "wp-ops", skipping any leading VAR=value environment prefixes
+// (screenshot-patterns' example opens with two). Returns "" for an example that
+// is not a wp-ops invocation at all, which the caller skips.
+func exampleCommandToken(ex string) string {
+	fields := strings.Fields(ex)
+	for i, f := range fields {
+		if f != "wp-ops" {
+			// Only an environment assignment may precede the binary.
+			if eq := strings.Index(f, "="); eq > 0 && !strings.ContainsAny(f[:eq], "/-.") {
+				continue
+			}
+			return ""
+		}
+		if i+1 < len(fields) {
+			return fields[i+1]
+		}
+		return ""
+	}
+	return ""
+}
+
+// TestExamplesNameTheCommand pins the other half of what a user reads. The
+// usage line is generated from ShortName, so it cannot be wrong; an @example is
+// prose copied verbatim out of a shell comment, and prose goes stale at every
+// rename. An example whose command token is not this entry's ShortName either
+// names an internal key that the usage line three rows above just contradicted,
+// or — as wp-cli-pattern-validate's did between 5.0.0 and 5.1.1 — names a
+// category that no longer exists at all.
+//
+// Deliberately not enforced: that an example mentions only its own command.
+// check-deny-ips legitimately pipes into check-ips, and banning that would need
+// a whitelist. The first-token rule covers the actual bug.
+func TestExamplesNameTheCommand(t *testing.T) {
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for _, e := range c.Entries {
+		for _, ex := range e.Examples {
+			tok := exampleCommandToken(ex)
+			if tok == "" || tok == e.ShortName {
+				continue
+			}
+			t.Errorf("%s: example names %q, but this command is typed as %q\n    %s",
+				e.Key, tok, e.ShortName, ex)
+		}
+	}
+}

--- a/go/internal/exec/ansible.go
+++ b/go/internal/exec/ansible.go
@@ -228,7 +228,7 @@ func BuildPlaybookArgs(e catalog.Entry, rawArgs []string) ([]string, error) {
 		if i >= len(rawArgs) || strings.HasPrefix(rawArgs[i], "-") {
 			return nil, fmt.Errorf(
 				"missing required argument <%s> (%s)\n\nUsage: wp-ops %s %s",
-				a.Name, a.Description, e.Key, positionalUsage(e),
+				a.Name, a.Description, e.CommandName(), positionalUsage(e),
 			)
 		}
 		built = append(built, "-e", a.Name+"="+rawArgs[i])
@@ -284,7 +284,7 @@ func FormatHelp(e catalog.Entry, trellisDir string) string {
 
 	if !e.Annotated {
 		var b strings.Builder
-		fmt.Fprintf(&b, "Usage: wp-ops %s -e site=<site> -e env=<development|staging|production> [-e key=value ...]\n\n", e.Key)
+		fmt.Fprintf(&b, "Usage: wp-ops %s -e site=<site> -e env=<development|staging|production> [-e key=value ...]\n\n", e.CommandName())
 		fmt.Fprintf(&b, "Description: %s\n\n", e.Description)
 		fmt.Fprintf(&b, "Playbook: %s\n", e.ScriptPath)
 		fmt.Fprintln(&b, "Runs via ansible-playbook against the Trellis project at $TRELLIS_DIR")

--- a/scripts/backup/db-backup.sh
+++ b/scripts/backup/db-backup.sh
@@ -53,7 +53,7 @@ usage() {
     echo "  wp db export --path=web/wp"
     echo ""
     echo "For automated/repeatable backups instead, use the Ansible playbook:"
-    echo "  wp-ops trellis/backup/database-backup -e site=example.com -e env=production"
+    echo "  wp-ops database-backup example.com production"
 }
 
 # Colors for output

--- a/scripts/backup/site-backup.sh
+++ b/scripts/backup/site-backup.sh
@@ -42,8 +42,8 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     echo "Writes to /srv/backups/<site-name>/{database,files,config}/ on the"
     echo "server. To pull copies down to your machine instead, use the Ansible"
     echo "playbooks:"
-    echo "  wp-ops trellis/backup/database-pull -e site=example.com -e env=production"
-    echo "  wp-ops trellis/backup/files-pull    -e site=example.com -e env=production"
+    echo "  wp-ops database-pull example.com production"
+    echo "  wp-ops files-pull    example.com production"
     exit 0
 fi
 

--- a/scripts/git/create-pr.sh
+++ b/scripts/git/create-pr.sh
@@ -24,8 +24,8 @@
 # @flag     --no-interactive  optional  {}  Skip all prompts, use defaults/arguments
 # @flag     --update          optional  {}  Update existing PR description for current branch
 # @flag     --dry-run         optional  {}  Print the generated body and exit without touching GitHub
-# @example  wp-ops scripts/git/create-pr --ai=claude
-# @example  wp-ops scripts/git/create-pr main "Add new feature" --no-ai
+# @example  wp-ops create-pr --ai=claude
+# @example  wp-ops create-pr main "Add new feature" --no-ai
 
 set -e
 

--- a/scripts/git/gh-traffic.sh
+++ b/scripts/git/gh-traffic.sh
@@ -15,7 +15,7 @@
 # @flag     --days   optional  {14}  Number of days to fetch (max: 14)
 # @flag     --json   optional  {}  Output raw JSON instead of formatted table
 # @flag     --quiet  optional  {}  Suppress header row in table output
-# @example  wp-ops scripts/git/gh-traffic imagewize/nynaeve --quiet
+# @example  wp-ops gh-traffic imagewize/nynaeve --quiet
 
 set -euo pipefail
 

--- a/scripts/git/git-log-oneline.sh
+++ b/scripts/git/git-log-oneline.sh
@@ -29,7 +29,7 @@
 # @runs     local
 # @requires git
 # @arg      n  optional  {10}  Number of commits to show
-# @example  wp-ops scripts/git/git-log-oneline 20
+# @example  wp-ops git-log-oneline 20
 
 set -euo pipefail
 

--- a/scripts/images/batch-resize.sh
+++ b/scripts/images/batch-resize.sh
@@ -39,7 +39,7 @@
 # @flag     --quality  optional  {85}  Quality for jpg/webp, 1-100
 # @flag     --dry-run  optional  {}  Show what would be done without processing
 # @flag     --delete   optional  {}  Delete original files after successful conversion
-# @example  wp-ops scripts/images/batch-resize -w 1200 -H 630 *.png
+# @example  wp-ops batch-resize -w 1200 -H 630 *.png
 
 set -euo pipefail
 

--- a/scripts/images/make-square-webp.sh
+++ b/scripts/images/make-square-webp.sh
@@ -12,7 +12,7 @@
 # @flag     --quality       optional  {85}  WebP quality (0-100)
 # @flag     --background    optional  {white}  Background color
 # @flag     --left-pad      optional  {200}  Add left padding by right-aligning after resize
-# @example  wp-ops scripts/images/make-square-webp input.webp output.webp --left-pad 200 --size 2000
+# @example  wp-ops make-square-webp input.webp output.webp --left-pad 200 --size 2000
 set -euo pipefail
 
 usage() {

--- a/scripts/images/openverse_download.py
+++ b/scripts/images/openverse_download.py
@@ -13,7 +13,7 @@
 # @flag     --quality       optional  {75}  WebP quality
 # @flag     --resize        optional  {0}  Resize width (0 to skip)
 # @flag     --keep-original optional  {}  Keep the original file after WebP conversion
-# @example  wp-ops scripts/images/openverse_download --url https://example.com/img.jpg --convert-webp
+# @example  wp-ops openverse_download --url https://example.com/img.jpg --convert-webp
 
 import argparse
 import os

--- a/scripts/images/openverse_search.py
+++ b/scripts/images/openverse_search.py
@@ -14,7 +14,7 @@
 # @flag     --mature         optional  {}  Include mature results
 # @flag     --provider       optional  {flickr}  Source provider filter
 # @flag     --json           optional  {}  Output raw JSON results
-# @example  wp-ops scripts/images/openverse_search sunset --license cc0 --limit 10
+# @example  wp-ops openverse_search sunset --license cc0 --limit 10
 
 import argparse
 import json

--- a/scripts/misc/convert-screenshot-for-claude.sh
+++ b/scripts/misc/convert-screenshot-for-claude.sh
@@ -25,7 +25,7 @@
 # @requires convert
 # @arg      png-file  required  {test-screenshot.png}  PNG file to convert
 # @flag     --quality optional  {90}  JPEG quality (1-100)
-# @example  wp-ops scripts/misc/convert-screenshot-for-claude .playwright/screenshots/test.png
+# @example  wp-ops convert-screenshot-for-claude .playwright/screenshots/test.png
 #
 
 set -e  # Exit on error

--- a/scripts/misc/find-and-replace-files.sh
+++ b/scripts/misc/find-and-replace-files.sh
@@ -33,7 +33,7 @@
 # @flag     --dry-run    optional  {}  Show what would be done without making changes
 # @flag     --list       optional  {}  List found files without replacing
 # @flag     --size       optional  {}  Also show file sizes in listing
-# @example  wp-ops scripts/misc/find-and-replace-files -l -s create-pr.sh
+# @example  wp-ops find-and-replace-files -l -s create-pr.sh
 # @doc      scripts/misc/README-FIND-AND-REPLACE.md
 
 set -euo pipefail

--- a/scripts/misc/post-count.sh
+++ b/scripts/misc/post-count.sh
@@ -50,7 +50,7 @@
 # @flag     --path     optional  {web/wp}  WordPress path passed to WP-CLI
 # @flag     --ssh      optional  {web@example.com}  Run remotely over ssh
 # @flag     --site     optional  {/srv/www/example.com/current}  Remote site dir to cd into with --ssh
-# @example  wp-ops scripts/misc/post-count --ssh web@example.com --year 2026
+# @example  wp-ops post-count --ssh web@example.com --year 2026
 
 set -euo pipefail
 

--- a/scripts/monitoring/404-checker.sh
+++ b/scripts/monitoring/404-checker.sh
@@ -22,8 +22,8 @@
 # @flag     --output   optional  Append broken-link results to this file
 # @flag     --timeout  optional  {10}  curl max-time per request, in seconds
 # @flag     --level    optional  {3}  Spider depth for --mode spider
-# @example  wp-ops scripts/monitoring/404-checker https://example.com
-# @example  wp-ops scripts/monitoring/404-checker --mode spider https://example.com
+# @example  wp-ops 404-checker https://example.com
+# @example  wp-ops 404-checker --mode spider https://example.com
 
 # ── Colours ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'

--- a/scripts/monitoring/cf7-smoke-test.js
+++ b/scripts/monitoring/cf7-smoke-test.js
@@ -23,7 +23,7 @@
  * @flag     --email    optional  {qa@example.com}  Test submitter email
  * @flag     --subject  optional  {"Rate limit smoke test"}  Test subject
  * @flag     --message  optional  {"..."}  Test message body
- * @example  wp-ops scripts/monitoring/cf7-smoke-test https://example.com/contact/ --name "QA Bot"
+ * @example  wp-ops cf7-smoke-test https://example.com/contact/ --name "QA Bot"
  */
 
 const { chromium } = require('playwright');

--- a/scripts/monitoring/redirect-check.sh
+++ b/scripts/monitoring/redirect-check.sh
@@ -9,7 +9,7 @@
 # @runs     local
 # @requires curl
 # @arg      urls  optional  One or more URLs to check; falls back to the hardcoded list in the script when omitted
-# @example  wp-ops scripts/monitoring/redirect-check https://example.com/old-page/
+# @example  wp-ops redirect-check https://example.com/old-page/
 
 # Check if URLs are provided as arguments, otherwise use defaults
 if [ $# -gt 0 ]; then

--- a/scripts/monitoring/remote-ttfb-ua.sh
+++ b/scripts/monitoring/remote-ttfb-ua.sh
@@ -21,7 +21,7 @@
 # @requires ssh
 # @arg      ssh-host  required  {web@example.com}  SSH user@host to run curl from
 # @arg      url       required  {https://example.com}  URL to test (repeatable)
-# @example  wp-ops scripts/monitoring/remote-ttfb-ua web@example.com https://example.com/
+# @example  wp-ops remote-ttfb-ua web@example.com https://example.com/
 # @doc      docs/wordpress-utilities/speed-optimization/README.md
 
 set -euo pipefail

--- a/scripts/monitoring/server-monitor.sh
+++ b/scripts/monitoring/server-monitor.sh
@@ -17,7 +17,7 @@
 # @requires ssh
 # @arg      ssh-target            required  {web@example.com}  SSH target to connect to
 # @arg      php-fpm-pool-pattern  optional  {php-fpm: pool}  Pattern to match PHP-FPM pool processes
-# @example  wp-ops scripts/monitoring/server-monitor web@example.com
+# @example  wp-ops server-monitor web@example.com
 # @doc      trellis/monitoring/README.md
 
 set -euo pipefail

--- a/scripts/monitoring/ttfb-test.sh
+++ b/scripts/monitoring/ttfb-test.sh
@@ -19,7 +19,7 @@
 # @runs     local
 # @requires curl bc
 # @arg      url  required  {https://example.com}  URL to test
-# @example  wp-ops scripts/monitoring/ttfb-test https://example.com
+# @example  wp-ops ttfb-test https://example.com
 # @doc      docs/wordpress-utilities/speed-optimization/README.md
 
 set -e

--- a/scripts/patterns/center-screenshots.sh
+++ b/scripts/patterns/center-screenshots.sh
@@ -18,7 +18,7 @@
 # @arg      screenshots-dir  required  {./screenshots}  Directory of pattern-*.webp screenshots
 # @arg      width            optional  {900}  Target canvas width
 # @arg      height           optional  {600}  Target canvas height
-# @example  wp-ops scripts/patterns/center-screenshots ./screenshots 900 600
+# @example  wp-ops center-screenshots ./screenshots 900 600
 # @doc      scripts/patterns/README.md
 
 set -euo pipefail

--- a/scripts/patterns/screenshot-patterns.sh
+++ b/scripts/patterns/screenshot-patterns.sh
@@ -35,7 +35,7 @@
 # @runs     local
 # @requires node
 # @arg      pattern-slug  required  {hero-dark}  Pattern slug(s) to screenshot (repeatable)
-# @example  PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops scripts/patterns/screenshot-patterns hero-dark
+# @example  PATTERN_NAMESPACE=mytheme SITE_URL=http://example.test wp-ops screenshot-patterns hero-dark
 # @doc      scripts/patterns/README.md
 
 set -euo pipefail

--- a/scripts/patterns/screenshot-url.js
+++ b/scripts/patterns/screenshot-url.js
@@ -35,7 +35,7 @@
  * @flag     --wait      optional  {3000}  Milliseconds to wait after load, for JS-rendered content
  * @flag     --selector  optional  {".entry-content > *:first-child"}  Comma-separated CSS selectors, tried in order
  * @flag     --full-page optional  {}  Skip selector matching and screenshot the entire page
- * @example  wp-ops scripts/patterns/screenshot-url http://example.test/my-page/ --out=pattern.png
+ * @example  wp-ops screenshot-url http://example.test/my-page/ --out=pattern.png
  * @doc      scripts/patterns/README.md
  */
 

--- a/scripts/patterns/trim-screenshots.sh
+++ b/scripts/patterns/trim-screenshots.sh
@@ -16,7 +16,7 @@
 # @requires magick
 # @arg      screenshots-dir  required  {./screenshots}  Directory of pattern-*.webp screenshots
 # @arg      width            optional  {900}  Resize width after trimming
-# @example  wp-ops scripts/patterns/trim-screenshots ./screenshots 900
+# @example  wp-ops trim-screenshots ./screenshots 900
 # @doc      scripts/patterns/README.md
 
 set -euo pipefail

--- a/scripts/release/deploy-plugin-wporg.sh
+++ b/scripts/release/deploy-plugin-wporg.sh
@@ -63,7 +63,7 @@ err()  { echo -e "${RED}✗ $1${NC}" >&2; }
 # @flag     --message     optional  {"Release <version>"}  Commit message
 # @flag     --commit      optional  {}  Actually run svn ci (prompts for SVN password)
 # @flag     --force       optional  {}  Allow re-deploying a tag that already exists
-# @example  wp-ops scripts/release/deploy-plugin-wporg warder-cookie-consent --build "npm ci && npx webpack"
+# @example  wp-ops deploy-plugin-wporg warder-cookie-consent --build "npm ci && npx webpack"
 ok()   { echo -e "${GREEN}  ✓ $1${NC}"; }
 info() { echo -e "${BLUE}$1${NC}"; }
 warn() { echo -e "${YELLOW}⚠ $1${NC}"; }

--- a/scripts/release/release-plugin.sh
+++ b/scripts/release/release-plugin.sh
@@ -28,7 +28,7 @@
 # @arg      version    required  {2.5.3}  New plugin version
 # @flag     --commit   optional  {}  Auto-commit the version bump and changelog
 # @flag     --ai       optional  {claude|codex}  AI CLI to use (default: claude, or the only one installed)
-# @example  wp-ops scripts/release/release-plugin 2.5.3 --commit
+# @example  wp-ops release-plugin 2.5.3 --commit
 
 set -e  # Exit on error
 

--- a/scripts/release/release-theme.sh
+++ b/scripts/release/release-theme.sh
@@ -30,7 +30,7 @@
 # @arg      version     required  {1.2.5}  New theme version
 # @flag     --commit    optional  {}  Auto-commit the version bump and changelog
 # @flag     --ai        optional  {claude|codex|vibe}  AI CLI to use (default: claude, or the only one installed)
-# @example  wp-ops scripts/release/release-theme nynaeve 1.0.0 --commit
+# @example  wp-ops release-theme nynaeve 1.0.0 --commit
 
 set -e  # Exit on error
 

--- a/scripts/release/upload-release-asset.sh
+++ b/scripts/release/upload-release-asset.sh
@@ -20,7 +20,7 @@
 # @arg      github-repo  required  {imagewize/warder-cookie-consent}  GitHub repo in owner/repo form
 # @arg      tag          required  {v1.3.1}  Release tag to attach the asset to
 # @arg      zip-name     optional  {warder-cookie-consent.zip}  Output zip filename (default: derived from repo slug)
-# @example  wp-ops scripts/release/upload-release-asset imagewize/warder-cookie-consent v1.3.1
+# @example  wp-ops upload-release-asset imagewize/warder-cookie-consent v1.3.1
 
 set -e
 

--- a/scripts/sync/rsync-package-to-site.sh
+++ b/scripts/sync/rsync-package-to-site.sh
@@ -46,7 +46,7 @@
 # @arg      package-slug  required  {my-plugin}  Plugin/theme directory slug at the destination
 # @arg      source-dir    optional  {.}  Package working tree (default: current directory)
 # @flag     --dry-run     optional  {}  Preview the sync without writing anything
-# @example  wp-ops scripts/sync/rsync-package-to-site theme my-theme
+# @example  wp-ops rsync-package-to-site theme my-theme
 # @doc      docs/bedrock/local-package-development/README.md
 set -euo pipefail
 

--- a/scripts/sync/rsync-theme.sh
+++ b/scripts/sync/rsync-theme.sh
@@ -34,7 +34,7 @@
 # @runs     local
 # @requires rsync
 # @flag     --dry-run  optional  {}  Preview the sync without writing anything
-# @example  wp-ops scripts/sync/rsync-theme --dry-run
+# @example  wp-ops rsync-theme --dry-run
 set -euo pipefail
 
 # Trailing slashes matter to rsync: "src/" copies the *contents* of src.

--- a/scripts/woocommerce/create-product-variations.sh
+++ b/scripts/woocommerce/create-product-variations.sh
@@ -25,8 +25,8 @@
 # @runs     local
 # @requires trellis
 # @flag     --dry-run  optional  {}  Print the planned wp wc product_variation create commands without running them
-# @example  wp-ops scripts/woocommerce/create-product-variations
-# @example  wp-ops scripts/woocommerce/create-product-variations --dry-run
+# @example  wp-ops create-product-variations
+# @example  wp-ops create-product-variations --dry-run
 # @doc      docs/wordpress-utilities/snippets/woocommerce-product-attributes-wpcli.md
 #
 

--- a/trellis/security/README.md
+++ b/trellis/security/README.md
@@ -180,7 +180,7 @@ echo 'ABUSEIPDB_KEY=your_key_here' > trellis/security/.env
 ./trellis/security/check-ips.sh 203.0.113.50 198.51.100.25
 
 # Via wp-ops
-wp-ops trellis/security/check-ips 203.0.113.50
+wp-ops check-ips 203.0.113.50
 ```
 
 ### Requirements
@@ -231,7 +231,7 @@ TRELLIS_DIR=/path/to/trellis ./trellis/security/check-deny-ips.sh
 TRELLIS_DIR=/path/to/trellis ./trellis/security/check-deny-ips.sh --full
 
 # Via wp-ops
-TRELLIS_DIR=/path/to/trellis wp-ops trellis/security/check-deny-ips
+TRELLIS_DIR=/path/to/trellis wp-ops check-deny-ips
 ```
 
 ---

--- a/trellis/security/check-deny-ips.sh
+++ b/trellis/security/check-deny-ips.sh
@@ -64,7 +64,7 @@ if [[ "${1:-}" == "--full" ]]; then
     echo "Error: wp-ops not found on PATH." >&2
     exit 1
   fi
-  echo "$IPS" | xargs wp-ops trellis/security/check-ips
+  echo "$IPS" | xargs wp-ops check-ips
   exit 0
 fi
 

--- a/trellis/security/check-deny-ips.sh
+++ b/trellis/security/check-deny-ips.sh
@@ -21,8 +21,8 @@
 # @runs     local
 # @requires curl jq trellis
 # @flag     --full  optional  {}  Full JSON output per IP via check-ips.sh, instead of the compact summary
-# @example  wp-ops trellis/security/check-deny-ips
-# @example  wp-ops trellis/security/check-deny-ips --full
+# @example  wp-ops check-deny-ips
+# @example  wp-ops check-deny-ips --full
 # @doc      trellis/security/README.md
 
 set -euo pipefail

--- a/trellis/security/check-ips.sh
+++ b/trellis/security/check-ips.sh
@@ -16,7 +16,7 @@
 # @runs     local
 # @requires curl
 # @arg      ip  required  {1.2.3.4}  IP address to check (repeatable)
-# @example  wp-ops trellis/security/check-ips 1.2.3.4 5.6.7.8
+# @example  wp-ops check-ips 1.2.3.4 5.6.7.8
 # @doc      trellis/security/README.md
 
 set -euo pipefail

--- a/wp-cli/content-creation/import-page-draft.sh
+++ b/wp-cli/content-creation/import-page-draft.sh
@@ -33,8 +33,8 @@
 # @arg      site-name    optional  {example.com}  Site name under /srv/www (default: example.com)
 # @arg      environment  optional  {local|production|both}  Where to apply the update (default: local)
 # @arg      template     optional  {template-no-header.blade.php}  Optional _wp_page_template value to set
-# @example  wp-ops wp-cli/content-creation/import-page-draft draft.html 7673
-# @example  wp-ops wp-cli/content-creation/import-page-draft draft.html 7673 example.com both template-no-header.blade.php
+# @example  wp-ops import-page-draft draft.html 7673
+# @example  wp-ops import-page-draft draft.html 7673 example.com both template-no-header.blade.php
 
 set -e
 

--- a/wp-cli/content-creation/page-creation.sh
+++ b/wp-cli/content-creation/page-creation.sh
@@ -21,7 +21,7 @@
 # @arg      content-file  required  {about-page-content.html}  Local HTML file with the page content
 # @arg      page-title    required  {About}  Page title
 # @arg      page-slug     required  {about}  Page slug/post name
-# @example  wp-ops wp-cli/content-creation/page-creation about-page-content.html "About" about
+# @example  wp-ops page-creation about-page-content.html "About" about
 # @doc      wp-cli/content-creation/PAGE-CREATION.md
 
 set -e  # Exit on error

--- a/wp-cli/content-creation/wp-cli-pattern-validate.php
+++ b/wp-cli/content-creation/wp-cli-pattern-validate.php
@@ -47,7 +47,7 @@
  * @flag     --log-dir          optional  {docs/pattern-logs}  Override the log directory
  * @flag     --compliance       optional  {}  Also run project-specific compliance checks
  * @flag     --compliance-only  optional  {}  Skip Gutenberg validation, only run compliance checks
- * @example  wp-ops bedrock/wp-cli-config/wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix
+ * @example  wp-ops wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix
  * @doc      docs/bedrock/wp-cli-config/README.md
  */
 

--- a/wp-cli/diagnostics/diagnostic-transients.php
+++ b/wp-cli/diagnostics/diagnostic-transients.php
@@ -10,7 +10,7 @@
  * @platform wordpress
  * @runs     local
  * @requires wp
- * @example  wp-ops wp-cli/diagnostics/diagnostic-transients
+ * @example  wp-ops diagnostic-transients
  * @doc      wp-cli/diagnostics/README.md
  */
 

--- a/wp-cli/diagnostics/list-posts-count.sh
+++ b/wp-cli/diagnostics/list-posts-count.sh
@@ -6,7 +6,7 @@
 # @platform trellis
 # @runs     local
 # @requires ssh
-# @example  wp-ops wp-cli/diagnostics/list-posts-count
+# @example  wp-ops list-posts-count
 # @doc      wp-cli/diagnostics/README.md
 
 ssh web@example.com "cd /srv/www/example.com/current && wp post list --post_type=post --post_status=publish --fields=ID,post_title,post_name,post_date --path=web/wp --format=csv" > /tmp/all_posts.csv 2>&1

--- a/wp-cli/security/scanner-general.php
+++ b/wp-cli/security/scanner-general.php
@@ -38,7 +38,7 @@
  * @runs     local
  * @requires wp
  * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
- * @example  wp-ops wp-cli/security/scanner-general
+ * @example  wp-ops scanner-general
  * @doc      wp-cli/security/README.md
  */
 

--- a/wp-cli/security/scanner-targeted.php
+++ b/wp-cli/security/scanner-targeted.php
@@ -32,7 +32,7 @@
  * @runs     local
  * @requires wp
  * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
- * @example  wp-ops wp-cli/security/scanner-targeted
+ * @example  wp-ops scanner-targeted
  * @doc      wp-cli/security/README.md
  */
 

--- a/wp-cli/security/scanner-wrapper.php
+++ b/wp-cli/security/scanner-wrapper.php
@@ -18,7 +18,7 @@
  * @runs     local
  * @requires wp
  * @arg      path  optional  {/path/to/scan}  Directory to scan (defaults to WordPress root)
- * @example  wp-ops wp-cli/security/scanner-wrapper
+ * @example  wp-ops scanner-wrapper
  * @doc      wp-cli/security/README.md
  */
 

--- a/wp-cli/seo/blog-audit.sh
+++ b/wp-cli/seo/blog-audit.sh
@@ -22,7 +22,7 @@
 # @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
 # @flag     --output    optional  {audits}  Output directory
 # @flag     --site-url  optional  {https://example.com}  Site URL for reports
-# @example  wp-ops wp-cli/seo/blog-audit --path web/wp --output reports/seo
+# @example  wp-ops blog-audit --path web/wp --output reports/seo
 # @doc      wp-cli/seo/README.md
 
 set -euo pipefail

--- a/wp-cli/seo/orphan-pages-audit.sh
+++ b/wp-cli/seo/orphan-pages-audit.sh
@@ -22,7 +22,7 @@
 # @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
 # @flag     --output    optional  {audits}  Output directory
 # @flag     --site-url  optional  {https://example.com}  Site URL for reports
-# @example  wp-ops wp-cli/seo/orphan-pages-audit --path web/wp --output reports/seo
+# @example  wp-ops orphan-pages-audit --path web/wp --output reports/seo
 # @doc      wp-cli/seo/README.md
 
 set -euo pipefail

--- a/wp-cli/seo/page-audit.sh
+++ b/wp-cli/seo/page-audit.sh
@@ -22,7 +22,7 @@
 # @flag     --path      optional  {web/wp}  WordPress path for WP-CLI
 # @flag     --output    optional  {audits}  Output directory
 # @flag     --site-url  optional  {https://example.com}  Site URL for reports
-# @example  wp-ops wp-cli/seo/page-audit --path web/wp --output reports/seo
+# @example  wp-ops page-audit --path web/wp --output reports/seo
 # @doc      wp-cli/seo/README.md
 
 set -euo pipefail

--- a/wp-cli/seo/redirect-audit.sh
+++ b/wp-cli/seo/redirect-audit.sh
@@ -24,7 +24,7 @@
 # @flag     --url      required  {https://example.com}  URL to test (repeatable)
 # @flag     --verbose  optional  {}  Show detailed curl output
 # @flag     --output   optional  {results/audits}  Output directory for reports
-# @example  wp-ops wp-cli/seo/redirect-audit --url https://example.com --verbose
+# @example  wp-ops redirect-audit --url https://example.com --verbose
 # @doc      wp-cli/seo/README.md
 
 set -euo pipefail

--- a/wp-cli/seo/schema-audit.sh
+++ b/wp-cli/seo/schema-audit.sh
@@ -21,7 +21,7 @@
 # @arg      site-url  required  {https://example.com}  Site URL to check
 # @flag     --output  optional  {audits}  Output directory
 # @flag     --pages   optional  {/,/about/,/contact/}  Comma-separated page paths to check
-# @example  wp-ops wp-cli/seo/schema-audit https://example.com --pages /,/services/,/contact/
+# @example  wp-ops schema-audit https://example.com --pages /,/services/,/contact/
 # @doc      wp-cli/seo/README.md
 
 set -euo pipefail


### PR DESCRIPTION
`wp-ops scanner-targeted --help` printed a correct usage line and then, three
rows below it, `wp-ops wp-cli/security/scanner-targeted`.

5.1.0 fixed the usage line for every command and every executor — but it fixed
it by changing the code that *generates* it. Example lines are not generated;
they are prose copied verbatim out of each script's `@example` annotation, so
they were never touched. **42 of the 71 commands that carry examples** printed
at least one path-style invocation, 47 lines in total, in both render paths
(`exec.DetailBody` and `exec.writeManifestHelpBody` each print the string
unchanged).

The path forms still resolved, so nothing was broken for anyone who pasted one.
They were wrong in that they taught the long form as the command's name.

One was genuinely broken: `wp-cli-pattern-validate`'s example still named
`bedrock/wp-cli-config/`, a category 5.0.0 retired, so the line it told you to
type answered `Unknown command or category`. Same class of bug 5.1.1 fixed in
`README.md`, missed then because nobody thought to grep the *scripts* for the
retired category name.

## Root cause

The catalog validates its own structure but not its prose. `ShortName` is
guaranteed to resolve, `TestLoad_ShortNameUniqueBasenames` pins that, and CI
regenerates the catalog and diffs it. Every one of those checks is about the
*key*. The `Examples` field travelled from a shell comment onto the user's
screen without a single assertion that the thing it told them to type exists.

## Approach

A sweep alone would fix today's output and guard nothing — the next rename
reintroduces it exactly as 5.1.1's would have, had its two `@example` lines not
happened to be the subject of that PR. Normalizing in the generator was
rejected: it would bake `ShortName` into `catalog.json`, which
`catalog.go:78-81` deliberately refuses to do, and it would leave the source
files lying, which matters because a script header is read directly at least as
often as through `--help`.

So: validate in the `catalog` package, then sweep once. The test works
post-`Load`, reading the real `ShortName` without persisting it.

## Commits

1. **The test, red.** Extracts the token after `wp-ops` — skipping `VAR=value`
   environment prefixes, which `screenshot-patterns`' example carries — and
   requires it to equal the entry's `ShortName`. It reproduced the 42/47 count
   independently, so it is both the audit and the guard, with no window where
   the guard exists but the sweep has not landed.
2. **The 47-line sweep**, across 42 scripts, plus the regenerated catalog.
   Command token only; arguments, flags and environment prefixes untouched.
   One change applied 47 times, kept as one commit despite the atomic-commit
   rule.
3. **The four Go sites** no sweep of the scripts could reach — the macOS
   access-log hint, the missing-argument error, the unannotated-playbook
   fallback — now read through `CommandName()`. The ambiguity message and
   `search` listing keep printing full keys, where the path is the point.

   The backup hints in `serverside.go`, `db-backup.sh` and `site-backup.sh`
   were stale twice over: path form *and* the `-e site=` syntax the playbooks
   stopped accepting when they moved to positional arguments. They now print
   `wp-ops database-pull example.com production`. `serverside_test.go` pinned
   the old strings, so its expectations move with them.

   `check-deny-ips.sh:67` was not a hint but a real invocation piping into
   `check-ips` — the one place a rename would have broken a code path rather
   than a comment.

Plus `docs/trellis-cli-comparison.md` §5, which asserted in the present tense
something its own status header says 5.1.0 fixed, and two
`trellis/security/README.md` invocations. Documents that quote the path form
*as the problem being analysed* were left alone.

## Verification

`go test ./...` passes. Both symptoms confirmed against the built binary:

```
$ wp-ops wp-cli-pattern-validate --help
Examples:
  wp-ops wp-cli-pattern-validate web/app/themes/theme-name/patterns/ --fix
```

`go/internal/manifest/testdata/` keeps its path-style examples — the parser must
go on accepting the form — and was kept out of the sweep.

## Not in scope

`search` prints full keys and `list` prints bare basenames, so the same command
appears under two names depending on how you found it. Neither is wrong on its
own terms; it is a UX call rather than a correctness one, and it stays open in
`docs/example-line-drift.md` §7.