### PR TITLE
Add wp-ops mcp-register command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - 2026-08-06
+
+### Added
+
+- **`wp-ops mcp-register`** — a native Go command (not a catalog script; same
+  bucket as `doctor`/`init`, since it's meta-tooling about wp-ops's own setup
+  rather than a WordPress/Trellis operation) that checks `~/.claude.json`,
+  `~/.vibe/config.toml`, and `~/.codex/config.toml` for an existing wp-ops MCP
+  entry and prints the exact block to add for whichever ones are missing it,
+  with the real resolved path to `mcp-server/run.sh` already filled in (via
+  the same `repoRoot()` dev-checkout-or-extracted-assets resolution every
+  other command uses). Read-only — never writes to a config file it doesn't
+  own. Claude's config is parsed as real JSON (`encoding/json`); Mistral's and
+  Codex's as real TOML (new `github.com/BurntSushi/toml` dependency), so
+  "already registered" detection doesn't rely on string-matching a file it
+  didn't validate. Documented in `mcp-server/README.md`'s new "Quick check"
+  section, ahead of the three manual "Register with ..." sections.
+
 ## [5.1.4] - 2026-08-06
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/go/cmd/mcpregister.go
+++ b/go/cmd/mcpregister.go
@@ -1,0 +1,259 @@
+// mcp-register: detect + print. Checks whether the MCP client configs wp-ops
+// knows how to register with (Claude Code, Mistral Vibe, OpenAI Codex CLI)
+// already have a wp-ops stdio entry, and for each one that's missing it,
+// prints the exact block to add — using the real, resolved path to
+// mcp-server/run.sh (via repoRoot(), the same dev-checkout-or-extracted-
+// assets resolution every other command already uses).
+//
+// Deliberately read-only: it never writes to a config file it doesn't own.
+// Claude's ~/.claude.json in particular can carry a lot of unrelated state
+// (per-project settings, etc.) that a naive rewrite could clobber; printing
+// the snippet and letting the user paste it is the safe default. Auto-write
+// is a reasonable follow-up once this is something run often enough (a
+// second machine, a teammate) to justify that risk — see the discussion in
+// mcp-server/README.md's registration sections.
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/spf13/cobra"
+)
+
+var mcpRegisterCmd = &cobra.Command{
+	Use:   "mcp-register",
+	Short: "Show MCP registration snippets for Claude Code, Mistral Vibe, and Codex CLI",
+	Long: `mcp-register checks whether ~/.claude.json, ~/.vibe/config.toml, and
+~/.codex/config.toml already have a wp-ops MCP entry, and for each one
+missing it, prints the exact stdio block to add — using the real, resolved
+path to mcp-server/run.sh.
+
+Read-only: never writes to a config file it doesn't own.`,
+	RunE: func(cc *cobra.Command, args []string) error {
+		os.Exit(runMCPRegister())
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(mcpRegisterCmd)
+}
+
+type regStatus int
+
+const (
+	regNotFound regStatus = iota
+	regAlreadyRegistered
+	regNeedsRegistration
+	regParseError
+)
+
+type regReport struct {
+	client   string
+	path     string
+	status   regStatus
+	snippet  string // set for regNeedsRegistration and regNotFound
+	parseErr error  // set for regParseError
+}
+
+func runMCPRegister() int {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-register: %v\n", err)
+		return 1
+	}
+	runSh := filepath.Join(root, "mcp-server", "run.sh")
+	if info, statErr := os.Stat(runSh); statErr != nil || info.IsDir() {
+		fmt.Fprintf(os.Stderr, "mcp-register: expected %s to exist — is your wp-ops checkout/extraction intact?\n", runSh)
+		return 1
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-register: %v\n", err)
+		return 1
+	}
+
+	reports := []regReport{
+		checkClaudeConfig(filepath.Join(home, ".claude.json"), runSh),
+		checkVibeConfig(filepath.Join(home, ".vibe", "config.toml"), runSh),
+		checkCodexConfig(filepath.Join(home, ".codex", "config.toml"), runSh),
+	}
+	for i, r := range reports {
+		if i > 0 {
+			fmt.Println()
+		}
+		printReport(r)
+	}
+	return 0
+}
+
+func printReport(r regReport) {
+	fmt.Printf("%s (%s):\n", r.client, r.path)
+	switch r.status {
+	case regNotFound:
+		fmt.Println("  not found — this client doesn't appear to be set up on this machine yet.")
+		fmt.Println("  To register wp-ops once it is, create that file with:")
+		fmt.Println()
+		fmt.Println(indent(r.snippet))
+	case regAlreadyRegistered:
+		fmt.Println("  already registered.")
+	case regNeedsRegistration:
+		fmt.Println("  no wp-ops entry found. Add this block:")
+		fmt.Println()
+		fmt.Println(indent(r.snippet))
+	case regParseError:
+		fmt.Printf("  found but couldn't parse (%v) — check it by hand; see mcp-server/README.md for the manual snippet.\n", r.parseErr)
+	}
+}
+
+func indent(s string) string {
+	out := "  "
+	for _, r := range s {
+		out += string(r)
+		if r == '\n' {
+			out += "  "
+		}
+	}
+	return out
+}
+
+// --- Claude Code (~/.claude.json, JSON) ---
+
+type claudeConfig struct {
+	McpServers map[string]any `json:"mcpServers"`
+}
+
+func checkClaudeConfig(path, runSh string) regReport {
+	r := regReport{client: "Claude Code", path: path}
+
+	snippet := fmt.Sprintf(`{
+  "mcpServers": {
+    "wp-ops": {
+      "command": %q,
+      "args": []
+    }
+  }
+}`, runSh)
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		r.status = regNotFound
+		r.snippet = snippet
+		return r
+	}
+	if err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+
+	var cfg claudeConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+	if _, ok := cfg.McpServers["wp-ops"]; ok {
+		r.status = regAlreadyRegistered
+		return r
+	}
+	r.status = regNeedsRegistration
+	// Only the entry to merge in, not the whole file — ~/.claude.json
+	// already exists and almost certainly has other settings alongside it.
+	r.snippet = fmt.Sprintf(`"wp-ops": {
+  "command": %q,
+  "args": []
+}`, runSh)
+	return r
+}
+
+// --- Mistral Vibe (~/.vibe/config.toml, [[mcp_servers]] array of tables) ---
+
+type vibeConfig struct {
+	McpServers []struct {
+		Name string `toml:"name"`
+	} `toml:"mcp_servers"`
+}
+
+func checkVibeConfig(path, runSh string) regReport {
+	r := regReport{client: "Mistral Vibe", path: path}
+
+	snippet := fmt.Sprintf(`[[mcp_servers]]
+name = "wp_ops"
+transport = "stdio"
+command = %q
+args = []`, runSh)
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		r.status = regNotFound
+		r.snippet = snippet
+		return r
+	}
+	if err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+
+	var cfg vibeConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+	for _, s := range cfg.McpServers {
+		if s.Name == "wp_ops" {
+			r.status = regAlreadyRegistered
+			return r
+		}
+	}
+	r.status = regNeedsRegistration
+	r.snippet = snippet
+	return r
+}
+
+// --- OpenAI Codex CLI (~/.codex/config.toml, [mcp_servers.<name>] keyed table) ---
+
+type codexConfig struct {
+	McpServers map[string]any `toml:"mcp_servers"`
+}
+
+func checkCodexConfig(path, runSh string) regReport {
+	r := regReport{client: "OpenAI Codex CLI", path: path}
+
+	snippet := fmt.Sprintf(`[mcp_servers.wp_ops]
+command = %q
+args = []`, runSh)
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		r.status = regNotFound
+		r.snippet = snippet
+		return r
+	}
+	if err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+
+	var cfg codexConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		r.status = regParseError
+		r.parseErr = err
+		return r
+	}
+	if _, ok := cfg.McpServers["wp_ops"]; ok {
+		r.status = regAlreadyRegistered
+		return r
+	}
+	r.status = regNeedsRegistration
+	r.snippet = snippet
+	return r
+}

--- a/go/cmd/mcpregister_test.go
+++ b/go/cmd/mcpregister_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const runShPath = "/fake/wp-ops/mcp-server/run.sh"
+
+func TestCheckClaudeConfig(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("file missing", func(t *testing.T) {
+		r := checkClaudeConfig(filepath.Join(tmp, "does-not-exist.json"), runShPath)
+		if r.status != regNotFound {
+			t.Fatalf("status = %v, want regNotFound", r.status)
+		}
+		if !strings.Contains(r.snippet, runShPath) {
+			t.Errorf("snippet %q missing run.sh path", r.snippet)
+		}
+	})
+
+	t.Run("already registered", func(t *testing.T) {
+		path := filepath.Join(tmp, "registered.json")
+		content := `{"mcpServers":{"wp-ops":{"command":"node","args":["x"]}},"projects":{}}`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkClaudeConfig(path, runShPath)
+		if r.status != regAlreadyRegistered {
+			t.Fatalf("status = %v, want regAlreadyRegistered", r.status)
+		}
+	})
+
+	t.Run("needs registration, other servers present", func(t *testing.T) {
+		path := filepath.Join(tmp, "other.json")
+		content := `{"mcpServers":{"some-other-tool":{"command":"x"}}}`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkClaudeConfig(path, runShPath)
+		if r.status != regNeedsRegistration {
+			t.Fatalf("status = %v, want regNeedsRegistration", r.status)
+		}
+		if !strings.Contains(r.snippet, `"wp-ops"`) || !strings.Contains(r.snippet, runShPath) {
+			t.Errorf("snippet missing expected content: %q", r.snippet)
+		}
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		path := filepath.Join(tmp, "broken.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkClaudeConfig(path, runShPath)
+		if r.status != regParseError {
+			t.Fatalf("status = %v, want regParseError", r.status)
+		}
+		if r.parseErr == nil {
+			t.Error("parseErr = nil, want non-nil")
+		}
+	})
+}
+
+func TestCheckVibeConfig(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("file missing", func(t *testing.T) {
+		r := checkVibeConfig(filepath.Join(tmp, "does-not-exist.toml"), runShPath)
+		if r.status != regNotFound {
+			t.Fatalf("status = %v, want regNotFound", r.status)
+		}
+	})
+
+	t.Run("already registered among other servers", func(t *testing.T) {
+		path := filepath.Join(tmp, "registered.toml")
+		content := `
+[[mcp_servers]]
+name = "fetch_server"
+transport = "stdio"
+command = "uvx"
+args = ["mcp-server-fetch"]
+
+[[mcp_servers]]
+name = "wp_ops"
+transport = "stdio"
+command = "/some/path/run.sh"
+args = []
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkVibeConfig(path, runShPath)
+		if r.status != regAlreadyRegistered {
+			t.Fatalf("status = %v, want regAlreadyRegistered", r.status)
+		}
+	})
+
+	t.Run("needs registration", func(t *testing.T) {
+		path := filepath.Join(tmp, "other.toml")
+		content := `
+[[mcp_servers]]
+name = "fetch_server"
+transport = "stdio"
+command = "uvx"
+args = ["mcp-server-fetch"]
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkVibeConfig(path, runShPath)
+		if r.status != regNeedsRegistration {
+			t.Fatalf("status = %v, want regNeedsRegistration", r.status)
+		}
+		if !strings.Contains(r.snippet, `name = "wp_ops"`) || !strings.Contains(r.snippet, runShPath) {
+			t.Errorf("snippet missing expected content: %q", r.snippet)
+		}
+	})
+
+	t.Run("malformed toml", func(t *testing.T) {
+		path := filepath.Join(tmp, "broken.toml")
+		if err := os.WriteFile(path, []byte("[[mcp_servers]\nname = "), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkVibeConfig(path, runShPath)
+		if r.status != regParseError {
+			t.Fatalf("status = %v, want regParseError", r.status)
+		}
+	})
+}
+
+func TestCheckCodexConfig(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("file missing", func(t *testing.T) {
+		r := checkCodexConfig(filepath.Join(tmp, "does-not-exist.toml"), runShPath)
+		if r.status != regNotFound {
+			t.Fatalf("status = %v, want regNotFound", r.status)
+		}
+	})
+
+	t.Run("already registered among other servers", func(t *testing.T) {
+		path := filepath.Join(tmp, "registered.toml")
+		content := `
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+
+[mcp_servers.wp_ops]
+command = "/some/path/run.sh"
+args = []
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkCodexConfig(path, runShPath)
+		if r.status != regAlreadyRegistered {
+			t.Fatalf("status = %v, want regAlreadyRegistered", r.status)
+		}
+	})
+
+	t.Run("needs registration", func(t *testing.T) {
+		path := filepath.Join(tmp, "other.toml")
+		content := `
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp"]
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := checkCodexConfig(path, runShPath)
+		if r.status != regNeedsRegistration {
+			t.Fatalf("status = %v, want regNeedsRegistration", r.status)
+		}
+		if !strings.Contains(r.snippet, `[mcp_servers.wp_ops]`) || !strings.Contains(r.snippet, runShPath) {
+			t.Errorf("snippet missing expected content: %q", r.snippet)
+		}
+	})
+}
+
+// TestPrintReportDoesNotPanic is a light smoke test over the four status
+// branches — printReport's formatting isn't asserted character-for-character
+// elsewhere, so this just guards against a panic (e.g. a nil parseErr
+// dereference) regressing silently.
+func TestPrintReportDoesNotPanic(t *testing.T) {
+	reports := []regReport{
+		{client: "X", path: "/x", status: regNotFound, snippet: "snippet"},
+		{client: "X", path: "/x", status: regAlreadyRegistered},
+		{client: "X", path: "/x", status: regNeedsRegistration, snippet: "snippet"},
+		{client: "X", path: "/x", status: regParseError, parseErr: errors.New("boom")},
+	}
+	for _, r := range reports {
+		captureStdout(t, func() { printReport(r) })
+	}
+}

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -34,6 +34,7 @@ playbooks, and more.
   wp-ops docs [term] [-l]                 Search the guides (no term lists them)
   wp-ops doctor                           Check dependencies and environment
   wp-ops init                             Install shell completions
+  wp-ops mcp-register                     Show MCP registration snippets for Claude/Mistral/Codex
   wp-ops --json                           Output the command list as JSON
   wp-ops --version                        Show version`,
 	// Arbitrary args: a bare command name that isn't one of the explicitly

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -91,6 +91,15 @@ npm run build
 `config/sites.json` is gitignored since it encodes your local paths/hosts. Set
 `WP_OPS_SITES_CONFIG=/path/to/sites.json` to point at a different location.
 
+## Quick check: `wp-ops mcp-register`
+
+Before doing any of this by hand, run `wp-ops mcp-register`. It checks
+`~/.claude.json`, `~/.vibe/config.toml`, and `~/.codex/config.toml` for an
+existing wp-ops entry and, for whichever ones are missing it, prints the exact
+block to paste — with the real path to `run.sh` on this machine already filled
+in, so there's no `/absolute/path/to/wp-ops/...` placeholder to get wrong.
+Read-only: it never writes to a config file itself.
+
 ## Register with Claude Code
 
 **Recommended:** Register the server **user-scoped** in `~/.claude.json` so the tools


### PR DESCRIPTION
## What

Detect-and-print helper for wiring wp-ops into an MCP client: checks
`~/.claude.json`, `~/.vibe/config.toml`, and `~/.codex/config.toml` for an
existing wp-ops entry, and for whichever ones are missing it, prints the
exact block to paste — with the real resolved path to `mcp-server/run.sh`
already filled in, not a placeholder.

## Why native Go, not a catalog script

Discussed in conversation: the repo's stated convention
(`docs/go-mcp-parity.md`) is "a new capability lands as a script first" — that
wasn't being overridden here. `mcp-register` fits the same narrower bucket
`doctor`/`init`/`list`/`search`/`docs` already occupy: meta-tooling about
wp-ops's own setup, not a WordPress/Trellis/curl operation, which is what the
script-first rule is actually about. It also gets a real correctness win from
Go's stdlib: Claude's config is validated as actual JSON, and Mistral's/Codex's
as actual TOML (new `github.com/BurntSushi/toml` dep), rather than
string-matching a file that was never parsed.

## Behavior

- Read-only — never writes to a config file it doesn't own.
- Resolves `mcp-server/run.sh`'s real path via the existing `repoRoot()`
  helper (dev checkout via `WP_OPS_ROOT`/walk-up, or the extracted-assets
  cache dir for a pure Homebrew install) — same resolution every other
  command already uses.
- Four states handled per client: file missing (prints the full snippet to
  create it with), already registered, needs registration (prints the block
  to add), and parse error (reports it, points at the manual README section).

Manually verified against my own machine: correctly reported "already
registered" for Claude Code's real `~/.claude.json`, and correctly parsed my
real (non-trivial, pre-existing) `~/.vibe/config.toml` and
`~/.codex/config.toml` — both of which are already in real use here — finding
no wp-ops entry in either, as expected.

## Also

- `mcp-server/README.md`: new "Quick check: `wp-ops mcp-register`" section
  ahead of the three manual "Register with ..." sections.
- Not a catalog command — no `go generate` needed, `catalog.json` untouched.

## Version

Minor bump (5.1.4 → 5.2.0) — new capability.