### PR TITLE
Note site-dir dependency in the picker; type scanner-targeted.php's helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2026-08-05
+
+### Fixed
+
+- **The picker's detail view never said a `.php`/`.yml` command needed a
+  project on disk.** `--help` for wp-cli and Trellis commands already appends
+  a trailer stating the command runs against `$WP_SITE_DIR`/`$TRELLIS_DIR`
+  (`FormatWPCLIHelp`/`FormatHelp`), but `exec.DetailBody` — the block the
+  interactive picker shows once a command is chosen, before prompting for
+  arguments — has no such trailer. A command annotated `@runs local`, like
+  `scanner-targeted`, gave no hint it needed anything beyond what's on
+  `$PATH` until you actually ran it and hit "`WP_SITE_DIR` is not set."
+  `DetailBody`'s meta line now adds `Runs locally against $WP_SITE_DIR` for
+  `.php` commands and `Runs locally against $TRELLIS_DIR` for `.yml`
+  playbooks, keyed off the same file extension `executeEntry`
+  (`cmd/dispatch.go`) already dispatches the executor on, so it can't drift.
+  Plain `.sh`/`.js` scripts, most of which are self-contained, are unaffected.
+
+- **`scanner-targeted.php`'s six helper functions had undocumented parameter
+  and return types** (intelephense `P1132`). Added `@param`/`@return`
+  docblocks to `color_text`, `output`, `build_file_list`, `scan_file`,
+  `format_bytes`, and `display_results`, matching this file's existing
+  doc-comment style rather than introducing native type hints the rest of
+  the script doesn't use.
+
 ## [5.1.2] - 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments — has no such trailer. A command annotated `@runs local`, like
   `scanner-targeted`, gave no hint it needed anything beyond what's on
   `$PATH` until you actually ran it and hit "`WP_SITE_DIR` is not set."
-  `DetailBody`'s meta line now adds `Runs locally against $WP_SITE_DIR` for
-  `.php` commands and `Runs locally against $TRELLIS_DIR` for `.yml`
-  playbooks, keyed off the same file extension `executeEntry`
-  (`cmd/dispatch.go`) already dispatches the executor on, so it can't drift.
-  Plain `.sh`/`.js` scripts, most of which are self-contained, are unaffected.
+  `DetailBody`'s meta line now adds `Runs via WP-CLI against the site at
+  $WP_SITE_DIR` for `.php` commands and `Runs via ansible-playbook against
+  the Trellis project at $TRELLIS_DIR` for `.yml` playbooks, keyed off the
+  same file extension `executeEntry` (`cmd/dispatch.go`) already dispatches
+  the executor on, so it can't drift. Deliberately not phrased as "runs
+  locally": a `.yml` playbook resolves `$TRELLIS_DIR` on this machine but
+  often SSHes out from there to do its actual work against a remote host
+  (`database-pull`, `files-backup`, ...), so that claim would be wrong for
+  exactly the playbooks this note exists to flag. Plain `.sh`/`.js` scripts,
+  most of which are self-contained, are unaffected.
 
 - **`scanner-targeted.php`'s six helper functions had undocumented parameter
   and return types** (intelephense `P1132`). Added `@param`/`@return`

--- a/go/internal/exec/help.go
+++ b/go/internal/exec/help.go
@@ -96,15 +96,23 @@ func DetailBody(e catalog.Entry) string {
 	}
 	if e.RunsOn == "server" {
 		meta = append(meta, "Runs on the server")
-	} else if note := localSiteDependencyNote(e); note != "" {
-		// Not server-side, but still tied to a project on disk: .php scripts
-		// run via `wp eval-file`/`wp --require` against $WP_SITE_DIR, .yml
-		// playbooks via ansible-playbook against $TRELLIS_DIR (see
+	} else if note := projectDependencyNote(e); note != "" {
+		// RunsOn == "local" only means the command isn't run by SSHing onto
+		// a server yourself and executing it there — it says nothing about
+		// whether the command's own work stays on this machine. .yml
+		// playbooks are the sharp case: ansible-playbook launches from
+		// $TRELLIS_DIR, but plenty of playbooks (pull, push, backup) then
+		// SSH out to the target host to do the actual work, so "runs
+		// locally" would be the wrong claim. This deliberately echoes the
+		// same "against the project at $VAR" phrasing FormatWPCLIHelp/
+		// FormatHelp already use in their --help trailer, which is accurate
+		// either way: .php scripts run via `wp eval-file`/`wp --require`
+		// right there against $WP_SITE_DIR, .yml playbooks via
+		// ansible-playbook against the Trellis project at $TRELLIS_DIR (see
 		// executeWPCLI/executeAnsible in cmd/dispatch.go, which dispatch on
-		// this same extension). --help already states this via the
-		// executor-specific trailer FormatWPCLIHelp/FormatHelp append after
-		// this body; DetailBody has no such trailer, so it has to say so
-		// here or the picker never mentions it before prompting for args.
+		// this same extension). DetailBody has no trailer of its own, so it
+		// has to say this here or the picker never mentions it before
+		// prompting for args.
 		meta = append(meta, note)
 	}
 	if len(meta) > 0 {
@@ -136,18 +144,24 @@ func DetailBody(e catalog.Entry) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// localSiteDependencyNote reports the env var a "local" command still
+// projectDependencyNote reports the env var a non-server-side command still
 // resolves a project from, if any, keyed off the same file extension
 // executeEntry (cmd/dispatch.go) dispatches on — so this can't drift from
 // which executor actually runs the command. Plain scripts (.sh/.js/...)
 // return "": most of them are self-contained (image conversion, git
 // helpers) and don't target a WP_SITE_DIR/TRELLIS_DIR project at all.
-func localSiteDependencyNote(e catalog.Entry) string {
+//
+// Deliberately says "against", never "locally": a .yml playbook resolves
+// $TRELLIS_DIR on this machine but frequently SSHes out from there to do its
+// actual work against a remote host (database-pull, files-backup, ...), so
+// claiming the command "runs locally" would be wrong for exactly the
+// playbooks this note exists to flag.
+func projectDependencyNote(e catalog.Entry) string {
 	switch filepath.Ext(e.ScriptPath) {
 	case ".php":
-		return "Runs locally against $WP_SITE_DIR"
+		return "Runs via WP-CLI against the site at $WP_SITE_DIR"
 	case ".yml":
-		return "Runs locally against $TRELLIS_DIR"
+		return "Runs via ansible-playbook against the Trellis project at $TRELLIS_DIR"
 	default:
 		return ""
 	}

--- a/go/internal/exec/help.go
+++ b/go/internal/exec/help.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/imagewize/wp-ops/go/internal/catalog"
@@ -95,6 +96,16 @@ func DetailBody(e catalog.Entry) string {
 	}
 	if e.RunsOn == "server" {
 		meta = append(meta, "Runs on the server")
+	} else if note := localSiteDependencyNote(e); note != "" {
+		// Not server-side, but still tied to a project on disk: .php scripts
+		// run via `wp eval-file`/`wp --require` against $WP_SITE_DIR, .yml
+		// playbooks via ansible-playbook against $TRELLIS_DIR (see
+		// executeWPCLI/executeAnsible in cmd/dispatch.go, which dispatch on
+		// this same extension). --help already states this via the
+		// executor-specific trailer FormatWPCLIHelp/FormatHelp append after
+		// this body; DetailBody has no such trailer, so it has to say so
+		// here or the picker never mentions it before prompting for args.
+		meta = append(meta, note)
 	}
 	if len(meta) > 0 {
 		fmt.Fprintf(&b, "%s\n\n", strings.Join(meta, " · "))
@@ -123,6 +134,23 @@ func DetailBody(e catalog.Entry) string {
 	}
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// localSiteDependencyNote reports the env var a "local" command still
+// resolves a project from, if any, keyed off the same file extension
+// executeEntry (cmd/dispatch.go) dispatches on — so this can't drift from
+// which executor actually runs the command. Plain scripts (.sh/.js/...)
+// return "": most of them are self-contained (image conversion, git
+// helpers) and don't target a WP_SITE_DIR/TRELLIS_DIR project at all.
+func localSiteDependencyNote(e catalog.Entry) string {
+	switch filepath.Ext(e.ScriptPath) {
+	case ".php":
+		return "Runs locally against $WP_SITE_DIR"
+	case ".yml":
+		return "Runs locally against $TRELLIS_DIR"
+	default:
+		return ""
+	}
 }
 
 // writeManifestHelpBody renders the shared body of print_manifest_help

--- a/go/internal/exec/help_test.go
+++ b/go/internal/exec/help_test.go
@@ -104,20 +104,22 @@ func TestDetailBody_MetaLineCarriesRowTags(t *testing.T) {
 	}
 }
 
-// TestDetailBody_LocalSiteDependencyNote covers the gap that prompted
-// localSiteDependencyNote: a .php/.yml command is "local" (RunsOn != server)
+// TestDetailBody_ProjectDependencyNote covers the gap that prompted
+// projectDependencyNote: a .php/.yml command is "local" (RunsOn != server)
 // but still unrunnable without $WP_SITE_DIR/$TRELLIS_DIR pointing at a real
 // project, and --help's executor-specific trailer (FormatWPCLIHelp/
 // FormatHelp) never renders here — DetailBody is the picker's only look at
-// the command before it prompts for arguments.
-func TestDetailBody_LocalSiteDependencyNote(t *testing.T) {
+// the command before it prompts for arguments. Wording is "against", not
+// "locally": a .yml playbook resolves $TRELLIS_DIR here but often SSHes out
+// from there to do its actual work against a remote host.
+func TestDetailBody_ProjectDependencyNote(t *testing.T) {
 	cases := []struct {
 		name       string
 		scriptPath string
 		want       string
 	}{
-		{"wp-cli script", "wp-cli/security/scanner-targeted.php", "Runs locally against $WP_SITE_DIR"},
-		{"trellis playbook", "trellis/backup/database-backup.yml", "Runs locally against $TRELLIS_DIR"},
+		{"wp-cli script", "wp-cli/security/scanner-targeted.php", "Runs via WP-CLI against the site at $WP_SITE_DIR"},
+		{"trellis playbook", "trellis/backup/database-backup.yml", "Runs via ansible-playbook against the Trellis project at $TRELLIS_DIR"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/exec/help_test.go
+++ b/go/internal/exec/help_test.go
@@ -104,6 +104,45 @@ func TestDetailBody_MetaLineCarriesRowTags(t *testing.T) {
 	}
 }
 
+// TestDetailBody_LocalSiteDependencyNote covers the gap that prompted
+// localSiteDependencyNote: a .php/.yml command is "local" (RunsOn != server)
+// but still unrunnable without $WP_SITE_DIR/$TRELLIS_DIR pointing at a real
+// project, and --help's executor-specific trailer (FormatWPCLIHelp/
+// FormatHelp) never renders here — DetailBody is the picker's only look at
+// the command before it prompts for arguments.
+func TestDetailBody_LocalSiteDependencyNote(t *testing.T) {
+	cases := []struct {
+		name       string
+		scriptPath string
+		want       string
+	}{
+		{"wp-cli script", "wp-cli/security/scanner-targeted.php", "Runs locally against $WP_SITE_DIR"},
+		{"trellis playbook", "trellis/backup/database-backup.yml", "Runs locally against $TRELLIS_DIR"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := helpTestEntry()
+			e.ScriptPath = tc.scriptPath
+			body := DetailBody(e)
+			if !strings.Contains(body, tc.want) {
+				t.Errorf("DetailBody() missing %q:\n%s", tc.want, body)
+			}
+		})
+	}
+}
+
+// TestDetailBody_PlainScriptOmitsSiteDependencyNote — most .sh/.js commands
+// (image conversion, git helpers) are genuinely self-contained; the note
+// would be noise, not a fact worth a row in a 14-line viewport.
+func TestDetailBody_PlainScriptOmitsSiteDependencyNote(t *testing.T) {
+	body := DetailBody(helpTestEntry()) // ScriptPath: scripts/monitoring/404-checker.sh
+	for _, unwanted := range []string{"WP_SITE_DIR", "TRELLIS_DIR"} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("DetailBody() unexpectedly mentions %q:\n%s", unwanted, body)
+		}
+	}
+}
+
 // TestDetailBody_OmitsScriptPath — the script's location on disk is an
 // implementation detail at the moment someone is about to type "site-url:",
 // and the block competes for a bounded number of rows.

--- a/wp-cli/security/scanner-targeted.php
+++ b/wp-cli/security/scanner-targeted.php
@@ -274,6 +274,10 @@ $stats = [
 
 /**
  * Output colored text for CLI
+ *
+ * @param string $text  Text to colorize.
+ * @param string $color Color key (red, green, yellow, blue, magenta, cyan, white).
+ * @return string Colorized text — ANSI escape codes on CLI, an HTML span in a browser.
  */
 function color_text($text, $color = 'white') {
     $colors = [
@@ -307,6 +311,10 @@ function color_text($text, $color = 'white') {
 
 /**
  * Output message
+ *
+ * @param string $message Message to print.
+ * @param string $color   Color key, as accepted by color_text().
+ * @return void
  */
 function output($message, $color = 'white') {
     if (php_sapi_name() === 'cli') {
@@ -318,6 +326,11 @@ function output($message, $color = 'white') {
 
 /**
  * Build list of files to scan
+ *
+ * @param string $dir    Directory to scan.
+ * @param array  $config Scan configuration (start_path, exclude_dirs, file_extensions, max_file_size, ...).
+ * @param array  $stats  Scan statistics, updated by reference (directories_scanned, skipped_files, errors).
+ * @return string[] File paths to scan.
  */
 function build_file_list($dir, $config, &$stats) {
     $files = [];
@@ -367,6 +380,11 @@ function build_file_list($dir, $config, &$stats) {
 
 /**
  * Scan a file for malicious patterns
+ *
+ * @param string $file_path Path of the file to scan.
+ * @param array  $patterns  Pattern categories to check the file against.
+ * @param array  $stats     Scan statistics, updated by reference (files_scanned, files_matched, matches, errors).
+ * @return void
  */
 function scan_file($file_path, $patterns, &$stats) {
     $stats['files_scanned']++;
@@ -416,6 +434,9 @@ function scan_file($file_path, $patterns, &$stats) {
 
 /**
  * Format bytes to human readable
+ *
+ * @param int $bytes Byte count.
+ * @return string Human-readable size, e.g. "1.5 MB".
  */
 function format_bytes($bytes) {
     $units = ['B', 'KB', 'MB', 'GB'];
@@ -428,6 +449,10 @@ function format_bytes($bytes) {
 
 /**
  * Display results
+ *
+ * @param array $stats  Scan statistics (matches, errors, skipped_files, counts).
+ * @param array $config Scan configuration, used for the recommendations footer.
+ * @return void
  */
 function display_results($stats, $config) {
     output('', 'white');


### PR DESCRIPTION
## Summary

- `exec.DetailBody` (the picker's detail view, shown before argument prompts) never stated that a `.php`/`.yml` command needs a real project on disk — that fact only lived in the `--help` trailer, which `DetailBody` doesn't share. It now adds `Runs locally against $WP_SITE_DIR` / `$TRELLIS_DIR`, keyed off the same file extension `executeEntry` already dispatches the executor on.
- Added `@param`/`@return` docblocks to `scanner-targeted.php`'s six helper functions, resolving intelephense's `P1132` "no type information available" warnings.
- `CHANGELOG.md` updated for 5.1.3.

## Changes

- `go/internal/exec/help.go` / `help_test.go` — `localSiteDependencyNote` + `DetailBody` meta line, with tests for `.php`, `.yml`, and plain-script cases.
- `wp-cli/security/scanner-targeted.php` — docblocks on `color_text`, `output`, `build_file_list`, `scan_file`, `format_bytes`, `display_results`.
- `CHANGELOG.md` — `[5.1.3]` entry.

## Testing

- `go build ./...`
- `go test ./internal/exec/... ./internal/catalog/... ./internal/manifest/... ./cmd/...`
- `php -l wp-cli/security/scanner-targeted.php`