### PR TITLE
feat(mcp-server): expand MCP tools from 7 to 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   directly against the AbuseIPDB API rather than shelling out to `curl`/`jq`.
   Reads the same `trellis/security/.env` `ABUSEIPDB_KEY` the CLI scripts use,
   or `WP_OPS_ABUSEIPDB_KEY` as an override.
+- **`admin_user_create` MCP tool** — wraps `wp-cli/security/admin-user-create.sh`
+  (lockout recovery: create a temporary WordPress admin with a generated
+  password, shown once and never stored) by reusing `wp_cli`'s existing
+  `runWpCliRaw` dispatch instead of reimplementing local/SSH/VM execution —
+  the script's three steps (check username, check email, create) are just
+  three WP-CLI calls against an already-resolved site/env entry. Requires
+  `confirm: true`.
 
 ## [5.3.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the script's three steps (check username, check email, create) are just
   three WP-CLI calls against an already-resolved site/env entry. Requires
   `confirm: true`.
+- **`db_pull` MCP tool** — ports `scripts/backup/db-pull.sh`'s workflow (pull
+  a remote database into local development, with URL search-replace and a
+  pre-pull backup of the dev database) to composable calls against the
+  registry's already-resolved site/env entries, instead of assembling one
+  large remote `bash -c` string: read both URLs via `wp_cli`'s own
+  `runWpCliRaw`, back up dev via the existing `db_backup` tool's
+  implementation, stream the remote export straight into
+  `trellis vm shell -- wp db import -` (buffer-only, no intermediate file
+  either side, same binary-safety rationale as `db_backup`'s own export),
+  search-replace, optional `--multisite` domain fixup, cache flush. Requires
+  `confirm: true` — overwrites the local development database.
+  **`db_push` is deliberately not implemented** — pulling into production
+  carries too much blast radius for a first pass; noted in
+  `mcp-server/README.md`.
 
 ## [5.3.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (tracked across this and the next few entries) filling in MCP tool gaps
   found by auditing `scripts/`, `trellis/`, and `wp-cli/` against the 7 tools
   that existed going into it.
+- **`ip_reputation_check` MCP tool** — wraps `trellis/security/check-ips.sh`
+  (arbitrary IP lookups against AbuseIPDB) and `check-deny-ips.sh` (audits
+  every individual IP in a Trellis project's `deny-ips.conf.j2` for
+  staleness, e.g. a score that's dropped to 0). Uses Node's native `fetch`
+  directly against the AbuseIPDB API rather than shelling out to `curl`/`jq`.
+  Reads the same `trellis/security/.env` `ABUSEIPDB_KEY` the CLI scripts use,
+  or `WP_OPS_ABUSEIPDB_KEY` as an override.
 
 ## [5.3.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **`db_push` is deliberately not implemented** — pulling into production
   carries too much blast radius for a first pass; noted in
   `mcp-server/README.md`.
+- **`files_pull` MCP tool** — wraps `trellis/backup/files-pull.yml`'s rsync
+  of a Trellis site's `shared/uploads/` into development's Bedrock
+  `web/app/uploads/` on the host (no VM shell needed — a Trellis dev VM
+  mounts the project directory into the host filesystem). Additive by
+  default; `delete: true` mirrors the remote exactly and requires
+  `confirm: true`, mirroring the playbook's own opt-in `--delete` footgun
+  flag. **`files_push` is deliberately not implemented**, for the same
+  production-risk reason as `db_push`.
 
 ## [5.3.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.0] - 2026-08-06
+
+### Added
+
+- **Three more read-only MCP tools**, following on from `monitor`:
+  `server_status` (`scripts/monitoring/server-monitor.sh` — live CPU/memory/
+  disk/PHP-FPM/MySQL/Nginx/OOM snapshot over SSH), `broken_link_audit`
+  (`scripts/monitoring/404-checker.sh` — internal-link 4xx/5xx check, global
+  or recursive-spider mode), and `remote_ttfb_audit`
+  (`scripts/monitoring/remote-ttfb-ua.sh` — TTFB measured from the server
+  itself across multiple crawler user agents). Part of a broader pass
+  (tracked across this and the next few entries) filling in MCP tool gaps
+  found by auditing `scripts/`, `trellis/`, and `wp-cli/` against the 7 tools
+  that existed going into it.
+
 ## [5.3.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2026-08-06
+
+### Added
+
+- **`monitor` MCP tool** — wraps `scripts/monitoring/monitor.sh` (combined
+  traffic, security, AI-crawler, and error-log analysis) as a 7th MCP tool.
+  Found missing after observing an agent asked to "use wp-ops mcp monitor"
+  fall back to nine ad-hoc bash/ssh steps (find the binary, read `--help`,
+  guess at the remote invocation, `Read` the 350-line script to work out its
+  argv) because no MCP tool existed for it — only a CLI-catalog script did.
+  Requires a site/env entry with `sshHost` (traffic/security logs only exist
+  on a deployed server, not local dev or a Trellis VM). Bundles all five
+  monitoring scripts (base64-encoded, same SSH-stdin approach as
+  `security_scan`) into a throwaway remote temp dir for the run, rather than
+  assuming `setup-monitoring.yml` already copied `traffic-monitor.sh` /
+  `security-monitor.sh` there — `ai-bot-monitor.sh` and `error-monitor.sh`
+  aren't provisioned by that playbook at all, so relying on pre-deployed
+  copies would have silently skipped two of the four reports on most sites.
+
 ## [5.2.0] - 2026-08-06
 
 ### Added

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — seven tools implemented so far:
+Scaffold — ten tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -49,6 +49,14 @@ Scaffold — seven tools implemented so far:
   (base64, over the same SSH-stdin approach as `security_scan`) into a throwaway remote
   temp dir for the run, so it works even on sites `setup-monitoring.yml` hasn't
   provisioned yet.
+- **`server_status`** — runs `scripts/monitoring/server-monitor.sh` for a live CPU, memory, disk,
+  top-processes, PHP-FPM, MySQL/MariaDB, Nginx, and recent-OOM-killer snapshot of a server over SSH.
+- **`broken_link_audit`** — runs `scripts/monitoring/404-checker.sh` to check a site's internal links for
+  broken (4xx/5xx) responses. `global` mode (default) checks homepage links (~30s); `spider` recursively
+  crawls the site (~5-10 min).
+- **`remote_ttfb_audit`** — runs `scripts/monitoring/remote-ttfb-ua.sh` to measure TTFB from the server
+  itself (over SSH, avoiding local network/DNS skew) across multiple user agents (default, Googlebot,
+  AhrefsBot, Screaming Frog).
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each
@@ -216,8 +224,9 @@ connecting to this server.
 
 ## Permissions (pre-approve read-only tools)
 
-The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`,
-`monitor`, and read-only `wp_cli` commands) are safe to run without confirmation —
+The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`, `monitor`,
+`server_status`, `broken_link_audit`, `remote_ttfb_audit`, and read-only `wp_cli` commands) are safe to
+run without confirmation —
 `url_audit` only ever queries counts and, at most, a `--dry-run` search-replace preview
 unless `confirm: true` is explicitly set. Pre-approve them in `~/.claude/settings.json`
 to avoid repeated permission prompts:
@@ -231,6 +240,9 @@ to avoid repeated permission prompts:
       "mcp__wp-ops__security_scan": { "allowed": true },
       "mcp__wp-ops__url_audit": { "allowed": true },
       "mcp__wp-ops__monitor": { "allowed": true },
+      "mcp__wp-ops__server_status": { "allowed": true },
+      "mcp__wp-ops__broken_link_audit": { "allowed": true },
+      "mcp__wp-ops__remote_ttfb_audit": { "allowed": true },
       "mcp__wp-ops__wp_cli": { "allowed": true }
     }
   }

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — ten tools implemented so far:
+Scaffold — eleven tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -57,6 +57,9 @@ Scaffold — ten tools implemented so far:
 - **`remote_ttfb_audit`** — runs `scripts/monitoring/remote-ttfb-ua.sh` to measure TTFB from the server
   itself (over SSH, avoiding local network/DNS skew) across multiple user agents (default, Googlebot,
   AhrefsBot, Screaming Frog).
+- **`ip_reputation_check`** — checks IPs against AbuseIPDB threat intelligence (score, report count,
+  ISP, Tor). Pass `ips` directly, or `trellisDir` to audit every IP already blocked in that project's
+  `deny-ips.conf.j2` for staleness. Requires `WP_OPS_ABUSEIPDB_KEY` or `trellis/security/.env`.
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each
@@ -225,8 +228,8 @@ connecting to this server.
 ## Permissions (pre-approve read-only tools)
 
 The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`, `monitor`,
-`server_status`, `broken_link_audit`, `remote_ttfb_audit`, and read-only `wp_cli` commands) are safe to
-run without confirmation —
+`server_status`, `broken_link_audit`, `remote_ttfb_audit`, `ip_reputation_check`, and read-only `wp_cli`
+commands) are safe to run without confirmation —
 `url_audit` only ever queries counts and, at most, a `--dry-run` search-replace preview
 unless `confirm: true` is explicitly set. Pre-approve them in `~/.claude/settings.json`
 to avoid repeated permission prompts:
@@ -243,6 +246,7 @@ to avoid repeated permission prompts:
       "mcp__wp-ops__server_status": { "allowed": true },
       "mcp__wp-ops__broken_link_audit": { "allowed": true },
       "mcp__wp-ops__remote_ttfb_audit": { "allowed": true },
+      "mcp__wp-ops__ip_reputation_check": { "allowed": true },
       "mcp__wp-ops__wp_cli": { "allowed": true }
     }
   }

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — twelve tools implemented so far:
+Scaffold — thirteen tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -62,6 +62,12 @@ Scaffold — twelve tools implemented so far:
   `deny-ips.conf.j2` for staleness. Requires `WP_OPS_ABUSEIPDB_KEY` or `trellis/security/.env`.
 - **`admin_user_create`** — creates a temporary WordPress administrator via WP-CLI (`user create`), for
   lockout recovery. The password is generated and returned once, never stored. Requires `confirm: true`.
+- **`db_pull`** — pulls a site's database from a remote environment into local development, with URL
+  search-replace, backing up the current development database first. Requires the site's `development`
+  entry to have `trellisDir`+`vmWorkdir` (drives the dev site through `trellis vm shell`) and the source
+  env to have `sshHost`+`remotePath`. Requires `confirm: true` — overwrites the local development
+  database. (`db_push` is deliberately not implemented — pulling into production carries a much higher
+  blast radius than overwriting a disposable local dev DB.)
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — six tools implemented so far:
+Scaffold — seven tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -42,6 +42,13 @@ Scaffold — six tools implemented so far:
   pattern. Pass `replace: {from, to}` to also preview a
   `wp search-replace --all-tables --precise --dry-run`; add `confirm: true` (only after
   explicit user approval) to apply it for real.
+- **`monitor`** — runs `scripts/monitoring/monitor.sh` (combined traffic, security,
+  AI-crawler, and error-log analysis) against a registered site's Nginx logs and returns
+  the generated markdown summary. Requires an `sshHost` entry — logs only exist on a
+  deployed server, not local dev or a Trellis VM. Bundles all five monitoring scripts
+  (base64, over the same SSH-stdin approach as `security_scan`) into a throwaway remote
+  temp dir for the run, so it works even on sites `setup-monitoring.yml` hasn't
+  provisioned yet.
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each
@@ -209,11 +216,11 @@ connecting to this server.
 
 ## Permissions (pre-approve read-only tools)
 
-The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`, and
-read-only `wp_cli` commands) are safe to run without confirmation — `url_audit` only
-ever queries counts and, at most, a `--dry-run` search-replace preview unless
-`confirm: true` is explicitly set. Pre-approve them in `~/.claude/settings.json` to
-avoid repeated permission prompts:
+The read-only tools (`redirect_audit`, `schema_audit`, `security_scan`, `url_audit`,
+`monitor`, and read-only `wp_cli` commands) are safe to run without confirmation —
+`url_audit` only ever queries counts and, at most, a `--dry-run` search-replace preview
+unless `confirm: true` is explicitly set. Pre-approve them in `~/.claude/settings.json`
+to avoid repeated permission prompts:
 
 ```json
 {
@@ -223,6 +230,7 @@ avoid repeated permission prompts:
       "mcp__wp-ops__schema_audit": { "allowed": true },
       "mcp__wp-ops__security_scan": { "allowed": true },
       "mcp__wp-ops__url_audit": { "allowed": true },
+      "mcp__wp-ops__monitor": { "allowed": true },
       "mcp__wp-ops__wp_cli": { "allowed": true }
     }
   }

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — thirteen tools implemented so far:
+Scaffold — fourteen tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -68,6 +68,11 @@ Scaffold — thirteen tools implemented so far:
   env to have `sshHost`+`remotePath`. Requires `confirm: true` — overwrites the local development
   database. (`db_push` is deliberately not implemented — pulling into production carries a much higher
   blast radius than overwriting a disposable local dev DB.)
+- **`files_pull`** — syncs a site's uploads directory from a remote environment into local development
+  via rsync. Additive by default (local-only files kept); `delete: true` mirrors the remote exactly and
+  needs `confirm: true`. Requires the site's `development` entry to have `localPath`, and the source env
+  to have `sshHost`. (`files_push` is deliberately not implemented, for the same production-risk reason
+  as `db_push`.)
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,7 @@ underlying scripts by hand.
 
 ## Status
 
-Scaffold — eleven tools implemented so far:
+Scaffold — twelve tools implemented so far:
 
 - **`security_scan`** — runs `wp-cli/security/scanner-targeted.php` / `scanner-general.php`
   against a registered site/environment. For remote environments it streams the scanner
@@ -60,6 +60,8 @@ Scaffold — eleven tools implemented so far:
 - **`ip_reputation_check`** — checks IPs against AbuseIPDB threat intelligence (score, report count,
   ISP, Tor). Pass `ips` directly, or `trellisDir` to audit every IP already blocked in that project's
   `deny-ips.conf.j2` for staleness. Requires `WP_OPS_ABUSEIPDB_KEY` or `trellis/security/.env`.
+- **`admin_user_create`** — creates a temporary WordPress administrator via WP-CLI (`user create`), for
+  lockout recovery. The password is generated and returned once, never stored. Requires `confirm: true`.
 
 More tools (PR creation, releases, image optimization, git/gh helpers) will follow the
 same pattern. See the parent repo's `CLAUDE.md` and the relevant README in each

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -12,6 +12,7 @@ import { runServerStatus } from "./tools/serverStatus.js";
 import { runBrokenLinkAudit } from "./tools/brokenLinkAudit.js";
 import { runRemoteTtfbAudit } from "./tools/remoteTtfbAudit.js";
 import { checkIpReputation, checkDenyList, type IpCheckResult } from "./tools/ipReputation.js";
+import { runAdminUserCreate } from "./tools/adminUserCreate.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -551,6 +552,55 @@ export function createServer(): McpServer {
 
         const results = await checkIpReputation(ips!);
         return { content: [{ type: "text" as const, text: results.map(formatIpResult).join("\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "admin_user_create",
+    "Create a temporary WordPress administrator via WP-CLI — for lockout recovery (lost admin password, " +
+      "a broken login plugin, an ownership handover with no working account). The password is generated " +
+      "and returned once, never stored. Requires confirm: true, only after explicit user approval.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "staging", "production"'),
+      username: z.string().min(1).describe("Username for the new administrator"),
+      email: z.string().email().describe("Email address for the new administrator"),
+      role: z.string().default("administrator").describe("Role to assign"),
+      password: z
+        .string()
+        .optional()
+        .describe("Password to set. Defaults to a generated random password, returned once in the response."),
+      confirm: z
+        .boolean()
+        .default(false)
+        .describe("Required (true) — creates a privileged account. Only set after explicit user approval."),
+    },
+    async ({ site, env, username, email, role, password, confirm }) => {
+      try {
+        if (!confirm) {
+          throw new Error(
+            "Creating a WordPress admin account needs confirm: true. Re-run with confirm: true only " +
+              "after the user has explicitly approved this."
+          );
+        }
+        const registry = loadRegistry();
+        const entry = resolveSiteEnv(registry, site, env);
+        const result = await runAdminUserCreate(entry, username, email, role, password);
+
+        const lines = [`User created: ${result.username} <${result.email}> (role: ${result.role})`];
+        if (result.generatedPassword) {
+          lines.push("", `Password: ${result.generatedPassword}`, "", "Shown once — copy it now.");
+        }
+        lines.push(
+          "",
+          "Delete this user when no longer needed, via the wp_cli tool: " +
+            `{ site: "${site}", env: "${env}", args: ["user", "delete", "${username}", "--yes", "--reassign=1"], confirm: true }`
+        );
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -14,6 +14,7 @@ import { runRemoteTtfbAudit } from "./tools/remoteTtfbAudit.js";
 import { checkIpReputation, checkDenyList, type IpCheckResult } from "./tools/ipReputation.js";
 import { runAdminUserCreate } from "./tools/adminUserCreate.js";
 import { runDbPull } from "./tools/dbPull.js";
+import { runFilesPull } from "./tools/filesPull.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -649,6 +650,56 @@ export function createServer(): McpServer {
         if (result.multisiteFixedUp) lines.push("  Multisite domain fixup applied.");
         lines.push("", "search-replace output:", result.searchReplaceOutput);
 
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "files_pull",
+    "Sync a site's uploads directory from a remote environment into local development via rsync. " +
+      "Additive by default (local-only files are kept); `delete: true` mirrors the remote exactly, " +
+      "deleting local uploads the remote no longer has — that needs confirm: true. Requires the site's " +
+      '"development" entry to have localPath, and the source env to have sshHost.',
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      fromEnv: envSchema.describe('Environment to pull from, e.g. "production", "staging" — not "development"'),
+      delete: z
+        .boolean()
+        .default(false)
+        .describe("Mirror the remote exactly, deleting local-only uploads. Destructive locally — needs confirm: true."),
+      confirm: z
+        .boolean()
+        .default(false)
+        .describe("Required (true) only when delete: true. Only set after explicit user approval."),
+    },
+    async ({ site, fromEnv, delete: del, confirm }) => {
+      try {
+        if (fromEnv === "development") {
+          throw new Error('"development" is not a valid source environment — you can\'t pull development into itself.');
+        }
+        if (del && !confirm) {
+          throw new Error(
+            "delete: true removes local-only uploads and needs confirm: true. Re-run with confirm: true " +
+              "only after the user has explicitly approved this."
+          );
+        }
+        const registry = loadRegistry();
+        const devEntry = resolveSiteEnv(registry, site, "development");
+        const fromEntry = resolveSiteEnv(registry, site, fromEnv);
+        const result = await runFilesPull(site, devEntry, fromEntry, del);
+
+        const lines = [
+          `Synced ${site}/${fromEnv} uploads into development.`,
+          `  Remote: ${result.remoteUploadsDir}`,
+          `  Local:  ${result.localUploadsDir}`,
+          `  Mode:   ${result.deleted ? "mirrored — local-only files deleted" : "additive — local-only files kept"}`,
+          "",
+          result.rsyncOutput,
+        ];
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -8,6 +8,9 @@ import { runRedirectAudit } from "./tools/redirectAudit.js";
 import { runSchemaAudit } from "./tools/schemaAudit.js";
 import { runUrlAudit, DEFAULT_URL_AUDIT_PATTERNS } from "./tools/urlAudit.js";
 import { runMonitor } from "./tools/monitor.js";
+import { runServerStatus } from "./tools/serverStatus.js";
+import { runBrokenLinkAudit } from "./tools/brokenLinkAudit.js";
+import { runRemoteTtfbAudit } from "./tools/remoteTtfbAudit.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -402,6 +405,103 @@ export function createServer(): McpServer {
         const registry = loadRegistry();
         const entry = resolveSiteEnv(registry, site, env);
         const output = await runMonitor(entry, domain ?? site, hours);
+        return { content: [{ type: "text" as const, text: output }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "server_status",
+    "Live CPU, memory, disk, top processes, PHP-FPM, MySQL/MariaDB, Nginx, and recent OOM-killer snapshot " +
+      "of a server over SSH. Requires a site/env with an sshHost entry — this reads live process state, " +
+      "not local dev or a Trellis VM.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "staging", "production"'),
+      phpFpmPattern: z
+        .string()
+        .optional()
+        .describe('Pattern to match PHP-FPM pool processes, e.g. "php-fpm: pool wordpress". Defaults to matching any pool.'),
+    },
+    async ({ site, env, phpFpmPattern }) => {
+      try {
+        const registry = loadRegistry();
+        const entry = resolveSiteEnv(registry, site, env);
+        const output = await runServerStatus(entry, phpFpmPattern);
+        return { content: [{ type: "text" as const, text: output }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "broken_link_audit",
+    "Check a site's internal links for broken (4xx/5xx) responses. `global` mode (default) checks all " +
+      "links found on the homepage (~30s); `spider` recursively crawls to a set depth (~5-10 min). Pass " +
+      "`siteUrl` or `site`+`env`.",
+    {
+      siteUrl: z.string().url().optional().describe('Site URL to check, e.g. "https://example.com"'),
+      site: siteSchema.optional().describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.optional().describe('Environment key for that site, e.g. "staging", "production"'),
+      mode: z
+        .enum(["global", "spider"])
+        .default("global")
+        .describe("global checks homepage links only (fast); spider recursively crawls the whole site (slow)"),
+      timeoutSeconds: z.number().int().positive().optional().describe("curl max-time per request, in seconds"),
+      spiderLevel: z.number().int().positive().optional().describe("Spider crawl depth, only used in spider mode"),
+    },
+    async ({ siteUrl, site, env, mode, timeoutSeconds, spiderLevel }) => {
+      try {
+        let targetUrl = siteUrl;
+        if (site && env) {
+          const registry = loadRegistry();
+          const entry = resolveSiteEnv(registry, site, env);
+          if (entry.url) {
+            targetUrl = entry.url;
+          } else {
+            throw new Error(`Site entry for "${site}"/"${env}" has no URL field. Use the "siteUrl" parameter instead.`);
+          }
+        }
+        if (!targetUrl) {
+          throw new Error("Either provide 'siteUrl' or 'site' + 'env' parameters.");
+        }
+
+        const result = await runBrokenLinkAudit(targetUrl, mode, timeoutSeconds, spiderLevel);
+        const text = result.hasBrokenLinks
+          ? `❌ Broken link(s) found:\n\n${result.output}`
+          : `✅ No broken links found.\n\n${result.output}`;
+        return { content: [{ type: "text" as const, text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "remote_ttfb_audit",
+    "Measure TTFB (time to first byte) from the server itself — via SSH, so DNS/network distance from " +
+      "your machine doesn't skew it — across multiple user agents (default, Googlebot, AhrefsBot, " +
+      "Screaming Frog). Useful after a WAF or caching change to check bots aren't treated differently " +
+      "from regular visitors. Requires a site/env with an sshHost entry.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "staging", "production"'),
+      urls: z.array(z.string().url()).min(1).describe('URL(s) to test, e.g. ["https://example.com/", "https://example.com/blog/"]'),
+    },
+    async ({ site, env, urls }) => {
+      try {
+        const registry = loadRegistry();
+        const entry = resolveSiteEnv(registry, site, env);
+        if (!entry.sshHost) {
+          throw new Error(`Site entry for "${site}"/"${env}" has no sshHost — remote_ttfb_audit runs curl on the server itself over SSH.`);
+        }
+        const output = await runRemoteTtfbAudit(entry.sshHost, urls);
         return { content: [{ type: "text" as const, text: output }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -13,6 +13,7 @@ import { runBrokenLinkAudit } from "./tools/brokenLinkAudit.js";
 import { runRemoteTtfbAudit } from "./tools/remoteTtfbAudit.js";
 import { checkIpReputation, checkDenyList, type IpCheckResult } from "./tools/ipReputation.js";
 import { runAdminUserCreate } from "./tools/adminUserCreate.js";
+import { runDbPull } from "./tools/dbPull.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -600,6 +601,54 @@ export function createServer(): McpServer {
           "Delete this user when no longer needed, via the wp_cli tool: " +
             `{ site: "${site}", env: "${env}", args: ["user", "delete", "${username}", "--yes", "--reassign=1"], confirm: true }`
         );
+        return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "db_pull",
+    "Pull a site's database from a remote environment into local development, with URL search-replace. " +
+      "Backs up the current development database first. Requires the site's \"development\" entry to have " +
+      "trellisDir+vmWorkdir (drives the dev site through `trellis vm shell`) and the source env to have " +
+      "sshHost+remotePath. Requires confirm: true — overwrites the local development database.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      fromEnv: envSchema.describe('Environment to pull from, e.g. "production", "staging" — not "development"'),
+      multisite: z
+        .boolean()
+        .default(false)
+        .describe("Also fix wp_blogs domains and scope search-replace with --url, for multisite networks"),
+      confirm: z
+        .boolean()
+        .default(false)
+        .describe("Required (true) — overwrites the local development database. Only set after explicit user approval."),
+    },
+    async ({ site, fromEnv, multisite, confirm }) => {
+      try {
+        if (!confirm) {
+          throw new Error(
+            "db_pull overwrites the local development database and needs confirm: true. Re-run with " +
+              "confirm: true only after the user has explicitly approved this."
+          );
+        }
+        const registry = loadRegistry();
+        const devEntry = resolveSiteEnv(registry, site, "development");
+        const fromEntry = resolveSiteEnv(registry, site, fromEnv);
+        const result = await runDbPull(site, devEntry, fromEntry, fromEnv, multisite);
+
+        const lines = [
+          `Pulled ${site}/${fromEnv} database into development.`,
+          `  ${fromEnv} URL: ${result.prodUrl}`,
+          `  development URL: ${result.devUrl}`,
+          `  Development backed up to: ${result.devBackupPath}`,
+        ];
+        if (result.multisiteFixedUp) lines.push("  Multisite domain fixup applied.");
+        lines.push("", "search-replace output:", result.searchReplaceOutput);
+
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { isReadOnlyWpCommand, runWpCli, truncateWpCliOutput } from "./tools/wpCl
 import { runRedirectAudit } from "./tools/redirectAudit.js";
 import { runSchemaAudit } from "./tools/schemaAudit.js";
 import { runUrlAudit, DEFAULT_URL_AUDIT_PATTERNS } from "./tools/urlAudit.js";
+import { runMonitor } from "./tools/monitor.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -370,6 +371,38 @@ export function createServer(): McpServer {
         }
 
         return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  server.tool(
+    "monitor",
+    "Run combined traffic, security, AI-crawler, and error-log monitoring against a site's Nginx logs " +
+      "and return the generated markdown summary. Requires a site/env with an SSH entry — logs only " +
+      "exist on a deployed server, not local dev or a Trellis VM. Self-contained: bundles the monitoring " +
+      "scripts into a throwaway remote temp dir for this run, so it works whether or not the site has " +
+      "`setup-monitoring.yml` already provisioned.",
+    {
+      site: siteSchema.describe('Site key from the wp-ops site registry (config/sites.json)'),
+      env: envSchema.describe('Environment key for that site, e.g. "staging", "production"'),
+      hours: z.number().int().positive().default(24).describe("How many hours of logs to analyze"),
+      domain: z
+        .string()
+        .optional()
+        .describe(
+          'Domain used to locate logs at /srv/www/<domain>/logs/access.log. Defaults to the "site" key, ' +
+            "which is the domain for every currently registered site."
+        ),
+    },
+    async ({ site, env, hours, domain }) => {
+      try {
+        const registry = loadRegistry();
+        const entry = resolveSiteEnv(registry, site, env);
+        const output = await runMonitor(entry, domain ?? site, hours);
+        return { content: [{ type: "text" as const, text: output }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { runMonitor } from "./tools/monitor.js";
 import { runServerStatus } from "./tools/serverStatus.js";
 import { runBrokenLinkAudit } from "./tools/brokenLinkAudit.js";
 import { runRemoteTtfbAudit } from "./tools/remoteTtfbAudit.js";
+import { checkIpReputation, checkDenyList, type IpCheckResult } from "./tools/ipReputation.js";
 
 // Building z.enum(...) schemas from the registry means a wrong site/env key gets caught
 // by the client/model before the call is ever made, instead of costing a full round trip
@@ -503,6 +504,53 @@ export function createServer(): McpServer {
         }
         const output = await runRemoteTtfbAudit(entry.sshHost, urls);
         return { content: [{ type: "text" as const, text: output }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+
+  function formatIpResult(r: IpCheckResult): string {
+    if (r.error) return `  ${r.ip}: ERROR — ${r.error}`;
+    const note = r.score === 0 ? " ⚠ CONSIDER REMOVING (score 0)" : r.score !== undefined && r.score <= 10 ? " ⚠ score dropped low" : "";
+    return `  ${r.ip}: score=${r.score} reports=${r.reports} lastSeen=${r.lastSeen ?? "never"} country=${r.country ?? "?"} isp=${r.isp ?? "?"}${r.tor ? " TOR" : ""}${note}`;
+  }
+
+  server.tool(
+    "ip_reputation_check",
+    "Check IP addresses against AbuseIPDB threat intelligence (score, report count, ISP, Tor). Pass " +
+      "`ips` directly, or `trellisDir` to audit every individual IP already blocked in that Trellis " +
+      "project's deny-ips.conf.j2 (useful for spotting stale blocks safe to remove). Requires an " +
+      "AbuseIPDB API key (WP_OPS_ABUSEIPDB_KEY env var, or trellis/security/.env).",
+    {
+      ips: z.array(z.string()).min(1).optional().describe('IP addresses to check, e.g. ["1.2.3.4", "5.6.7.8"]'),
+      trellisDir: z
+        .string()
+        .optional()
+        .describe("Path to a Trellis project, to audit its nginx-includes/all/deny-ips.conf.j2 instead of arbitrary IPs"),
+    },
+    async ({ ips, trellisDir }) => {
+      try {
+        if (!ips && !trellisDir) {
+          throw new Error("Provide either 'ips' or 'trellisDir'.");
+        }
+        if (ips && trellisDir) {
+          throw new Error("Provide only one of 'ips' or 'trellisDir', not both.");
+        }
+
+        if (trellisDir) {
+          const result = await checkDenyList(trellisDir);
+          const lines = [
+            `${result.ips.length} IP(s) checked, ${result.subnetsSkipped} subnet(s) skipped`,
+            "",
+            ...result.ips.map(formatIpResult),
+          ];
+          return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+        }
+
+        const results = await checkIpReputation(ips!);
+        return { content: [{ type: "text" as const, text: results.map(formatIpResult).join("\n") }] };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };

--- a/mcp-server/src/tools/adminUserCreate.ts
+++ b/mcp-server/src/tools/adminUserCreate.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from "node:crypto";
+import type { EnvEntry } from "../registry.js";
+import { runWpCliRaw } from "./wpCli.js";
+
+export interface AdminUserCreateResult {
+  username: string;
+  email: string;
+  role: string;
+  // Only set when generated (not caller-supplied) — shown once, matching
+  // admin-user-create.sh's "printed once, not stored anywhere" behavior.
+  generatedPassword?: string;
+}
+
+// Mirrors wp-cli/security/admin-user-create.sh: check the username/email aren't
+// already taken, then create the user with --porcelain. Reuses runWpCliRaw
+// directly rather than reimplementing local/SSH/VM dispatch — the same three
+// checks the script does (existing username, existing email, then create) are
+// just three ordinary WP-CLI calls against the already-resolved site/env entry.
+export async function runAdminUserCreate(
+  entry: EnvEntry,
+  username: string,
+  email: string,
+  role: string,
+  password?: string
+): Promise<AdminUserCreateResult> {
+  const byUsername = await runWpCliRaw(entry, ["user", "get", username, "--field=ID"]);
+  if (byUsername.code === 0) {
+    throw new Error(`A user named "${username}" already exists.`);
+  }
+
+  const byEmail = await runWpCliRaw(entry, ["user", "get", email, "--field=ID"]);
+  if (byEmail.code === 0) {
+    throw new Error(`A user with email "${email}" already exists.`);
+  }
+
+  const generated = !password;
+  // openssl rand -base64 24 (the script's default) encodes 24 raw bytes; match
+  // that exactly rather than picking an arbitrary Node equivalent.
+  const finalPassword = password ?? randomBytes(24).toString("base64");
+
+  const create = await runWpCliRaw(entry, [
+    "user",
+    "create",
+    username,
+    email,
+    `--role=${role}`,
+    `--user_pass=${finalPassword}`,
+    "--display_name=Temporary Admin",
+    "--porcelain",
+  ]);
+  if (create.code !== 0) {
+    throw new Error(`WP-CLI could not create the user (exit ${create.code}): ${create.stderr || create.stdout}`);
+  }
+
+  return { username, email, role, generatedPassword: generated ? finalPassword : undefined };
+}

--- a/mcp-server/src/tools/brokenLinkAudit.ts
+++ b/mcp-server/src/tools/brokenLinkAudit.ts
@@ -1,0 +1,55 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.resolve(__dirname, "../../../scripts/monitoring/404-checker.sh");
+
+export type LinkAuditMode = "global" | "spider";
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function run(args: string[]): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bash", [SCRIPT_PATH, ...args]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+export interface LinkAuditResult {
+  hasBrokenLinks: boolean;
+  output: string;
+}
+
+// 404-checker.sh's own exit codes: 0 = clean, 1 = broken link(s) found, 2 = usage
+// error. Only 2 is a genuine tool failure — 1 is a normal (if unwelcome) result.
+export async function runBrokenLinkAudit(
+  siteUrl: string,
+  mode: LinkAuditMode,
+  timeoutSeconds?: number,
+  spiderLevel?: number
+): Promise<LinkAuditResult> {
+  const args = ["--mode", mode];
+  if (timeoutSeconds !== undefined) args.push("--timeout", String(timeoutSeconds));
+  if (mode === "spider" && spiderLevel !== undefined) args.push("--level", String(spiderLevel));
+  args.push(siteUrl);
+
+  const result = await run(args);
+  if (result.code === 2) {
+    throw new Error(`404-checker.sh usage error: ${result.stderr || result.stdout}`);
+  }
+
+  return {
+    hasBrokenLinks: result.code === 1,
+    output: (result.stdout + (result.stderr ? `\n${result.stderr}` : "")).trim(),
+  };
+}

--- a/mcp-server/src/tools/dbPull.ts
+++ b/mcp-server/src/tools/dbPull.ts
@@ -1,0 +1,129 @@
+import { spawn } from "node:child_process";
+import type { EnvEntry } from "../registry.js";
+import { hasTrellisVm, resolveWpBin, resolvePhpBin } from "../registry.js";
+import { runWpCliRaw } from "./wpCli.js";
+import { runDbBackup } from "./dbBackup.js";
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+interface BufferExecResult {
+  stdout: Buffer;
+  stderr: string;
+  code: number;
+}
+
+// Buffer-based like dbBackup.ts's exportSql — a SQL dump isn't guaranteed valid
+// UTF-8, and here it also needs to go *in* as stdin, not just come out.
+function exec(command: string, args: string[], cwd: string | undefined, input: Buffer): Promise<BufferExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, cwd ? { cwd } : {});
+    const chunks: Buffer[] = [];
+    let stderr = "";
+    child.stdout.on("data", (d) => chunks.push(d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout: Buffer.concat(chunks), stderr, code: code ?? 1 }));
+    child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
+function hostOf(url: string): string {
+  return url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+}
+
+export interface DbPullResult {
+  devBackupPath: string;
+  prodUrl: string;
+  devUrl: string;
+  multisiteFixedUp: boolean;
+  searchReplaceOutput: string;
+}
+
+// Ports scripts/backup/db-pull.sh's PULL_COMMAND to composable calls against the
+// already-resolved registry entries, instead of building one big remote bash -c
+// string: read both URLs, back up dev first, stream the remote export straight
+// into `trellis vm shell -- wp db import -` (buffer-only, no intermediate file
+// either side), search-replace, optional multisite domain fixup, flush cache.
+export async function runDbPull(
+  site: string,
+  devEntry: EnvEntry,
+  fromEntry: EnvEntry,
+  fromEnv: string,
+  multisite: boolean
+): Promise<DbPullResult> {
+  if (fromEnv === "development") {
+    throw new Error('"development" is not a valid source environment — you can\'t pull development into itself.');
+  }
+  if (!hasTrellisVm(devEntry)) {
+    throw new Error(
+      `Site "${site}"'s development entry needs trellisDir+vmWorkdir — db_pull drives the local dev site ` +
+        "through `trellis vm shell`."
+    );
+  }
+  if (!fromEntry.sshHost || !fromEntry.remotePath) {
+    throw new Error(`Site "${site}"'s "${fromEnv}" entry needs sshHost+remotePath to pull a database from.`);
+  }
+
+  const devWpBin = resolveWpBin(devEntry);
+  const devPhpBin = resolvePhpBin(devEntry);
+  const devPath = devEntry.vmPath ?? "web/wp";
+  const devWpCommand = devPhpBin ? [devPhpBin, devWpBin] : [devWpBin];
+
+  const fromWpBin = resolveWpBin(fromEntry);
+  const fromPhpBin = resolvePhpBin(fromEntry);
+  const fromWpCommand = fromPhpBin ? [fromPhpBin, fromWpBin] : [fromWpBin];
+
+  const prodUrl = (await runWpCliRaw(fromEntry, ["option", "get", "siteurl"])).stdout.trim();
+  const devUrl = (await runWpCliRaw(devEntry, ["option", "get", "siteurl"])).stdout.trim();
+
+  // Back up dev's current DB before overwriting it — same safety step db-pull.sh
+  // takes, reusing the db_backup tool's own implementation rather than
+  // duplicating export logic.
+  const backup = await runDbBackup(devEntry, site, "development");
+
+  const exportCmd = [...fromWpCommand, "db", "export", "-", `--path=${fromEntry.remotePath}`].map(shellQuote).join(" ");
+  const dump = await exec("ssh", [fromEntry.sshHost, exportCmd], undefined, Buffer.alloc(0));
+  if (dump.code !== 0) {
+    throw new Error(`Remote db export from "${fromEnv}" failed (exit ${dump.code}): ${dump.stderr}`);
+  }
+
+  const importResult = await exec(
+    "trellis",
+    ["vm", "shell", "--workdir", devEntry.vmWorkdir, "--", ...devWpCommand, "db", "import", "-", `--path=${devPath}`],
+    devEntry.trellisDir,
+    dump.stdout
+  );
+  if (importResult.code !== 0) {
+    throw new Error(`Import into development failed (exit ${importResult.code}): ${importResult.stderr}`);
+  }
+
+  const searchReplaceArgs = ["search-replace", prodUrl, devUrl, "--all-tables", "--precise"];
+  if (multisite) searchReplaceArgs.push(`--url=${prodUrl}`);
+  const searchReplace = await runWpCliRaw(devEntry, searchReplaceArgs);
+  if (searchReplace.code !== 0) {
+    throw new Error(`search-replace failed (exit ${searchReplace.code}): ${searchReplace.stderr}`);
+  }
+
+  let multisiteFixedUp = false;
+  if (multisite) {
+    const query = `UPDATE wp_blogs SET domain = REPLACE(domain, '${hostOf(prodUrl)}', '${hostOf(devUrl)}');`;
+    const fixup = await runWpCliRaw(devEntry, ["db", "query", query]);
+    if (fixup.code !== 0) {
+      throw new Error(`Multisite domain fixup failed (exit ${fixup.code}): ${fixup.stderr}`);
+    }
+    multisiteFixedUp = true;
+  }
+
+  await runWpCliRaw(devEntry, ["cache", "flush"]);
+
+  return {
+    devBackupPath: backup.filePath,
+    prodUrl,
+    devUrl,
+    multisiteFixedUp,
+    searchReplaceOutput: (searchReplace.stdout + searchReplace.stderr).trim(),
+  };
+}

--- a/mcp-server/src/tools/filesPull.ts
+++ b/mcp-server/src/tools/filesPull.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { EnvEntry } from "../registry.js";
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function exec(command: string, args: string[]): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+export interface FilesPullResult {
+  remoteUploadsDir: string;
+  localUploadsDir: string;
+  deleted: boolean;
+  rsyncOutput: string;
+}
+
+// Mirrors trellis/backup/files-pull.yml: rsync a Trellis site's shared uploads
+// directory (a fixed path outside the deploy-versioned `current/`, so it isn't
+// derived from remotePath) into development's Bedrock uploads dir on the host.
+export async function runFilesPull(site: string, devEntry: EnvEntry, fromEntry: EnvEntry, del: boolean): Promise<FilesPullResult> {
+  if (!devEntry.localPath) {
+    throw new Error(
+      `Site "${site}"'s development entry needs localPath set — files_pull rsyncs straight to the host ` +
+        "filesystem (a Trellis dev VM mounts the project directory into the host, so no VM shell is needed)."
+    );
+  }
+  if (!fromEntry.sshHost) {
+    throw new Error(`Site "${site}"'s source entry needs sshHost to pull uploads from.`);
+  }
+
+  const remoteUploadsDir = `/srv/www/${site}/shared/uploads/`;
+
+  // devEntry.localPath is the WordPress core dir (Bedrock's web/wp, by the same
+  // convention runLocal/runVm elsewhere assume); site root is two levels up,
+  // and uploads live at the Bedrock-standard web/app/uploads sibling.
+  const siteRoot = path.dirname(path.dirname(devEntry.localPath));
+  const localUploadsDir = path.join(siteRoot, "web", "app", "uploads") + "/";
+  await mkdir(localUploadsDir, { recursive: true });
+
+  const rsyncArgs = ["--archive", "--compress"];
+  if (del) rsyncArgs.push("--delete");
+  rsyncArgs.push(`${fromEntry.sshHost}:${remoteUploadsDir}`, localUploadsDir);
+
+  const result = await exec("rsync", rsyncArgs);
+  if (result.code !== 0) {
+    throw new Error(`rsync exited ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`);
+  }
+
+  return {
+    remoteUploadsDir,
+    localUploadsDir,
+    deleted: del,
+    rsyncOutput: (result.stdout + result.stderr).trim(),
+  };
+}

--- a/mcp-server/src/tools/ipReputation.ts
+++ b/mcp-server/src/tools/ipReputation.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Same .env file trellis/security/check-ips.sh and check-deny-ips.sh read
+// (ABUSEIPDB_KEY=...), so a key dropped in for the CLI scripts works here too.
+const ENV_FILE = path.resolve(__dirname, "../../../trellis/security/.env");
+const DENY_IPS_RELATIVE_PATH = "nginx-includes/all/deny-ips.conf.j2";
+
+function loadAbuseIpDbKey(): string {
+  if (process.env.WP_OPS_ABUSEIPDB_KEY) return process.env.WP_OPS_ABUSEIPDB_KEY;
+
+  if (existsSync(ENV_FILE)) {
+    const match = readFileSync(ENV_FILE, "utf-8").match(/^ABUSEIPDB_KEY=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+
+  throw new Error(
+    `ABUSEIPDB_KEY not found. Set WP_OPS_ABUSEIPDB_KEY, or add it to ${ENV_FILE}:\n` +
+      `  echo 'ABUSEIPDB_KEY=your_key_here' > ${ENV_FILE}\n` +
+      "Get a free key (1,000 checks/day) at https://www.abuseipdb.com/register"
+  );
+}
+
+export interface IpCheckResult {
+  ip: string;
+  score?: number;
+  reports?: number;
+  lastSeen?: string | null;
+  country?: string;
+  isp?: string;
+  usageType?: string;
+  domain?: string;
+  tor?: boolean;
+  error?: string;
+}
+
+async function checkOne(ip: string, apiKey: string): Promise<IpCheckResult> {
+  const url = new URL("https://api.abuseipdb.com/api/v2/check");
+  url.searchParams.set("ipAddress", ip);
+  url.searchParams.set("maxAgeInDays", "90");
+
+  try {
+    const res = await fetch(url, {
+      headers: { Key: apiKey, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    const body = (await res.json()) as any;
+
+    if (body.errors) {
+      return { ip, error: body.errors.map((e: any) => e.detail ?? JSON.stringify(e)).join("; ") };
+    }
+
+    const d = body.data ?? {};
+    return {
+      ip,
+      score: d.abuseConfidenceScore,
+      reports: d.totalReports,
+      lastSeen: d.lastReportedAt ?? null,
+      country: d.countryCode,
+      isp: d.isp,
+      usageType: d.usageType,
+      domain: d.domain,
+      tor: d.isTor,
+    };
+  } catch (err) {
+    return { ip, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// AbuseIPDB's free tier is 1 req/sec — check sequentially with a delay, same as
+// check-ips.sh / check-deny-ips.sh, rather than firing requests concurrently.
+export async function checkIpReputation(ips: string[]): Promise<IpCheckResult[]> {
+  const apiKey = loadAbuseIpDbKey();
+  const results: IpCheckResult[] = [];
+  for (const ip of ips) {
+    results.push(await checkOne(ip, apiKey));
+    if (ip !== ips[ips.length - 1]) await sleep(1000);
+  }
+  return results;
+}
+
+export interface DenyListCheckResult {
+  ips: IpCheckResult[];
+  subnetsSkipped: number;
+}
+
+// Mirrors check-deny-ips.sh: reads every individual `deny <ip>;` line from a
+// Trellis project's deny-ips.conf.j2 and checks each against AbuseIPDB, so
+// stale blocks (score dropped to 0) are easy to spot. CIDR/subnet entries are
+// skipped — AbuseIPDB checks single IPs, not ranges — and just counted.
+export async function checkDenyList(trellisDir: string): Promise<DenyListCheckResult> {
+  const confPath = path.join(trellisDir, DENY_IPS_RELATIVE_PATH);
+  if (!existsSync(confPath)) {
+    throw new Error(`deny-ips.conf.j2 not found at ${confPath}`);
+  }
+
+  const conf = readFileSync(confPath, "utf-8");
+  const ips: string[] = [];
+  let subnetsSkipped = 0;
+  for (const m of conf.matchAll(/^deny ([0-9a-f:./]+);/gm)) {
+    if (m[1].includes("/")) {
+      subnetsSkipped++;
+    } else {
+      ips.push(m[1]);
+    }
+  }
+
+  return { ips: await checkIpReputation(ips), subnetsSkipped };
+}

--- a/mcp-server/src/tools/monitor.ts
+++ b/mcp-server/src/tools/monitor.ts
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { EnvEntry } from "../registry.js";
+
+function shellQuote(arg: string): string {
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MONITOR_DIR = path.resolve(__dirname, "../../../scripts/monitoring");
+
+// monitor.sh dispatches to these four as sibling files via
+// `${SCRIPT_DIR}/traffic-monitor.sh` etc. — SCRIPT_DIR is derived from
+// `${BASH_SOURCE[0]}`, which is empty when the script is read from stdin, so
+// on a bare `ssh host 'bash -s' < monitor.sh` it resolves to the remote
+// shell's cwd instead. That only works if these four already happen to live
+// there (e.g. a prior `setup-monitoring.yml` run). Bundling all five and
+// writing them into a throwaway remote temp dir removes that assumption —
+// the tool works against any registered SSH site, provisioned or not.
+const MONITOR_SCRIPTS = [
+  "monitor.sh",
+  "traffic-monitor.sh",
+  "security-monitor.sh",
+  "ai-bot-monitor.sh",
+  "error-monitor.sh",
+] as const;
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function runRemote(sshHost: string, script: string): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("ssh", [sshHost, "bash", "-s"]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+    child.stdin.write(script);
+    child.stdin.end();
+  });
+}
+
+// Builds one self-contained bash script: unpack all five monitoring scripts
+// (base64, to sidestep quoting the heredoc body) into a `mktemp -d` remote
+// temp dir, run monitor.sh there, print its own progress output, then print
+// whichever summary markdown file it produced and clean up the temp dir.
+// monitor.sh's OUTPUT_DIR is `~/monitoring` when `/srv/www/<domain>` exists on
+// the host (a real Trellis deploy) or `./monitoring-reports` (under the temp
+// dir) otherwise — checking both paths after the run covers either case
+// without duplicating that detection logic here.
+function buildRemoteScript(hours: number, domain: string): string {
+  const lines = ["set -e", "TMPDIR=$(mktemp -d)", 'trap \'rm -rf "$TMPDIR"\' EXIT', 'cd "$TMPDIR"'];
+
+  for (const name of MONITOR_SCRIPTS) {
+    const source = readFileSync(path.join(MONITOR_DIR, name), "utf-8");
+    const b64 = Buffer.from(source, "utf-8").toString("base64");
+    lines.push(`base64 -d > ${shellQuote(name)} <<'WP_OPS_B64'`, b64, "WP_OPS_B64");
+  }
+
+  lines.push(
+    "chmod +x ./*.sh",
+    `bash ./monitor.sh ${shellQuote(String(hours))} ${shellQuote(domain)}`,
+    "echo '--- MONITORING SUMMARY ---'",
+    'SUMMARY=$(ls -t "$HOME/monitoring"/monitoring-summary*.md "$PWD/monitoring-reports"/monitoring-summary*.md 2>/dev/null | head -1)',
+    'if [ -n "$SUMMARY" ]; then cat "$SUMMARY"; else echo "(no summary report file found)"; fi'
+  );
+
+  return lines.join("\n");
+}
+
+export async function runMonitor(entry: EnvEntry, domain: string, hours: number): Promise<string> {
+  if (!entry.sshHost) {
+    throw new Error(
+      "monitor requires a site/env entry with sshHost — traffic and security logs only exist on a " +
+        "deployed server, not local dev or a Trellis VM."
+    );
+  }
+
+  const script = buildRemoteScript(hours, domain);
+  const result = await runRemote(entry.sshHost, script);
+
+  if (result.code !== 0) {
+    throw new Error(`monitor exited ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`);
+  }
+
+  return result.stdout.trim() + (result.stderr.trim() ? `\n\nSTDERR:\n${result.stderr.trim()}` : "");
+}

--- a/mcp-server/src/tools/remoteTtfbAudit.ts
+++ b/mcp-server/src/tools/remoteTtfbAudit.ts
@@ -1,0 +1,49 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.resolve(__dirname, "../../../scripts/monitoring/remote-ttfb-ua.sh");
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function run(command: string, args: string[], cwd: string): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+// remote-ttfb-ua.sh writes its own report to ./audits/remote-ttfb-ua-<timestamp>.txt
+// relative to cwd rather than printing it — run it in a throwaway temp dir so the
+// report lands somewhere predictable, read it back, then discard the directory.
+export async function runRemoteTtfbAudit(sshHost: string, urls: string[]): Promise<string> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "wp-ops-ttfb-"));
+  try {
+    const result = await run("bash", [SCRIPT_PATH, sshHost, ...urls], tmpDir);
+    if (result.code !== 0) {
+      throw new Error(`remote-ttfb-ua.sh exited ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`);
+    }
+
+    const savedMatch = result.stdout.match(/^Saved: (.+)$/m);
+    if (!savedMatch) {
+      throw new Error(`remote-ttfb-ua.sh didn't report a saved file. Output:\n${result.stdout}`);
+    }
+
+    const report = await readFile(path.join(tmpDir, savedMatch[1]), "utf-8");
+    return report.trim();
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/mcp-server/src/tools/serverStatus.ts
+++ b/mcp-server/src/tools/serverStatus.ts
@@ -1,0 +1,46 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { EnvEntry } from "../registry.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.resolve(__dirname, "../../../scripts/monitoring/server-monitor.sh");
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+// Unlike monitor.ts's scripts, server-monitor.sh is meant to run on the *calling*
+// machine — it takes the target as an argv SSH target and issues its own `ssh
+// "$SERVER" ...` call per metric. So this just runs the script locally with the
+// registry-resolved sshHost as its argument, no SSH-stdin streaming needed.
+function runLocal(sshHost: string, phpFpmPattern?: string): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    const args = [SCRIPT_PATH, sshHost];
+    if (phpFpmPattern) args.push(phpFpmPattern);
+    const child = spawn("bash", args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+export async function runServerStatus(entry: EnvEntry, phpFpmPattern?: string): Promise<string> {
+  if (!entry.sshHost) {
+    throw new Error(
+      "server_status requires a site/env entry with sshHost — it measures live resource usage on a " +
+        "deployed server, not local dev or a Trellis VM."
+    );
+  }
+
+  const result = await runLocal(entry.sshHost, phpFpmPattern);
+  if (result.code !== 0) {
+    throw new Error(`server-monitor.sh exited ${result.code}${result.stderr ? `: ${result.stderr}` : ""}`);
+  }
+  return result.stdout.trim();
+}


### PR DESCRIPTION
## Summary

Expands the wp-ops MCP server from 7 tools to 14, closing a gap found in practice: asking an agent (Mistral Vibe) to "use wp-ops mcp monitor" fell back to nine ad-hoc bash/ssh steps because no MCP tool existed for it — only a CLI-catalog script did. Surveyed the rest of `scripts/`, `trellis/`, and `wp-cli/` for the same gap and added the tools that clear the bar set in `docs/go-mcp-parity.md`: "the MCP server gets a tool only if agent access adds something."

## New tools

| Tool | Wraps | Gating |
|---|---|---|
| `monitor` | `scripts/monitoring/monitor.sh` (bundles all 5 sibling scripts into a throwaway remote temp dir, so it works whether or not `setup-monitoring.yml` provisioned the site) | read-only |
| `server_status` | `server-monitor.sh` | read-only |
| `broken_link_audit` | `404-checker.sh` | read-only |
| `remote_ttfb_audit` | `remote-ttfb-ua.sh` | read-only |
| `ip_reputation_check` | `check-ips.sh` + `check-deny-ips.sh` (native `fetch`, not curl/jq) | read-only |
| `admin_user_create` | `admin-user-create.sh` (lockout recovery) | `confirm: true` |
| `db_pull` | `db-pull.sh`'s workflow, ported to composable calls against the registry (reuses `wp_cli`'s dispatch and `db_backup`'s export logic) instead of one big remote `bash -c` string | `confirm: true` |
| `files_pull` | `files-pull.yml`'s rsync of Trellis `shared/uploads/` into Bedrock's local `web/app/uploads/` | `confirm: true` only if `delete: true` |

## Deliberately not implemented

`db_push`, `files_push`, and a `site_backup` wrapper — pushing into or writing to a production server carries more blast radius than this pass takes on. Reasoning is left in `mcp-server/README.md` and `CHANGELOG.md` next to each tool it's paired with, so the omission reads as a decision, not an oversight.

## Notes

- Each tool is its own commit; the changelog is bumped once (5.3.0 → 5.4.0) since this is one coherent batch of work.
- `mcp-server/README.md`'s tool list, permissions section, and tool count are all updated to match.
- Builds clean (`npm run build` in `mcp-server/`) after every commit.
